### PR TITLE
feat: add schema definition for project keys table

### DIFF
--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -1,10 +1,23 @@
 // These schemas are all in a "client" database. There is only one client
 // database and it contains information that is shared across all projects on a
 // device
-import { sqliteTable } from 'drizzle-orm/sqlite-core'
+import { blob, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import { dereferencedDocSchemas as schemas } from '@mapeo/schema'
 import { jsonSchemaToDrizzleColumns as toColumns } from './schema-to-drizzle.js'
 import { backlinkTable } from './utils.js'
 
-export const projectTable = sqliteTable('project', toColumns(schemas.project))
-export const projectBacklinkTable = backlinkTable(projectTable)
+export const projectInfoTable = sqliteTable(
+  'project',
+  toColumns(schemas.project)
+)
+
+export const projectKeysTable = sqliteTable('project_keys', {
+  projectKey: text('projectKey').notNull().primaryKey(),
+  projectSecretKey: blob('projectSecretKey'),
+  authEncryptionKey: blob('authEncryptionKey'),
+  dataEncryptionKey: blob('dataEncryptionKey'),
+  blobIndexEncryptionKey: blob('blobIndexEncryptionKey'),
+  blobEncryptionKey: blob('blobEncryptionKey'),
+})
+
+export const projectBacklinkTable = backlinkTable(projectInfoTable)

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -3,18 +3,25 @@
 // device
 import { blob, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import { dereferencedDocSchemas as schemas } from '@mapeo/schema'
+import { NAMESPACES } from '../core-manager/index.js'
 import { jsonSchemaToDrizzleColumns as toColumns } from './schema-to-drizzle.js'
 import { backlinkTable } from './utils.js'
 
 export const projectTable = sqliteTable('project', toColumns(schemas.project))
-
-export const projectKeysTable = sqliteTable('project_keys', {
-  projectKey: text('projectKey').notNull().primaryKey(),
-  projectSecretKey: blob('projectSecretKey'),
-  authEncryptionKey: blob('authEncryptionKey'),
-  dataEncryptionKey: blob('dataEncryptionKey'),
-  blobIndexEncryptionKey: blob('blobIndexEncryptionKey'),
-  blobEncryptionKey: blob('blobEncryptionKey'),
-})
-
 export const projectBacklinkTable = backlinkTable(projectTable)
+export const projectKeysTable = generateProjectKeysTable()
+
+function generateProjectKeysTable() {
+  /** @type {Record<string, import('drizzle-orm/sqlite-core').SQLiteColumnBuilder>}*/
+  const columns = {
+    projectId: text('projectId').notNull().primaryKey(),
+    projectSecretKey: blob('projectSecretKey'),
+  }
+
+  for (const namespace in NAMESPACES) {
+    const columnName = namespace + 'EncryptionKey'
+    columns[columnName] = blob(columnName)
+  }
+
+  return sqliteTable('projectKeys', columns)
+}

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -6,10 +6,7 @@ import { dereferencedDocSchemas as schemas } from '@mapeo/schema'
 import { jsonSchemaToDrizzleColumns as toColumns } from './schema-to-drizzle.js'
 import { backlinkTable } from './utils.js'
 
-export const projectInfoTable = sqliteTable(
-  'project',
-  toColumns(schemas.project)
-)
+export const projectTable = sqliteTable('project', toColumns(schemas.project))
 
 export const projectKeysTable = sqliteTable('project_keys', {
   projectKey: text('projectKey').notNull().primaryKey(),
@@ -20,4 +17,4 @@ export const projectKeysTable = sqliteTable('project_keys', {
   blobEncryptionKey: blob('blobEncryptionKey'),
 })
 
-export const projectBacklinkTable = backlinkTable(projectInfoTable)
+export const projectBacklinkTable = backlinkTable(projectTable)

--- a/tests/schema.js
+++ b/tests/schema.js
@@ -12,6 +12,8 @@ import {
 } from '../src/schema/utils.js'
 import { deNullify } from '../src/datatype/index.js'
 
+const MAPEO_DATATYPE_NAMES = Object.keys(jsonSchemas)
+
 test('Expected table config', (t) => {
   const allTableSchemas = [
     ...Object.values(clientTableSchemas),
@@ -20,8 +22,10 @@ test('Expected table config', (t) => {
 
   for (const tableSchema of allTableSchemas) {
     const config = getTableConfig(tableSchema)
-    // Ignore backlink tables for this test
-    if (config.name.endsWith(BACKLINK_TABLE_POSTFIX)) continue
+
+    // Only test Mapeo Schema data types in this test
+    if (!MAPEO_DATATYPE_NAMES.includes(config.name)) continue
+
     const schemaName = config.name
     if (!(schemaName in jsonSchemas)) {
       t.fail()
@@ -87,7 +91,6 @@ test('Types match', { skip: true }, (t) => {
 test('backlink table exists for every endexed data type', (t) => {
   // Every indexed datatype needs a backlink table, which is used by
   // sqlite-indexer to track backlinks
-
   const allTableNames = [
     ...Object.values(clientTableSchemas),
     ...Object.values(projectTableSchemas),
@@ -98,8 +101,8 @@ test('backlink table exists for every endexed data type', (t) => {
   const backlinkTableNames = allTableNames.filter((name) =>
     name.endsWith(BACKLINK_TABLE_POSTFIX)
   )
-  const dataTypeTableNames = allTableNames.filter(
-    (name) => !name.endsWith(BACKLINK_TABLE_POSTFIX)
+  const dataTypeTableNames = allTableNames.filter((name) =>
+    MAPEO_DATATYPE_NAMES.includes(name)
   )
 
   for (const name of dataTypeTableNames) {

--- a/tests/schema.js
+++ b/tests/schema.js
@@ -88,7 +88,7 @@ test('Types match', { skip: true }, (t) => {
   t.pass()
 })
 
-test('backlink table exists for every endexed data type', (t) => {
+test('backlink table exists for every indexed data type', (t) => {
   // Every indexed datatype needs a backlink table, which is used by
   // sqlite-indexer to track backlinks
   const allTableNames = [


### PR DESCRIPTION
Closes #165 

Questions:

- [ ] should we rename the `project` table to something like `project_info`? Didn't think it was highly necessary so only updated the associated variable name for now
- [X] what should the table name be? i.e. `projectKeys` (consistent with our naming conventions) vs `project_keys` (consistent with sqlite table naming conventions. also, singular or plural here?
- [X] should it be `projectKey` column be named `projectId` instead? Should it be more specific i.e. `projectPublicKey`?
- [X] would it be helpful to add a note in https://github.com/digidem/mapeo-core-next/blob/38ab9de01c83f99cd161c0a76317c395209b097c/src/core-manager/index.js#L13 about updating this file if more namespaces are created, if applicable?