### PR TITLE
feat: updated DataStore [2/n]

### DIFF
--- a/lib/core-manager/index.js
+++ b/lib/core-manager/index.js
@@ -10,7 +10,12 @@ import { ReplicationStateMachine } from './replication-state-machine.js'
 
 // WARNING: Changing these will break things for existing apps, since namespaces
 // are used for key derivation
-const NAMESPACES = /** @type {const} */ (['auth', 'data', 'blobIndex', 'blob'])
+export const NAMESPACES = /** @type {const} */ ([
+  'auth',
+  'data',
+  'blobIndex',
+  'blob'
+])
 // WARNING: If changed once in production then we need a migration strategy
 const TABLE = 'cores'
 const CREATE_SQL = `CREATE TABLE IF NOT EXISTS ${TABLE} (
@@ -18,10 +23,11 @@ const CREATE_SQL = `CREATE TABLE IF NOT EXISTS ${TABLE} (
   namespace TEXT NOT NULL
 )`
 
+/** @typedef {import('hypercore')<'binary', Buffer>} Core */
 /** @typedef {(typeof NAMESPACES)[number]} Namespace */
-/** @typedef {{ core: import('hypercore').default, key: Buffer, namespace: Namespace }} CoreRecord */
+/** @typedef {{ core: Core, key: Buffer, namespace: Namespace }} CoreRecord */
 /** @typedef {import('streamx').Duplex} DuplexStream */
-/** @typedef {{ rsm: ReplicationStateMachine, stream: DuplexStream, cores: Set<Hypercore> }} ReplicationRecord */
+/** @typedef {{ rsm: ReplicationStateMachine, stream: DuplexStream, cores: Set<Core> }} ReplicationRecord */
 /**
  * @typedef {Object} Events
  * @property {(coreRecord: CoreRecord) => void} add-core
@@ -33,7 +39,7 @@ const CREATE_SQL = `CREATE TABLE IF NOT EXISTS ${TABLE} (
 export class CoreManager extends TypedEmitter {
   #corestore
   #coreIndex
-  /** @type {Hypercore} */
+  /** @type {Core} */
   #creatorCore
   #projectKey
   #addCoreSqlStmt
@@ -63,7 +69,7 @@ export class CoreManager extends TypedEmitter {
     projectKey,
     projectSecretKey,
     encryptionKeys = {},
-    storage,
+    storage
   }) {
     super()
     assert(
@@ -156,7 +162,7 @@ export class CoreManager extends TypedEmitter {
    * Get a core by its public key
    *
    * @param {Buffer} key
-   * @returns {Hypercore | undefined}
+   * @returns {Core | undefined}
    */
   getCoreByKey (key) {
     const coreRecord = this.#coreIndex.getByCoreKey(key)
@@ -285,6 +291,7 @@ export class CoreManager extends TypedEmitter {
         'Passed an existing protocol stream to coreManager.replicate(). Other corestores and core managers replicated to this stream will no longer automatically inject shared cores into the stream'
       )
     }
+    // @ts-ignore - too complex to type right now
     const stream = Hypercore.createProtocolStream(noiseStream)
     const protocol = stream.noiseStream.userData
     if (!protocol) throw new Error('Invalid stream')

--- a/lib/core-manager/index.js
+++ b/lib/core-manager/index.js
@@ -291,7 +291,7 @@ export class CoreManager extends TypedEmitter {
         'Passed an existing protocol stream to coreManager.replicate(). Other corestores and core managers replicated to this stream will no longer automatically inject shared cores into the stream'
       )
     }
-    // @ts-ignore - too complex to type right now
+    // @ts-expect-error - too complex to type right now
     const stream = Hypercore.createProtocolStream(noiseStream)
     const protocol = stream.noiseStream.userData
     if (!protocol) throw new Error('Invalid stream')

--- a/lib/datastore/data-store-new.js
+++ b/lib/datastore/data-store-new.js
@@ -1,5 +1,5 @@
 import { TypedEmitter } from 'tiny-typed-emitter'
-import { encode, decode } from '@mapeo/schema'
+import { encode, decode, getVersionId, parseVersionId } from '@mapeo/schema'
 import MultiCoreIndexer from 'multi-core-indexer'
 import Ram from 'random-access-memory'
 import pDefer from 'p-defer'
@@ -147,29 +147,4 @@ export class DataStore extends TypedEmitter {
     if (!block) throw new Error('Not Found')
     return decode(block, { coreKey: coreKey, index })
   }
-}
-
-/**
- *
- * @param {object} opts
- * @param {Buffer} opts.coreKey
- * @param {number} opts.index
- * @returns string
- */
-function getVersionId({ coreKey, index }) {
-  return coreKey.toString('hex') + '/' + index
-}
-
-/**
- *
- * @param {string} versionId
- */
-function parseVersionId(versionId) {
-  const items = versionId.split('/')
-  if (!items[0] || !items[1]) throw new Error('Invalid versionId')
-  const coreKey = Buffer.from(items[0], 'hex')
-  if (coreKey.length !== 32) throw new Error('Invalid versionId')
-  const index = Number.parseInt(items[1])
-  if (isNaN(index)) throw new Error('Invalid versionId')
-  return { coreKey, index }
 }

--- a/lib/datastore/data-store-new.js
+++ b/lib/datastore/data-store-new.js
@@ -1,0 +1,175 @@
+import { TypedEmitter } from 'tiny-typed-emitter'
+import { encode, decode } from '@mapeo/schema'
+import MultiCoreIndexer from 'multi-core-indexer'
+import Ram from 'random-access-memory'
+import pDefer from 'p-defer'
+
+/**
+ * @typedef {import('multi-core-indexer').IndexEvents} IndexEvents
+ */
+/**
+ * @typedef {import('@mapeo/schema').MapeoDoc} MapeoDoc
+ */
+/**
+ * @typedef {object} DefaultEmitterEvents
+ * @property {(eventName: keyof IndexEvents, listener: (...args: any[]) => any) => void} newListener
+ * @property {(eventName: keyof IndexEvents, listener: (...args: any[]) => any) => void} removeListener
+ */
+/**
+ * @template T
+ * @template {keyof any} K
+ * @typedef {T extends any ? Omit<T, K> : never} OmitUnion
+ */
+
+const NAMESPACE_SCHEMAS = /** @type {const} */ ({
+  data: ['observation'],
+  auth: [],
+})
+
+/**
+ * @typedef {typeof NAMESPACE_SCHEMAS} NamespaceSchemas
+ */
+
+/**
+ * @template {keyof NamespaceSchemas} TNamespace
+ * @template {NamespaceSchemas[TNamespace][number]} TSchemaName
+ * @extends {TypedEmitter<IndexEvents & DefaultEmitterEvents>}
+ */
+export class DataStore extends TypedEmitter {
+  #coreManager
+  #namespace
+  #writerCore
+  #coreIndexer
+  /** @type {Map<string, import('p-defer').DeferredPromise<void>>} */
+  #pending = new Map()
+
+  /**
+   * @param {object} opts
+   * @param {import('../core-manager/index.js').CoreManager} opts.coreManager
+   * @param {TNamespace} opts.namespace
+   * @param {(entries: MultiCoreIndexer.Entry<'binary'>[]) => Promise<void>} opts.indexEntries
+   */
+  constructor({ coreManager, namespace, indexEntries }) {
+    super()
+    this.#coreManager = coreManager
+    this.#namespace = namespace
+    this.#writerCore = coreManager.getWriterCore(namespace).core
+    const cores = coreManager.getCores(namespace).map((cr) => cr.core)
+    this.#coreIndexer = new MultiCoreIndexer(cores, {
+      storage: (name) => new Ram(name),
+      batch: (entries) => this.#batch(entries, indexEntries),
+    })
+
+    // Forward events from coreIndexer
+    this.on('newListener', (eventName, listener) => {
+      if (['newListener', 'removeListener'].includes(eventName)) return
+      this.#coreIndexer.on(eventName, listener)
+    })
+    this.on('removeListener', (eventName, listener) => {
+      if (['newListener', 'removeListener'].includes(eventName)) return
+      this.#coreIndexer.off(eventName, listener)
+    })
+  }
+
+  getIndexState() {
+    return this.#coreIndexer.state
+  }
+
+  /**
+   *
+   * @param {MultiCoreIndexer.Entry<'binary'>[]} entries
+   * @param {ConstructorParameters<typeof DataStore>[0]['indexEntries']} indexEntries
+   */
+  async #batch(entries, indexEntries) {
+    // This is needed to avoid the batch running before the append resolves, but
+    // I think this is only necessary when using random-access-memory, and will
+    // not be an issue when the indexer is on a separate thread.
+    await new Promise((res) => setTimeout(res, 0))
+    await indexEntries(entries)
+    // Writes to the writerCore need to wait until the entry is indexed before
+    // returning, so we check if any incoming entry has a pending promise
+    for (const entry of entries) {
+      if (!entry.key.equals(this.#writerCore.key)) continue
+      const versionId = getVersionId({
+        coreKey: entry.key,
+        index: entry.index,
+      })
+      const pending = this.#pending.get(versionId)
+      if (!pending) continue
+      pending.resolve()
+    }
+  }
+
+  /**
+   * UNSAFE: Does not check links: [] refer to a valid doc - should only be used
+   * internally.
+   *
+   * Write a doc, must be one of the schema types supported by the namespace of
+   * this DataStore.
+   * @template {Extract<Parameters<encode>[0], { schemaName: TSchemaName }>} TDoc
+   * @param {TDoc} doc
+   * @returns {Promise<Extract<MapeoDoc, TDoc>>}
+   */
+  async write(doc) {
+    // @ts-ignore
+    if (!NAMESPACE_SCHEMAS[this.#namespace].includes(doc.schemaName)) {
+      throw new Error(
+        `Schema '${doc.schemaName}' is not allowed in namespace '${
+          this.#namespace
+        }'`
+      )
+    }
+    const block = encode(doc)
+
+    const { length } = await this.#writerCore.append(block)
+    const index = length - 1
+    const versionId = getVersionId({ coreKey: this.#writerCore.key, index })
+    /** @type {import('p-defer').DeferredPromise<void>} */
+    const deferred = pDefer()
+    this.#pending.set(versionId, deferred)
+    await deferred.promise
+
+    return /** @type {Extract<MapeoDoc, TDoc>} */ (
+      decode(block, { coreKey: this.#writerCore.key, index })
+    )
+  }
+
+  /**
+   *
+   * @param {string} versionId
+   * @returns {Promise<MapeoDoc>}
+   */
+  async read(versionId) {
+    const { coreKey, index } = parseVersionId(versionId)
+    const core = this.#coreManager.getCoreByKey(coreKey)
+    if (!core) throw new Error('Invalid versionId')
+    const block = await core.get(index, { wait: false })
+    if (!block) throw new Error('Not Found')
+    return decode(block, { coreKey: coreKey, index })
+  }
+}
+
+/**
+ *
+ * @param {object} opts
+ * @param {Buffer} opts.coreKey
+ * @param {number} opts.index
+ * @returns string
+ */
+function getVersionId({ coreKey, index }) {
+  return coreKey.toString('hex') + '/' + index
+}
+
+/**
+ *
+ * @param {string} versionId
+ */
+function parseVersionId(versionId) {
+  const items = versionId.split('/')
+  if (!items[0] || !items[1]) throw new Error('Invalid versionId')
+  const coreKey = Buffer.from(items[0], 'hex')
+  if (coreKey.length !== 32) throw new Error('Invalid versionId')
+  const index = Number.parseInt(items[1])
+  if (isNaN(index)) throw new Error('Invalid versionId')
+  return { coreKey, index }
+}

--- a/tests/datastore-new.js
+++ b/tests/datastore-new.js
@@ -53,7 +53,7 @@ test('read and write', async (t) => {
   )
 })
 
-test.solo('index events', async (t) => {
+test('index events', async (t) => {
   const cm = createCoreManager()
   const writerCore = cm.getWriterCore('data').core
   await writerCore.ready()

--- a/tests/datastore-new.js
+++ b/tests/datastore-new.js
@@ -1,0 +1,91 @@
+// @ts-check
+import test from 'brittle'
+import { DataStore } from '../lib/datastore/data-store-new.js'
+import { createCoreManager } from './helpers/core-manager.js'
+import { getVersionId } from '@mapeo/schema'
+import { once } from 'events'
+
+/** @type {Omit<import('@mapeo/schema').Observation, 'versionId'>} */
+const obs = {
+  docId: 'abc',
+  links: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  schemaName: 'observation',
+  refs: [],
+  tags: {},
+  attachments: [],
+  metadata: {},
+}
+
+test('read and write', async (t) => {
+  const cm = createCoreManager()
+  const writerCore = cm.getWriterCore('data').core
+  await writerCore.ready()
+  const indexedVersionIds = []
+  const dataStore = new DataStore({
+    coreManager: cm,
+    namespace: 'data',
+    indexEntries: async (entries) => {
+      for (const { index, key } of entries) {
+        const versionId = getVersionId({ coreKey: key, index })
+        indexedVersionIds.push(versionId)
+      }
+    },
+  })
+  const written = await dataStore.write(obs)
+  const expectedVersionId = getVersionId({ coreKey: writerCore.key, index: 0 })
+  t.is(
+    written.versionId,
+    expectedVersionId,
+    'versionId is set to expected value'
+  )
+  const read = await dataStore.read(written.versionId)
+  t.alike(
+    read,
+    written,
+    'data returned from write matches data returned from read'
+  )
+  t.alike(
+    indexedVersionIds,
+    [written.versionId],
+    'The indexEntries function is called with all data that is added'
+  )
+})
+
+test.solo('index events', async (t) => {
+  const cm = createCoreManager()
+  const writerCore = cm.getWriterCore('data').core
+  await writerCore.ready()
+  const indexStates = []
+  const dataStore = new DataStore({
+    coreManager: cm,
+    namespace: 'data',
+    indexEntries: async () => {
+      await new Promise((res) => setTimeout(res, 10))
+    },
+  })
+  dataStore.on('index-state', (state) => {
+    // eslint-disable-next-line no-unused-vars
+    const { entriesPerSecond, ...rest } = state
+    indexStates.push(rest)
+  })
+  const idlePromise = once(dataStore, 'idle')
+  await dataStore.write(obs)
+  await idlePromise
+  const expectedStates = [
+    {
+      current: 'idle',
+      remaining: 0,
+    },
+    {
+      current: 'indexing',
+      remaining: 1,
+    },
+    {
+      current: 'idle',
+      remaining: 0,
+    },
+  ]
+  t.alike(indexStates, expectedStates, 'expected index states emitted')
+})

--- a/types/corestore.d.ts
+++ b/types/corestore.d.ts
@@ -14,21 +14,26 @@ declare module 'corestore' {
   class Corestore extends TypedEmitter<CorestoreEvents> {
     constructor(
       storage: HypercoreStorage,
-      options?: { primaryKey?: Buffer | Uint8Array, poolSize?: number }
+      options?: { primaryKey?: Buffer | Uint8Array; poolSize?: number }
     )
-    get(key: Buffer | Uint8Array): Hypercore
+    get(key: Buffer | Uint8Array): Hypercore<Hypercore.ValueEncoding, Buffer>
     get(
       options: Omit<HypercoreOptions, 'keyPair'> & { name: string }
-    ): Hypercore
+    ): Hypercore<Hypercore.ValueEncoding, Buffer>
     get(
       options: Omit<HypercoreOptions, 'keyPair'> & { key: Buffer | Uint8Array }
-    ): Hypercore
-    get(options: SetRequired<HypercoreOptions, 'keyPair'>): Hypercore
+    ): Hypercore<Hypercore.ValueEncoding, Buffer>
+    get(
+      options: Omit<HypercoreOptions, 'keyPair' | 'key'> & {
+        key?: Buffer | string | undefined
+        keyPair: { publicKey: Buffer; secretKey?: Buffer | undefined | null }
+      }
+    ): Hypercore<Hypercore.ValueEncoding, Buffer>
     replicate: typeof Hypercore.prototype.replicate
     namespace(name: string): Corestore
     ready(): Promise<void>
     close(): Promise<void>
-    cores: Map<string, Hypercore>
+    cores: Map<string, Hypercore<Hypercore.ValueEncoding, Buffer>>
   }
 
   export = Corestore

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -5,7 +5,6 @@
 // - DhtNode
 
 declare module 'nanobench'
-declare module 'multi-core-indexer'
 declare module '@mapeo/sqlite-indexer'
 declare module 'sodium-universal'
 declare module 'base32.js'


### PR DESCRIPTION
From #139:

A `DataStore` should be an abstraction over a particular "Mapeo Store", e.g. a collection of hypercores that store a particular datatype. Responsibilities:

- Write a document to the write core of the store.
- Read a document based on versionId.
- Manage read indexing and return current indexing state.
- Handle decoding/encoding of data

With this we can isolate the boundary with hypercore / core store to this module (apart from within the blob store), and largely isolate indexing: The write method can resolve when the document is indexed.

```ts
const store = new DataStore({
  coreManager,
  namespace: 'auth' | 'data',
  // DataStore will consider a block "indexed" once this function resolves.
  indexDocs: (blocks: Buffer[]) => Promise<void>
})

// Guarantee that `doc` is indexed once this resolves
store.write(doc: Exclude<MapeoDoc, 'versionId'>): Promise<MapeoDoc>

store.read(versionId: string): Promise<MapeoDoc>

store.getIndexState() // return whether is currently indexing, and estimate of indexing remaining to be done

store.on('index-state') // same as above.
```
