### PR TITLE
feat: `IndexWriter` for all things indexy [3/n]

### DIFF
--- a/lib/index-writer.js
+++ b/lib/index-writer.js
@@ -1,0 +1,62 @@
+import { decode } from '@mapeo/schema'
+import SqliteIndexer from '@mapeo/sqlite-indexer'
+import { getTableConfig } from 'drizzle-orm/sqlite-core'
+import { getBacklinkTableName } from './schema/utils.js'
+
+/**
+ * @typedef {import('./schema/utils.js').SqliteTable} SqliteTable
+ */
+/**
+ * @typedef {import('@mapeo/schema').MapeoDoc} MapeoDoc
+ */
+
+export class IndexWriter {
+  /** @type {Record<string, SqliteIndexer>} */
+  #indexers = {}
+  /**
+   *
+   * @param {object} opts
+   * @param {import('better-sqlite3').Database} opts.db
+   * @param {SqliteTable[]} opts.schemas
+   */
+  constructor({ schemas, db }) {
+    for (const schema of schemas) {
+      const config = getTableConfig(schema)
+      this.#indexers[config.name] = new SqliteIndexer(db, {
+        docTableName: config.name,
+        backlinkTableName: getBacklinkTableName(config.name),
+      })
+    }
+  }
+
+  /**
+   *
+   * @param {import('multi-core-indexer').Entry[]} entries
+   */
+  async batch(entries) {
+    // sqlite-indexer is _significantly_ faster when batching even <10 at a
+    // time, so best to queue docs here before calling sliteIndexer.batch()
+    /** @type {Record<string, MapeoDoc[]>} */
+    const queued = {}
+    for (const { block, key, index } of entries) {
+      try {
+        var doc = decode(block, { coreKey: key, index })
+      } catch (e) {
+        // Unknown entry - silently ignore
+        continue
+      }
+      if (queued[doc.schemaName]) {
+        queued[doc.schemaName].push(doc)
+      } else {
+        queued[doc.schemaName] = [doc]
+      }
+    }
+    for (const [schemaName, docs] of Object.entries(queued)) {
+      if (!this.#indexers[schemaName]) {
+        // Don't have an indexer for this type - silently ignore
+        continue
+      }
+      this.#indexers[schemaName].batch(docs)
+    }
+  }
+}

--- a/lib/schema/client.js
+++ b/lib/schema/client.js
@@ -4,5 +4,7 @@
 import { sqliteTable } from 'drizzle-orm/sqlite-core'
 import { dereferencedDocSchemas as schemas } from '@mapeo/schema'
 import { jsonSchemaToDrizzleColumns as toColumns } from './schema-to-drizzle.js'
+import { backlinkTable } from './utils.js'
 
 export const projectTable = sqliteTable('project', toColumns(schemas.project))
+export const projectBacklinkTable = backlinkTable(projectTable)

--- a/lib/schema/project.js
+++ b/lib/schema/project.js
@@ -3,6 +3,7 @@
 import { sqliteTable } from 'drizzle-orm/sqlite-core'
 import { dereferencedDocSchemas as schemas } from '@mapeo/schema'
 import { jsonSchemaToDrizzleColumns as toColumns } from './schema-to-drizzle.js'
+import { backlinkTable } from './utils.js'
 
 export const observationTable = sqliteTable(
   'observation',
@@ -10,3 +11,7 @@ export const observationTable = sqliteTable(
 )
 export const presetTable = sqliteTable('preset', toColumns(schemas.preset))
 export const fieldTable = sqliteTable('field', toColumns(schemas.field))
+
+export const observationBacklinkTable = backlinkTable(observationTable)
+export const presetBacklinkTable = backlinkTable(presetTable)
+export const fieldBacklinkTable = backlinkTable(fieldTable)

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -1,0 +1,26 @@
+import { text, getTableConfig, sqliteTable } from 'drizzle-orm/sqlite-core'
+
+/**
+ * @typedef {import('drizzle-orm/sqlite-core').SQLiteTableWithColumns<import('drizzle-orm/sqlite-core').TableConfig & { columns: any }>} SqliteTable
+ */
+
+export const BACKLINK_TABLE_POSTFIX = '_backlink'
+
+/**
+ * Table for storing backlinks, used for indexing. There needs to be one for
+ * each indexed document type
+ * @param {SqliteTable} tableSchema
+ */
+export function backlinkTable(tableSchema) {
+  const { name } = getTableConfig(tableSchema)
+  return sqliteTable(getBacklinkTableName(name), {
+    versionId: text('versionId').notNull().primaryKey(),
+  })
+}
+
+/**
+ * @param {string} tableName
+ */
+export function getBacklinkTableName(tableName) {
+  return tableName + BACKLINK_TABLE_POSTFIX
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "^1.0.0-alpha.4",
         "@mapeo/schema": "^3.0.0-next.5",
-        "@mapeo/sqlite-indexer": "github:digidem/mapeo-sqlite-indexer#no-prepare",
+        "@mapeo/sqlite-indexer": "file:../@mapeo/sqlite-indexer/mapeo-sqlite-indexer-1.0.0-alpha.4.tgz",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
         "base32.js": "^0.1.0",
@@ -1603,21 +1603,13 @@
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
-      "version": "1.0.0-alpha.2",
-      "resolved": "git+ssh://git@github.com/digidem/mapeo-sqlite-indexer.git#44e1e940dc8f3f9d1a3cb1227e2bd121fb187365",
+      "version": "1.0.0-alpha.4",
+      "resolved": "file:../@mapeo/sqlite-indexer/mapeo-sqlite-indexer-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-fNHqK1pQ3QwliDlBQshIwlrScpDXwmDm2Rj3VD4BvCE3QuUSbzPFQHl6Ed2ooLzmzJnKF7oklPaxJYcc0oMEvg==",
       "license": "MIT",
       "dependencies": {
-        "@types/better-sqlite3": "^7.6.2",
-        "better-sqlite3": "^7.6.2"
-      }
-    },
-    "node_modules/@mapeo/sqlite-indexer/node_modules/better-sqlite3": {
-      "version": "7.6.2",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.0"
+        "@types/better-sqlite3": "^7.6.4",
+        "better-sqlite3": "^8.4.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1739,8 +1731,9 @@
       }
     },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.3",
