### PR TITLE
fix: properly generate column names in projectKeys table

### DIFF
--- a/drizzle/client/0000_lonely_yellow_claw.sql
+++ b/drizzle/client/0000_lonely_yellow_claw.sql
@@ -5,11 +5,10 @@ CREATE TABLE `project_backlink` (
 CREATE TABLE `projectKeys` (
 	`projectId` text PRIMARY KEY NOT NULL,
 	`projectSecretKey` blob,
-	`0EncryptionKey` blob,
-	`1EncryptionKey` blob,
-	`2EncryptionKey` blob,
-	`3EncryptionKey` blob,
-	`randomEncryptionKey` blob
+	`authEncryptionKey` blob,
+	`dataEncryptionKey` blob,
+	`blobIndexEncryptionKey` blob,
+	`blobEncryptionKey` blob
 );
 --> statement-breakpoint
 CREATE TABLE `project` (

--- a/drizzle/client/0000_unknown_umar.sql
+++ b/drizzle/client/0000_unknown_umar.sql
@@ -2,6 +2,16 @@ CREATE TABLE `project_backlink` (
 	`versionId` text PRIMARY KEY NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE `projectKeys` (
+	`projectId` text PRIMARY KEY NOT NULL,
+	`projectSecretKey` blob,
+	`0EncryptionKey` blob,
+	`1EncryptionKey` blob,
+	`2EncryptionKey` blob,
+	`3EncryptionKey` blob,
+	`randomEncryptionKey` blob
+);
+--> statement-breakpoint
 CREATE TABLE `project` (
 	`docId` text PRIMARY KEY NOT NULL,
 	`versionId` text NOT NULL,

--- a/drizzle/client/meta/0000_snapshot.json
+++ b/drizzle/client/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "7c71cacf-9e86-4679-a3e4-622c9d43b95a",
+  "id": "1aed30a0-5e2b-49fe-8c42-5249ff6fb13c",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "project_backlink": {
@@ -12,6 +12,64 @@
           "type": "text",
           "primaryKey": true,
           "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectKeys": {
+      "name": "projectKeys",
+      "columns": {
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectSecretKey": {
+          "name": "projectSecretKey",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "0EncryptionKey": {
+          "name": "0EncryptionKey",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "1EncryptionKey": {
+          "name": "1EncryptionKey",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "2EncryptionKey": {
+          "name": "2EncryptionKey",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "3EncryptionKey": {
+          "name": "3EncryptionKey",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "randomEncryptionKey": {
+          "name": "randomEncryptionKey",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
           "autoincrement": false
         }
       },

--- a/drizzle/client/meta/0000_snapshot.json
+++ b/drizzle/client/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "1aed30a0-5e2b-49fe-8c42-5249ff6fb13c",
+  "id": "dba5d47a-2cbd-4312-854b-b6fab03c1a74",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "project_backlink": {
@@ -37,36 +37,29 @@
           "notNull": false,
           "autoincrement": false
         },
-        "0EncryptionKey": {
-          "name": "0EncryptionKey",
+        "authEncryptionKey": {
+          "name": "authEncryptionKey",
           "type": "blob",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
         },
-        "1EncryptionKey": {
-          "name": "1EncryptionKey",
+        "dataEncryptionKey": {
+          "name": "dataEncryptionKey",
           "type": "blob",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
         },
-        "2EncryptionKey": {
-          "name": "2EncryptionKey",
+        "blobIndexEncryptionKey": {
+          "name": "blobIndexEncryptionKey",
           "type": "blob",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
         },
-        "3EncryptionKey": {
-          "name": "3EncryptionKey",
-          "type": "blob",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "randomEncryptionKey": {
-          "name": "randomEncryptionKey",
+        "blobEncryptionKey": {
+          "name": "blobEncryptionKey",
           "type": "blob",
           "primaryKey": false,
           "notNull": false,

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1692026739109,
-      "tag": "0000_cloudy_puppet_master",
+      "when": 1692044207611,
+      "tag": "0000_unknown_umar",
       "breakpoints": true
     }
   ]

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1692044207611,
-      "tag": "0000_unknown_umar",
+      "when": 1692044608840,
+      "tag": "0000_lonely_yellow_claw",
       "breakpoints": true
     }
   ]

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -18,7 +18,7 @@ function generateProjectKeysTable() {
     projectSecretKey: blob('projectSecretKey'),
   }
 
-  for (const namespace in NAMESPACES) {
+  for (const namespace of NAMESPACES) {
     const columnName = namespace + 'EncryptionKey'
     columns[columnName] = blob(columnName)
   }


### PR DESCRIPTION
Fixes a bug introduced in #169, as I used a `for...in` instead of a `for...of` loop...

Also creates the drizzle files becaues I forgot to do that in the other PR. My understanding is that it should be okay to overwrite the original migration files, as opposed to creating a new migration

Referencing #165 for linking purposes