### PR TITLE
chore: add more tests for discovery

### DIFF
--- a/tests/discovery.js
+++ b/tests/discovery.js
@@ -186,6 +186,79 @@ test('discovery - mdns', async (t) => {
   await discover2.join(keyPair.publicKey)
 })
 
+test('replication - mdns', async (t) => {
+  t.plan(3)
+
+  const testnet = await createTestnet(10)
+  const bootstrap = testnet.bootstrap
+
+  const core1 = new Hypercore(ram)
+  await core1.ready()
+
+  const core2 = new Hypercore(ram, core1.key)
+  await core2.ready()
+
+  core1.append(['a', 'b', 'c'])
+
+  const identity1 = createIdentityKeys()
+  const identityPublicKey1 = identity1.identityKeyPair.publicKey.toString('hex')
+
+  const identity2 = createIdentityKeys()
+  const identityPublicKey2 = identity2.identityKeyPair.publicKey.toString('hex')
+
+  const discover1 = new Discovery({
+    identityKeyPair: identity1.identityKeyPair,
+    mdns: true,
+    dht: false,
+  })
+
+  const discover2 = new Discovery({
+    identityKeyPair: identity2.identityKeyPair,
+    mdns: true,
+    dht: false,
+  })
+
+  await discover1.ready()
+  await discover2.ready()
+
+  discover1.on('connection', async (connection, peer) => {
+    t.ok(peer.identityPublicKey === identityPublicKey2, 'match key of 2nd peer')
+    core1.replicate(connection)
+    await step()
+  })
+
+  discover2.on('connection', async (connection, peer) => {
+    t.ok(peer.identityPublicKey === identityPublicKey1, 'match key of 1st peer')
+    core2.replicate(connection)
+
+    const stream = core2.createReadStream()
+
+    const results = []
+    stream.on('data', async (/** @type {any} */ data) => {
+      results.push(data)
+      if (results.length === 3) {
+        t.pass()
+        await step()
+      }
+    })
+  })
+
+  let count = 0
+  async function step() {
+    count++
+    if (count === 2) {
+      await discover1.leave(core1.discoveryKey)
+      await discover2.leave(core1.discoveryKey)
+      await discover1.destroy()
+      await discover2.destroy()
+      await testnet.destroy()
+    }
+  }
+
+  await discover1.join(core1.discoveryKey)
+  await discover2.join(core1.discoveryKey)
+})
+
 test('discovery - multiple successive joins', async (t) => {
   t.plan(4)
 


### PR DESCRIPTION
Closes #18. May add more to this but can iterate later on too.

Adds tests for:

- Replication over mDNS
- Ensuring that connections are made over valid discovery mechanism