### PR TITLE
chore: remove randombytes ts module declaration

### DIFF
--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -874,5 +874,4 @@ declare module 'random-access-memory' {
   export = RandomAccessMemory
 }
 declare module 'random-access-file'
-declare module 'randombytes'
 declare module 'b4a'


### PR DESCRIPTION
Seems like we're using `crypto.randomBytes`, which should be derived from the `@types/node`, so figured it should be okay to remove the module declaration here