### PR TITLE
feat: add projectConfig & encryptionKeys to invite

### DIFF
--- a/lib/rpc/index.js
+++ b/lib/rpc/index.js
@@ -110,7 +110,7 @@ class Peer {
 
 /** @extends {TypedEmitter<MapeoRPCEvents>} */
 export class MapeoRPC extends TypedEmitter {
-  /** @type {Map<string, Peer} */
+  /** @type {Map<string, Peer>} */
   #peers = new Map()
 
   constructor () {
@@ -126,7 +126,8 @@ export class MapeoRPC extends TypedEmitter {
    * @param {string} peerId
    * @param {object} options
    * @param {Invite['projectKey']} options.projectKey project key
-   * @param {Invite['encryptionKey']} [options.encryptionKey] project encryption key
+   * @param {Invite['encryptionKeys']} [options.encryptionKeys] project encryption key
+   * @param {Invite['projectConfig']} [options.projectConfig] project config (presets, fields & icons)
    * @param {number} [options.timeout] timeout waiting for invite response before rejecting (default 1 minute)
    * @returns {Promise<InviteResponse['decision']>}
    */

--- a/lib/rpc/messages.d.ts
+++ b/lib/rpc/messages.d.ts
@@ -2,7 +2,14 @@
 import _m0 from "protobufjs/minimal.js";
 export interface Invite {
     projectKey: Buffer;
-    encryptionKey?: Buffer | undefined;
+    encryptionKeys?: Invite_EncryptionKeys | undefined;
+    projectConfig?: Buffer | undefined;
+}
+export interface Invite_EncryptionKeys {
+    auth?: Buffer | undefined;
+    data?: Buffer | undefined;
+    blobIndex?: Buffer | undefined;
+    blob?: Buffer | undefined;
 }
 export interface InviteResponse {
     projectKey: Buffer;
@@ -19,6 +26,10 @@ export declare function inviteResponse_DecisionToNumber(object: InviteResponse_D
 export declare const Invite: {
     encode(message: Invite, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): Invite;
+};
+export declare const Invite_EncryptionKeys: {
+    encode(message: Invite_EncryptionKeys, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): Invite_EncryptionKeys;
 };
 export declare const InviteResponse: {
     encode(message: InviteResponse, writer?: _m0.Writer): _m0.Writer;

--- a/lib/rpc/messages.js
+++ b/lib/rpc/messages.js
@@ -46,8 +46,11 @@ export var Invite = {
         if (message.projectKey.length !== 0) {
             writer.uint32(10).bytes(message.projectKey);
         }
-        if (message.encryptionKey !== undefined) {
-            writer.uint32(18).bytes(message.encryptionKey);
+        if (message.encryptionKeys !== undefined) {
+            Invite_EncryptionKeys.encode(message.encryptionKeys, writer.uint32(18).fork()).ldelim();
+        }
+        if (message.projectConfig !== undefined) {
+            writer.uint32(26).bytes(message.projectConfig);
         }
         return writer;
     },
@@ -62,7 +65,57 @@ export var Invite = {
                     message.projectKey = reader.bytes();
                     break;
                 case 2:
-                    message.encryptionKey = reader.bytes();
+                    message.encryptionKeys = Invite_EncryptionKeys.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    message.projectConfig = reader.bytes();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+            }
+        }
+        return message;
+    }
+};
+function createBaseInvite_EncryptionKeys() {
+    return {};
+}
+export var Invite_EncryptionKeys = {
+    encode: function (message, writer) {
+        if (writer === void 0) { writer = _m0.Writer.create(); }
+        if (message.auth !== undefined) {
+            writer.uint32(10).bytes(message.auth);
+        }
+        if (message.data !== undefined) {
+            writer.uint32(18).bytes(message.data);
+        }
+        if (message.blobIndex !== undefined) {
+            writer.uint32(26).bytes(message.blobIndex);
+        }
+        if (message.blob !== undefined) {
+            writer.uint32(34).bytes(message.blob);
+        }
+        return writer;
+    },
+    decode: function (input, length) {
+        var reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+        var end = length === undefined ? reader.len : reader.pos + length;
+        var message = createBaseInvite_EncryptionKeys();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    message.auth = reader.bytes();
+                    break;
+                case 2:
+                    message.data = reader.bytes();
+                    break;
+                case 3:
+                    message.blobIndex = reader.bytes();
+                    break;
+                case 4:
+                    message.blob = reader.bytes();
                     break;
                 default:
                     reader.skipType(tag & 7);

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -1,8 +1,15 @@
 syntax = "proto3";
 
 message Invite {
+  message EncryptionKeys {
+    optional bytes auth = 1;
+    optional bytes data = 2;
+    optional bytes blobIndex = 3;
+    optional bytes blob = 4;
+  }
   bytes projectKey = 1;
-  optional bytes encryptionKey = 2;
+  optional EncryptionKeys encryptionKeys = 2;
+  optional bytes projectConfig = 3;
 }
 message InviteResponse {
   enum Decision {


### PR DESCRIPTION
Adds support for sending multiple encryption keys (one for each namespace) along with an invite, and also adds support for an optional "projectConfig" buffer.

Actual handling of the projectConfig in the invite will need to be done in a follow up PR.