### PR TITLE
feat: support block encryption

### DIFF
--- a/lib/core-manager/core-index.js
+++ b/lib/core-manager/core-index.js
@@ -1,45 +1,17 @@
 import crypto from 'hypercore-crypto'
-import { TypedEmitter } from 'tiny-typed-emitter'
 
 /** @typedef {import('./index.js').Namespace} Namespace */
-/** @typedef {{ core: import('hypercore').default, key: Buffer, namespace: Namespace }} CoreRecord */
-/**
- * @typedef {Object} CoreIndexEvents
- * @property {(coreRecord: CoreRecord) => void} add-core
- */
+/** @typedef {import('./index.js').CoreRecord} CoreRecord */
 
-// WARNING: If changed once in production then we need a migration strategy
-const TABLE = 'cores'
-const CREATE_SQL = `CREATE TABLE IF NOT EXISTS ${TABLE} (
-  publicKey BLOB NOT NULL,
-  namespace TEXT NOT NULL
-)`
 
 /**
- * An in-memory index of open cores that persists core keys & namespaces to disk
- *
- * @extends {TypedEmitter<CoreIndexEvents>}
+ * An in-memory index of open cores.
  */
-export class CoreIndex extends TypedEmitter {
+export class CoreIndex {
   /** @type {Map<string, CoreRecord>} */
   #coresByDiscoveryId = new Map()
   /** @type {Map<Namespace, CoreRecord>} */
-  #writersByNamespace = new Map()
-  #addCoreSqlStmt
-
-  /**
-   * @param {object} options
-   * @param {import('better-sqlite3').Database} options.db better-sqlite3 database instance
-   */
-  constructor ({ db }) {
-    super()
-    // Make sure table exists for persisting known cores
-    db.prepare(CREATE_SQL).run()
-    // Pre-prepare SQL statement for better performance
-    this.#addCoreSqlStmt = db.prepare(
-      `INSERT OR IGNORE INTO ${TABLE} VALUES (@publicKey, @namespace)`
-    )
-  }
+  #writersByNamespace = new Map();
 
   [Symbol.iterator]() {
     return this.#coresByDiscoveryId.values()
@@ -54,9 +26,8 @@ export class CoreIndex extends TypedEmitter {
    * @param {Buffer} options.key Buffer containing public key of this core
    * @param {Namespace} options.namespace
    * @param {boolean} [options.writer] Is this a writer core?
-   * @param {boolean} [options.persist] Persist to cb?
    */
-  add ({ core, key, namespace, writer = false, persist = false }) {
+  add ({ core, key, namespace, writer = false }) {
     const discoveryKey = crypto.discoveryKey(key)
     const discoveryId = discoveryKey.toString('hex')
     const record = { core, key, namespace }
@@ -64,10 +35,6 @@ export class CoreIndex extends TypedEmitter {
       this.#writersByNamespace.set(namespace, record)
     }
     this.#coresByDiscoveryId.set(discoveryId, record)
-    if (persist) {
-      this.#addCoreSqlStmt.run({ publicKey: key, namespace })
-    }
-    this.emit('add-core', { core, key, namespace })
   }
 
   /**

--- a/lib/core-manager/index.js
+++ b/lib/core-manager/index.js
@@ -1,7 +1,8 @@
 // @ts-check
 import { TypedEmitter } from 'tiny-typed-emitter'
 import Corestore from 'corestore'
-import assert from 'assert'
+import assert from 'node:assert'
+import { once } from 'node:events'
 import Hypercore from 'hypercore'
 import { ProjectExtension } from './messages.js'
 import { CoreIndex } from './core-index.js'
@@ -39,6 +40,8 @@ export class CoreManager extends TypedEmitter {
   /** @type {Set<ReplicationRecord>} */
   #replications = new Set()
   #extension
+  /** @type {'opened' | 'closing' | 'closed'} */
+  #state = 'opened'
 
   static get namespaces () {
     return NAMESPACES
@@ -152,6 +155,24 @@ export class CoreManager extends TypedEmitter {
   }
 
   /**
+   * Close all open cores and end any replication streams
+   * TODO: gracefully close replication streams
+   */
+  async close() {
+    this.#state = 'closing'
+    const promises = []
+    for (const { core } of this.#coreIndex) {
+      promises.push(core.close())
+    }
+    for (const { stream } of this.#replications) {
+      promises.push(once(stream, 'close'))
+      stream.destroy()
+    }
+    await Promise.all(promises)
+    this.#state = 'closed'
+  }
+
+  /**
    * Add a core to the manager (will be persisted across restarts)
    *
    * @param {Buffer} key 32-byte public key of core to add
@@ -247,6 +268,7 @@ export class CoreManager extends TypedEmitter {
    * @param {NoiseStream | ProtocolStream} noiseStream framed noise secret stream, i.e. @hyperswarm/secret-stream
    */
   replicate (noiseStream) {
+    if (this.#state !== 'opened') throw new Error('Core manager is closed')
     if (/** @type {ProtocolStream} */ (noiseStream).noiseStream?.userData) {
       console.warn(
         'Passed an existing protocol stream to coreManager.replicate(). Other corestores and core managers replicated to this stream will no longer automatically inject shared cores into the stream'

--- a/lib/core-manager/index.js
+++ b/lib/core-manager/index.js
@@ -10,13 +10,20 @@ import { ReplicationStateMachine } from './replication-state-machine.js'
 // WARNING: Changing these will break things for existing apps, since namespaces
 // are used for key derivation
 const NAMESPACES = /** @type {const} */ (['auth', 'data', 'blobIndex', 'blob'])
+// WARNING: If changed once in production then we need a migration strategy
+const TABLE = 'cores'
+const CREATE_SQL = `CREATE TABLE IF NOT EXISTS ${TABLE} (
+  publicKey BLOB NOT NULL,
+  namespace TEXT NOT NULL
+)`
 
 /** @typedef {(typeof NAMESPACES)[number]} Namespace */
+/** @typedef {{ core: import('hypercore').default, key: Buffer, namespace: Namespace }} CoreRecord */
 /** @typedef {import('streamx').Duplex} DuplexStream */
 /** @typedef {{ rsm: ReplicationStateMachine, stream: DuplexStream, cores: Set<Hypercore> }} ReplicationRecord */
 /**
  * @typedef {Object} Events
- * @property {import('./core-index.js').CoreIndexEvents['add-core']} add-core
+ * @property {(coreRecord: CoreRecord) => void} add-core
  */
 
 /**
@@ -28,6 +35,7 @@ export class CoreManager extends TypedEmitter {
   /** @type {Hypercore} */
   #creatorCore
   #projectKey
+  #addCoreSqlStmt
   /** @type {Set<ReplicationRecord>} */
   #replications = new Set()
   #extension
@@ -57,14 +65,20 @@ export class CoreManager extends TypedEmitter {
     const primaryKey = keyManager.getDerivedKey('primaryKey', projectKey)
     this.#projectKey = projectKey
 
+    // Make sure table exists for persisting known cores
+    db.prepare(CREATE_SQL).run()
+    // Pre-prepare SQL statement for better performance
+    this.#addCoreSqlStmt = db.prepare(
+      `INSERT OR IGNORE INTO ${TABLE} VALUES (@publicKey, @namespace)`
+    )
+
     // Note: this should not be used, because we do not rely on corestore for
     // key storage (i.e. we do not get cores from corestore via a name, which
     // would derive the keypair from the primary key), but setting this just in
     // case a dependency does (e.g. hyperdrive-next) and we miss it.
     this.#corestore = new Corestore(storage, { primaryKey })
     // Persistent index of core keys and namespaces in the project
-    this.#coreIndex = new CoreIndex({ db })
-    this.#coreIndex.on('add-core', core => this.emit('add-core', core))
+    this.#coreIndex = new CoreIndex()
 
     // Writer cores and root core, keys and namespaces are not persisted because
     // we derive the keys here.
@@ -86,7 +100,13 @@ export class CoreManager extends TypedEmitter {
 
     if (!this.#creatorCore) {
       // For anyone other than the project creator, creatorCore is readonly
-      this.#creatorCore = this.addCore(projectKey, 'auth').core
+      this.#creatorCore = this.#addCore({ publicKey: projectKey }, 'auth').core
+    }
+
+    // Load persisted cores
+    const stmt = db.prepare(`SELECT publicKey, namespace FROM ${TABLE}`)
+    for (const { publicKey, namespace } of stmt.all()) {
+      this.#addCore({ publicKey }, namespace)
     }
 
     this.#extension = this.#creatorCore.registerExtension('mapeo/project', {
@@ -139,7 +159,7 @@ export class CoreManager extends TypedEmitter {
    * @returns {import('./core-index.js').CoreRecord}
    */
   addCore (key, namespace) {
-    return this.#addCore({ publicKey: key }, namespace)
+    return this.#addCore({ publicKey: key }, namespace, true)
   }
 
   /**
@@ -147,21 +167,19 @@ export class CoreManager extends TypedEmitter {
    *
    * @param {{ publicKey: Buffer, secretKey?: Buffer }} keyPair
    * @param {Namespace} namespace
+   * @param {boolean} [persist=false]
    * @returns {import('./core-index.js').CoreRecord}
    */
-  #addCore (keyPair, namespace) {
+  #addCore (keyPair, namespace, persist = false) {
     // No-op if core is already managed
     const existingCore = this.#coreIndex.getByCoreKey(keyPair.publicKey)
     if (existingCore) return existingCore
 
     const { publicKey: key, secretKey } = keyPair
     const writer = !!secretKey
-    // Don't persist the writer cores or the creatorCore - they are derived from
-    // the keyManager and the projectKey
-    const persist = !writer && !key.equals(this.#projectKey)
     // @ts-ignore - TS doesn't understand checking writer ensures secretKey
     const core = this.#corestore.get(writer ? { keyPair } : key)
-    this.#coreIndex.add({ core, key, namespace, writer, persist })
+    this.#coreIndex.add({ core, key, namespace, writer })
 
     // **Hack** As soon as a peer is added, eagerly send a "want" for the entire
     // core. This ensures that the peer sends back its entire bitfield.
@@ -202,6 +220,12 @@ export class CoreManager extends TypedEmitter {
         })
       }
     }
+
+    if (persist) {
+      this.#addCoreSqlStmt.run({ publicKey: key, namespace })
+    }
+
+    this.emit('add-core', { core, key, namespace })
 
     return { core, key, namespace }
   }
@@ -323,6 +347,7 @@ export class CoreManager extends TypedEmitter {
       }
     }
     for (const authCoreKey of authCoreKeys) {
+      // Use public method - these must be persisted (private method defaults to persisted=false)
       this.addCore(authCoreKey, 'auth')
     }
   }

--- a/lib/core-manager/index.js
+++ b/lib/core-manager/index.js
@@ -37,6 +37,7 @@ export class CoreManager extends TypedEmitter {
   #creatorCore
   #projectKey
   #addCoreSqlStmt
+  #encryptionKeys
   /** @type {Set<ReplicationRecord>} */
   #replications = new Set()
   #extension
@@ -53,9 +54,17 @@ export class CoreManager extends TypedEmitter {
    * @param {import('@mapeo/crypto').KeyManager} options.keyManager mapeo/crypto KeyManager instance
    * @param {Buffer} options.projectKey 32-byte public key of the project creator core
    * @param {Buffer} [options.projectSecretKey] 32-byte secret key of the project creator core
+   * @param {Partial<Record<Namespace, Buffer>>} [options.encryptionKeys] Encryption keys for each namespace
    * @param {import('hypercore').HypercoreStorage} options.storage Folder to store all hypercore data
    */
-  constructor ({ db, keyManager, projectKey, projectSecretKey, storage }) {
+  constructor ({
+    db,
+    keyManager,
+    projectKey,
+    projectSecretKey,
+    encryptionKeys = {},
+    storage
+  }) {
     super()
     assert(
       projectKey.length === 32,
@@ -67,6 +76,7 @@ export class CoreManager extends TypedEmitter {
     )
     const primaryKey = keyManager.getDerivedKey('primaryKey', projectKey)
     this.#projectKey = projectKey
+    this.#encryptionKeys = encryptionKeys
 
     // Make sure table exists for persisting known cores
     db.prepare(CREATE_SQL).run()
@@ -75,10 +85,10 @@ export class CoreManager extends TypedEmitter {
       `INSERT OR IGNORE INTO ${TABLE} VALUES (@publicKey, @namespace)`
     )
 
-    // Note: this should not be used, because we do not rely on corestore for
-    // key storage (i.e. we do not get cores from corestore via a name, which
-    // would derive the keypair from the primary key), but setting this just in
-    // case a dependency does (e.g. hyperdrive-next) and we miss it.
+    // Note: the primary key here should not be used, because we do not rely on
+    // corestore for key storage (i.e. we do not get cores from corestore via a
+    // name, which would derive the keypair from the primary key), but setting
+    // this just in case a dependency does (e.g. hyperdrive) and we miss it.
     this.#corestore = new Corestore(storage, { primaryKey })
     // Persistent index of core keys and namespaces in the project
     this.#coreIndex = new CoreIndex()
@@ -158,7 +168,7 @@ export class CoreManager extends TypedEmitter {
    * Close all open cores and end any replication streams
    * TODO: gracefully close replication streams
    */
-  async close() {
+  async close () {
     this.#state = 'closing'
     const promises = []
     for (const { core } of this.#coreIndex) {
@@ -198,8 +208,10 @@ export class CoreManager extends TypedEmitter {
 
     const { publicKey: key, secretKey } = keyPair
     const writer = !!secretKey
-    // @ts-ignore - TS doesn't understand checking writer ensures secretKey
-    const core = this.#corestore.get(writer ? { keyPair } : key)
+    const core = this.#corestore.get({
+      keyPair,
+      encryptionKey: this.#encryptionKeys[namespace]
+    })
     this.#coreIndex.add({ core, key, namespace, writer })
 
     // **Hack** As soon as a peer is added, eagerly send a "want" for the entire

--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -253,6 +253,31 @@ test('multiplexing waits for cores to be added', async function (t) {
   t.alike(await b2.get(0), Buffer.from('ho'))
 })
 
+test('Added cores are persisted', async t => {
+  const db = new Sqlite(':memory:')
+  const keyManager = new KeyManager(randomBytes(16))
+  const projectKey = randomBytes(32)
+  const cm1 = new CoreManager({
+    db,
+    keyManager,
+    storage: RAM,
+    projectKey
+  })
+  const key = randomBytes(32)
+  cm1.addCore(key, 'auth')
+
+  // No close method yet, need to add one.
+
+  const cm2 = new CoreManager({
+    db,
+    keyManager,
+    storage: RAM,
+    projectKey
+  })
+
+  t.ok(cm2.getCoreByKey(key), 'Added core is persisted')
+})
+
 async function waitForCores (coreManager, keys) {
   const allKeys = getAllKeys(coreManager)
   if (hasKeys(keys, allKeys)) return

--- a/tests/helpers/core-manager.js
+++ b/tests/helpers/core-manager.js
@@ -7,7 +7,8 @@ import NoiseSecretStream from '@hyperswarm/secret-stream'
 
 export function createCoreManager ({
   rootKey = randomBytes(16),
-  projectKey = randomBytes(32)
+  projectKey = randomBytes(32),
+  ...opts
 } = {}) {
   const db = new Sqlite(':memory:')
   const keyManager = new KeyManager(rootKey)
@@ -15,28 +16,40 @@ export function createCoreManager ({
     db,
     keyManager,
     storage: RAM,
-    projectKey
+    projectKey,
+    ...opts
   })
 }
 
-export function replicate(cm1, cm2) {
+/**
+ *
+ * @param {CoreManager} cm1
+ * @param {CoreManager} cm2
+ * @returns
+ */
+export function replicate (cm1, cm2) {
   const n1 = new NoiseSecretStream(true)
   const n2 = new NoiseSecretStream(false)
   n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
 
-  cm1.replicate(n1)
-  cm2.replicate(n2)
+  const rsm1 = cm1.replicate(n1)
+  const rsm2 = cm2.replicate(n2)
 
-  return async function destroy () {
-    return Promise.all([
-      new Promise((res) => {
+  async function destroy () {
+    await Promise.all([
+      new Promise(res => {
         n1.on('close', res)
         n1.destroy()
       }),
-      new Promise((res) => {
+      new Promise(res => {
         n2.on('close', res)
         n2.destroy()
       })
     ])
+  }
+
+  return {
+    rsm: [rsm1, rsm2],
+    destroy
   }
 }

--- a/types/corestore.d.ts
+++ b/types/corestore.d.ts
@@ -1,6 +1,10 @@
 declare module 'corestore' {
   import { TypedEmitter } from 'tiny-typed-emitter'
-  import Hypercore, { type HypercoreStorage, type HypercoreOptions } from 'hypercore'
+  import Hypercore, {
+    type HypercoreStorage,
+    type HypercoreOptions,
+  } from 'hypercore'
+  import { SetRequired } from 'type-fest'
 
   interface CorestoreEvents {
     'core-open'(core: Corestore): void
@@ -8,17 +12,18 @@ declare module 'corestore' {
   }
 
   class Corestore extends TypedEmitter<CorestoreEvents> {
-    constructor(storage: HypercoreStorage, options?: { primaryKey?: Buffer | Uint8Array })
+    constructor(
+      storage: HypercoreStorage,
+      options?: { primaryKey?: Buffer | Uint8Array }
+    )
     get(key: Buffer | Uint8Array): Hypercore
-    get(options: HypercoreOptions & { name: string }): Hypercore
     get(
-      options: HypercoreOptions & { key: Buffer | Uint8Array }
+      options: Omit<HypercoreOptions, 'keyPair'> & { name: string }
     ): Hypercore
     get(
-      options: HypercoreOptions & {
-        keyPair: { publicKey: Buffer; secretKey: Buffer }
-      }
+      options: Omit<HypercoreOptions, 'keyPair'> & { key: Buffer | Uint8Array }
     ): Hypercore
+    get(options: SetRequired<HypercoreOptions, 'keyPair'>): Hypercore
     replicate: typeof Hypercore.prototype.replicate
     namespace(name: string): Corestore
     ready(): Promise<void>

--- a/types/hypercore.d.ts
+++ b/types/hypercore.d.ts
@@ -31,7 +31,7 @@ declare module 'hypercore' {
     overwrite?: boolean // overwrite any old Hypercore that might already exist
     valueEncoding?: ValueEncoding // defaults to binary
     encodeBatch?(batch: any[]): void // optionally apply an encoding to complete batches
-    keyPair?: { publicKey: Buffer; secretKey: Buffer } // optionally pass the public key and secret key as a key pair
+    keyPair?: { publicKey: Buffer; secretKey?: Buffer | null } // optionally pass the public key and secret key as a key pair
     encryptionKey?: Buffer // optionally pass an encryption key to enable block encryption
     sparse?: boolean // optionally disable sparse mode
   }


### PR DESCRIPTION
Add support for block-level encryption of all hypercores. Separate encryption key for each namespace, to allow for future features (e.g. only sharing encryption key for specific namespaces). 

TODO after PR is merged:

- [ ] Add tests for encryption support to BlobStore #90 