### PR TITLE
feat: updated DataType class [4/n]

### DIFF
--- a/lib/datatype/data-type-new.js
+++ b/lib/datatype/data-type-new.js
@@ -1,0 +1,206 @@
+// @ts-check
+import { validate } from '@mapeo/schema'
+import { getTableConfig } from 'drizzle-orm/sqlite-core'
+import { eq, placeholder } from 'drizzle-orm'
+import { randomBytes } from 'node:crypto'
+
+/**
+ * @typedef {import('@mapeo/schema').MapeoDoc} MapeoDoc
+ */
+/**
+ * @typedef {import('@mapeo/schema').MapeoValue} MapeoValue
+ */
+/**
+ * @typedef {import('../types.js').MapeoDocMap} MapeoDocMap
+ */
+/**
+ * @typedef {import('../types.js').MapeoValueMap} MapeoValueMap
+ */
+/**
+ * @typedef {`${MapeoDoc['schemaName']}Table`} MapeoDocTableName
+ */
+/**
+ * @template T
+ * @typedef {T[(keyof T) & MapeoDocTableName]} GetMapeoDocTables
+ */
+/**
+ * Union of Drizzle schema tables that correspond to MapeoDoc types (e.g. excluding backlink tables and other utility tables)
+ * @typedef {GetMapeoDocTables<import('../schema/project.js')> | GetMapeoDocTables<import('../schema/client.js')>} MapeoDocTables
+ */
+/**
+ * @typedef {{ [K in MapeoDocTables['_']['name']]: Extract<MapeoDocTables, { _: { name: K }}> }} MapeoDocTablesMap
+ */
+/**
+ * @template T
+ * @template {keyof any} K
+ * @typedef {T extends any ? Omit<T, K> : never} OmitUnion
+ */
+
+function generateId() {
+  return randomBytes(32).toString('hex')
+}
+function generateDate() {
+  return new Date().toISOString()
+}
+
+/**
+ * @template {import('../datastore/new-data-store.js').DataStore} TDataStore
+ * @template {TDataStore['schemas'][number]} TSchemaName
+ * @template {MapeoDocTablesMap[TSchemaName]} TTable
+ * @template {MapeoDocMap[TSchemaName]} TDoc
+ * @template {MapeoValueMap[TSchemaName]} TValue
+ */
+export class DataType {
+  #dataStore
+  #table
+  #getPermissions
+  #schemaName
+  #sql
+
+  /**
+   *
+   * @param {object} opts
+   * @param {TTable} opts.table
+   * @param {TDataStore} opts.dataStore
+   * @param {import('drizzle-orm/better-sqlite3').BetterSQLite3Database} opts.db
+   * @param {() => any} [opts.getPermissions]
+   */
+  constructor({ dataStore, table, getPermissions, db }) {
+    this.#dataStore = dataStore
+    this.#table = table
+    this.#schemaName = /** @type {TSchemaName} */ (getTableConfig(table).name)
+    this.#getPermissions = getPermissions
+    this.#sql = {
+      getByDocId: db
+        .select()
+        .from(table)
+        .where(eq(table.docId, placeholder('docId')))
+        .prepare(),
+      getMany: db.select().from(table).prepare(),
+    }
+  }
+
+  /**
+   * @template {import('type-fest').Exact<TValue, T>} T
+   * @param {T} value
+   */
+  async create(value) {
+    if (!validate(this.#schemaName, value)) {
+      // TODO: pass through errors from validate functions
+      throw new Error('Invalid value ' + value)
+    }
+    const nowDateString = generateDate()
+    /** @type {OmitUnion<MapeoDoc, 'versionId'>} */
+    const doc = {
+      ...value,
+      docId: generateId(),
+      createdAt: nowDateString,
+      updatedAt: nowDateString,
+      links: [],
+    }
+
+    // TS can't track the relationship between TDoc and TValue, so doc above is
+    // typed as MapeoDoc (without versionId) rather than as TDoc.
+    await this.#dataStore.write(/** @type {TDoc} */ (doc))
+    return this.getByDocId(doc.docId)
+  }
+
+  /**
+   * @param {string} docId
+   */
+  async getByDocId(docId) {
+    return deNullify(this.#sql.getByDocId.get({ docId }))
+  }
+
+  /** @param {string} versionId */
+  async getByVersionId(versionId) {
+    return this.#dataStore.read(versionId)
+  }
+
+  async getMany() {
+    return this.#sql.getMany.all().map((doc) => deNullify(doc))
+  }
+
+  /**
+   *
+   * @template {import('type-fest').Exact<TValue, T>} T
+   * @param {string | string[]} versionId
+   * @param {T} value
+   */
+  async update(versionId, value) {
+    const links = Array.isArray(versionId) ? versionId : [versionId]
+    const { docId, createdAt } = await this.#validateLinks(links)
+    /** @type {any} */
+    const doc = {
+      ...value,
+      docId,
+      createdAt,
+      updatedAt: new Date().toISOString(),
+      links,
+    }
+    await this.#dataStore.write(doc)
+    return this.getByDocId(docId)
+  }
+
+  /**
+   * Not yet implemented
+   * @param {string | string[]} versionId
+   */
+  async delete(versionId) {
+    const links = Array.isArray(versionId) ? versionId : [versionId]
+    const { docId, createdAt } = await this.#validateLinks(links)
+    /** @type {any} */
+    const doc = {
+      docId,
+      createdAt,
+      updatedAt: new Date().toISOString(),
+      links,
+      schemaName: this.#schemaName,
+      deleted: true,
+    }
+    await this.#dataStore.write(doc)
+    return this.getByDocId(docId)
+  }
+
+  /**
+   * Validate that existing docs with the given versionIds (links):
+   * - exist
+   * - have the same schemaName as this dataType
+   * - all share the same docId
+   * - all share the same createdAt
+   * Throws if any of these conditions fail, otherwise returns the validated
+   * docId and createAt datetime
+   * @param {string[]} links
+   * @returns {Promise<{ docId: MapeoDoc['docId'], createdAt: MapeoDoc['createdAt'] }>}
+   */
+  async #validateLinks(links) {
+    const prevDocs = await Promise.all(
+      links.map((versionId) => this.getByVersionId(versionId))
+    )
+    const { docId, createdAt } = prevDocs[0]
+    const areLinksValid = prevDocs.every(
+      (doc) => doc.docId === docId && doc.schemaName === this.#schemaName
+    )
+    if (!areLinksValid) {
+      throw new Error('Updated docs must have the same docId and schemaName')
+    }
+    return { docId, createdAt }
+  }
+}
+
+/**
+ * When reading from SQLite, any optional properties are set to `null`. This
+ * converts `null` back to `undefined` to match the input types (e.g. the types
+ * defined in @mapeo/schema)
+ * @template T
+ * @param {T} obj
+ * @returns {import('../types.js').NullableToOptional<T>}
+ */
+function deNullify(obj) {
+  /** @type {Record<string, any>} */
+  const objNoNulls = {}
+  for (const [key, value] of Object.entries(obj)) {
+    objNoNulls[key] = value === null ? undefined : value
+  }
+  return /** @type {import('../types.js').NullableToOptional<T>} */ (objNoNulls)
+}

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -1,7 +1,12 @@
 import { text, getTableConfig, sqliteTable } from 'drizzle-orm/sqlite-core'
 
 /**
- * @typedef {import('drizzle-orm/sqlite-core').SQLiteTableWithColumns<import('drizzle-orm/sqlite-core').TableConfig & { columns: any }>} SqliteTable
+ * @template {string} [TName=string]
+ * @typedef {import('drizzle-orm/sqlite-core').SQLiteTableWithColumns<{
+ *   name: TName;
+ *   schema: string | undefined;
+ *   columns: any
+ * }>} SqliteTable
  */
 
 export const BACKLINK_TABLE_POSTFIX = '_backlink'

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -3,6 +3,7 @@ import type {
   TupleToUnion,
   ValueOf,
   RequireAtLeastOne,
+  SetOptional,
 } from 'type-fest'
 import { SUPPORTED_BLOB_VARIANTS } from './blob-store/index.js'
 import { MapeoDoc, MapeoValue } from '@mapeo/schema'