-      "license": "MIT",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.4.tgz",
+      "integrity": "sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2076,9 +2069,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.3.0.tgz",
-      "integrity": "sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.5.0.tgz",
+      "integrity": "sha512-vbPcv/Hx5WYdyNg/NbcfyaBZyv9s/NVbxb7yCeC5Bq1pVocNxeL2tZmSu3Rlm4IEOTjYdGyzWQgyx0OSdORBzw==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "^1.0.0-alpha.4",
         "@mapeo/schema": "^3.0.0-next.5",
-        "@mapeo/sqlite-indexer": "file:../@mapeo/sqlite-indexer/mapeo-sqlite-indexer-1.0.0-alpha.4.tgz",
+        "@mapeo/sqlite-indexer": "^1.0.0-alpha.5",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
         "base32.js": "^0.1.0",
@@ -1603,10 +1603,9 @@
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
-      "version": "1.0.0-alpha.4",
-      "resolved": "file:../@mapeo/sqlite-indexer/mapeo-sqlite-indexer-1.0.0-alpha.4.tgz",
-      "integrity": "sha512-fNHqK1pQ3QwliDlBQshIwlrScpDXwmDm2Rj3VD4BvCE3QuUSbzPFQHl6Ed2ooLzmzJnKF7oklPaxJYcc0oMEvg==",
-      "license": "MIT",
+      "version": "1.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@mapeo/sqlite-indexer/-/sqlite-indexer-1.0.0-alpha.5.tgz",
+      "integrity": "sha512-80I+5Tr+3pFaxqloi9VKCtL53lH4aelrc4XodBVtObN7oNhIDYnWqVNOxlOlIXQhHY0igjCjt7Y4EIKLbHJJUg==",
       "dependencies": {
         "@types/better-sqlite3": "^7.6.4",
         "better-sqlite3": "^8.4.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "^1.0.0-alpha.4",
     "@mapeo/schema": "^3.0.0-next.5",
-    "@mapeo/sqlite-indexer": "file:../@mapeo/sqlite-indexer/mapeo-sqlite-indexer-1.0.0-alpha.4.tgz",
+    "@mapeo/sqlite-indexer": "^1.0.0-alpha.5",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",
     "base32.js": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "^1.0.0-alpha.4",
     "@mapeo/schema": "^3.0.0-next.5",
-    "@mapeo/sqlite-indexer": "github:digidem/mapeo-sqlite-indexer#no-prepare",
+    "@mapeo/sqlite-indexer": "file:../@mapeo/sqlite-indexer/mapeo-sqlite-indexer-1.0.0-alpha.4.tgz",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",
     "base32.js": "^0.1.0",

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -5,7 +5,6 @@
 // - DhtNode
 
 declare module 'nanobench'
-declare module '@mapeo/sqlite-indexer'
 declare module 'sodium-universal'
 declare module 'base32.js'
 declare module 'sub-encoder'


### PR DESCRIPTION
All indexing goes through this class, which just exports a single method `batch()`. Later we can move the index code into a separate thread for performance.

Depends on:

- [x] https://github.com/digidem/mapeo-sqlite-indexer/pull/11
- [x] https://github.com/digidem/mapeo-sqlite-indexer/pull/14

Makes more sense to e2e test rather than unit test, which depends on
the new DataType class, which is next up.