@@ -54,3 +55,29 @@ export type MapeoValueMap = {
   [K in MapeoValue['schemaName']]: Extract<MapeoValue, { schemaName: K }>
 }
 
+type NullToOptional<T> = SetOptional<T, NullKeys<T>>
+type RemoveNull<T> = {
+  [K in keyof T]: Exclude<T[K], null>
+}
+
+type NullKeys<Base> = NonNullable<
+  // Wrap in `NonNullable` to strip away the `undefined` type from the produced union.
+  {
+    // Map through all the keys of the given base type.
+    [Key in keyof Base]: null extends Base[Key] // Pick only keys with types extending the given `Condition` type.
+      ? // Retain this key since the condition passes.
+        Key
+      : // Discard this key since the condition fails.
+        never
+
+    // Convert the produced object into a union type of the keys which passed the conditional test.
+  }[keyof Base]
+>
+
+/**
+ * Make any properties whose value include `null` optional, and remove `null`
+ * from the type. This converts the types returned from SQLite (which have all
+ * top-level optional props set to `null`) to the original types in
+ * @mapeo/schema
+ */
+export type NullableToOptional<T> = Simplify<RemoveNull<NullToOptional<T>>>

--- a/test-e2e/crud.js
+++ b/test-e2e/crud.js
@@ -1,0 +1,111 @@
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { temporaryFile } from 'tempy'
+import fs from 'node:fs'
+import { execSync } from 'child_process'
+import { test } from 'brittle'
+import { DataStore } from '../lib/datastore/data-store-new.js'
+import { DataType } from '../lib/datatype/data-type-new.js'
+import { IndexWriter } from '../lib/index-writer.js'
+import { observationTable } from '../lib/schema/project.js'
+import { createCoreManager } from '../tests/helpers/core-manager.js'
+
+/** @type {import('@mapeo/schema').ObservationValue} */
+const obsValue = {
+  schemaName: 'observation',
+  refs: [],
+  tags: {},
+  attachments: [],
+  metadata: {},
+}
+
+test('create and read', async (t) => {
+  const observation = await createDataType(t)
+  const written = await observation.create(obsValue)
+  const read = await observation.getByDocId(written.docId)
+  t.alike(written, read)
+})
+
+test('update', async (t) => {
+  const observation = await createDataType(t)
+  const written = await observation.create(obsValue)
+  const writtenValue = valueOf(written)
+  const updated = await observation.update(written.versionId, {
+    ...writtenValue,
+    lon: 0.573453,
+    lat: 50.854259,
+  })
+  const updatedReRead = await observation.getByDocId(written.docId)
+  t.alike(updated, updatedReRead)
+  // Floating-point errors
+  t.ok((updated.lon || 0) - 0.573453 < 0.000001)
+  t.ok((updated.lat || 0) - 50.854259 < 0.000001)
+})
+
+test('getMany', async (t) => {
+  const observation = await createDataType(t)
+  const obs = new Array(5).fill(null).map((value, index) => {
+    return {
+      ...obsValue,
+      tags: { index },
+    }
+  })
+  for (const value of obs) {
+    await observation.create(value)
+  }
+  const many = await observation.getMany()
+  const manyValues = many.map((doc) => valueOf(doc))
+  t.alike(manyValues, obs)
+})
+
+/**
+ * @template {import('@mapeo/schema').MapeoDoc & { forks: string[] }} T
+ * @param {T} doc
+ * @returns {Omit<T, 'docId' | 'versionId' | 'links' | 'forks' | 'createdAt' | 'updatedAt'>}
+ */
+function valueOf(doc) {
+  // eslint-disable-next-line no-unused-vars
+  const { docId, versionId, links, forks, createdAt, updatedAt, ...rest } = doc
+  return rest
+}
+
+/** @param {import('brittle').TestInstance} t */
+async function createDataType(t) {
+  const coreManager = createCoreManager()
+  await coreManager.getWriterCore('auth').core.ready()
+  const { db, sqlite } = createDb(t)
+  const indexWriter = new IndexWriter({
+    schemas: [observationTable],
+    db: sqlite,
+  })
+  const dataStore = new DataStore({
+    coreManager,
+    namespace: 'data',
+    indexEntries: indexWriter.batch.bind(indexWriter),
+  })
+  return new DataType({
+    dataStore,
+    table: observationTable,
+    db,
+    getPermissions: () => {},
+  })
+}
+
+/** @param {import('brittle').TestInstance} t */
+function createDb(t) {
+  const dbPath = temporaryFile()
+
+  execSync(
+    `drizzle-kit push:sqlite --schema=lib/schema/project.js --driver=better-sqlite --url=${dbPath}`
+  )
+
+  const sqlite = new Database(dbPath)
+  const db = drizzle(sqlite)
+
+  t.teardown(() => {
+    sqlite.close()
+    fs.unlinkSync(dbPath)
+  })
+
+  return { db, sqlite }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
       ]
     }
   },
-  "files": ["tests/schema.js"],
+  "files": ["tests/schema.js", "test-e2e/crud.js"],
   "include": ["**/*"],
   "exclude": ["node_modules", "tmp", "tests", "examples"]
 }

--- a/types/brittle.d.ts
+++ b/types/brittle.d.ts
@@ -36,7 +36,7 @@ declare module 'brittle' {
     todo?: boolean
   }
 
-  interface TestInstance extends Assertion {
+  export interface TestInstance extends Assertion {
     plan(n: number): void
     teardown(fn: () => void | Promise<void>, options?: { order?: number }): void
     timeout(ms: number): void


### PR DESCRIPTION
Going to leave `delete()` implementation to a separate task, since it requires changes to @mapeo/schema as well.

**TODO:**

- [x] When writing and updating, return the data from SQLite db (not direct from hypercores)
- [x] Remove `null` values from returned data
- [x] Add tests for each method
- [x] Update types to include `forks`
