### PR TITLE
feat: Add config store and preset & field types

### DIFF
--- a/drizzle/project/0000_special_masque.sql
+++ b/drizzle/project/0000_special_masque.sql
@@ -12,10 +12,10 @@ CREATE TABLE `field` (
 	`tagKey` text NOT NULL,
 	`type` text NOT NULL,
 	`label` text NOT NULL,
-	`appearance` text DEFAULT 'multiline',
-	`snakeCase` integer DEFAULT false,
+	`appearance` text,
+	`snakeCase` integer,
 	`options` text,
-	`universal` integer DEFAULT false,
+	`universal` integer,
 	`placeholder` text,
 	`helperText` text,
 	`forks` text NOT NULL
@@ -58,7 +58,7 @@ CREATE TABLE `preset` (
 	`addTags` text NOT NULL,
 	`removeTags` text NOT NULL,
 	`fieldIds` text NOT NULL,
-	`icon` text,
+	`iconId` text,
 	`terms` text NOT NULL,
 	`forks` text NOT NULL
 );

--- a/drizzle/project/meta/0000_snapshot.json
+++ b/drizzle/project/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "a1266e0d-e17f-41e2-a5ab-fdf6e30eaf71",
+  "id": "7252a475-6391-4179-bb17-214a01d57960",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "field_backlink": {
@@ -91,16 +91,14 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false,
-          "autoincrement": false,
-          "default": "'multiline'"
+          "autoincrement": false
         },
         "snakeCase": {
           "name": "snakeCase",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,
-          "autoincrement": false,
-          "default": false
+          "autoincrement": false
         },
         "options": {
           "name": "options",
@@ -114,8 +112,7 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": false,
-          "autoincrement": false,
-          "default": false
+          "autoincrement": false
         },
         "placeholder": {
           "name": "placeholder",
@@ -363,8 +360,8 @@
           "notNull": true,
           "autoincrement": false
         },
-        "icon": {
-          "name": "icon",
+        "iconId": {
+          "name": "iconId",
           "type": "text",
           "primaryKey": false,
           "notNull": false,

--- a/drizzle/project/meta/_journal.json
+++ b/drizzle/project/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1691501404186,
-      "tag": "0000_sloppy_mikhail_rasputin",
+      "when": 1692098766607,
+      "tag": "0000_special_masque",
       "breakpoints": true
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fastify/type-provider-typebox": "^3.3.0",
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "^1.0.0-alpha.4",
-        "@mapeo/schema": "file:../mapeo-schema/mapeo-schema-3.0.0-next.5.tgz",
+        "@mapeo/schema": "^3.0.0-next.6",
         "@mapeo/sqlite-indexer": "^1.0.0-alpha.5",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
@@ -1492,10 +1492,9 @@
       }
     },
     "node_modules/@mapeo/schema": {
-      "version": "3.0.0-next.5",
-      "resolved": "file:../mapeo-schema/mapeo-schema-3.0.0-next.5.tgz",
-      "integrity": "sha512-mai3H/5OgM8KVlgRkp+ANEY5e3qLCMMeuPpFkCtOtfVvDHhkc+XImnYRHt4GFgw4x0jQM7ppfYYqok/tZJrS7A==",
-      "license": "MIT",
+      "version": "3.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.6.tgz",
+      "integrity": "sha512-t//MpT1FSXatgrW4w2JncOnS8vp2PXKWYb6l5LsXRHp0syFlBbHn9YAhkNla53l7GkuZ0LdeGZ6yXx614Fx9ww==",
       "dependencies": {
         "@json-schema-tools/dereferencer": "^1.6.1",
         "ajv": "^8.12.0",
@@ -1597,9 +1596,9 @@
       }
     },
     "node_modules/@mapeo/schema/node_modules/type-fest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.1.0.tgz",
-      "integrity": "sha512-VJGJVepayd8OWavP+rgXt4i3bfLk+tSomTV7r4mca2XD/oTCWnkJlNkpXavkxdmtU2aKdAmFGeHvoQutOVHCZg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.2.0.tgz",
+      "integrity": "sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==",
       "engines": {
         "node": ">=16"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fastify/type-provider-typebox": "^3.3.0",
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "^1.0.0-alpha.4",
-        "@mapeo/schema": "^3.0.0-next.5",
+        "@mapeo/schema": "file:../mapeo-schema/mapeo-schema-3.0.0-next.5.tgz",
         "@mapeo/sqlite-indexer": "^1.0.0-alpha.5",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
@@ -1493,8 +1493,9 @@
     },
     "node_modules/@mapeo/schema": {
       "version": "3.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.5.tgz",
-      "integrity": "sha512-KnJcQW02gdedkCfQLFFcVV8Nsq77fToQw23BcJOZ3YSGta+BsPFZXyaxrdeYHQuGjBuTVJIbU78dwU7hvmqsOw==",
+      "resolved": "file:../mapeo-schema/mapeo-schema-3.0.0-next.5.tgz",
+      "integrity": "sha512-mai3H/5OgM8KVlgRkp+ANEY5e3qLCMMeuPpFkCtOtfVvDHhkc+XImnYRHt4GFgw4x0jQM7ppfYYqok/tZJrS7A==",
+      "license": "MIT",
       "dependencies": {
         "@json-schema-tools/dereferencer": "^1.6.1",
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@fastify/type-provider-typebox": "^3.3.0",
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "^1.0.0-alpha.4",
-    "@mapeo/schema": "file:../mapeo-schema/mapeo-schema-3.0.0-next.5.tgz",
+    "@mapeo/schema": "^3.0.0-next.6",
     "@mapeo/sqlite-indexer": "^1.0.0-alpha.5",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@fastify/type-provider-typebox": "^3.3.0",
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "^1.0.0-alpha.4",
-    "@mapeo/schema": "^3.0.0-next.5",
+    "@mapeo/schema": "file:../mapeo-schema/mapeo-schema-3.0.0-next.5.tgz",
     "@mapeo/sqlite-indexer": "^1.0.0-alpha.5",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -12,6 +12,7 @@ import { ReplicationStateMachine } from './replication-state-machine.js'
 // are used for key derivation
 export const NAMESPACES = /** @type {const} */ ([
   'auth',
+  'config',
   'data',
   'blobIndex',
   'blob',

--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -25,6 +25,7 @@ import pDefer from 'p-defer'
 
 const NAMESPACE_SCHEMAS = /** @type {const} */ ({
   data: ['observation'],
+  config: ['preset', 'field'],
   auth: [],
 })
 
@@ -50,7 +51,7 @@ export class DataStore extends TypedEmitter {
    * @param {object} opts
    * @param {import('../core-manager/index.js').CoreManager} opts.coreManager
    * @param {TNamespace} opts.namespace
-   * @param {import('../index-writer/index.js').IndexWriter<MapeoDocTablesMap[TSchemaName]>} opts.indexWriter
+   * @param {import('../index-writer/index.js').IndexWriter} opts.indexWriter
    * @param {MultiCoreIndexer.StorageParam} opts.storage
    */
   constructor({ coreManager, namespace, indexWriter, storage }) {

--- a/src/datatype/index.d.ts
+++ b/src/datatype/index.d.ts
@@ -22,8 +22,8 @@ type OmitUnion<T, K extends keyof any> = T extends any ? Omit<T, K> : never
 
 export class DataType<
   TDataStore extends import('../datastore/index.js').DataStore,
-  TSchemaName extends TDataStore['schemas'][number],
-  TTable extends MapeoDocTablesMap[TSchemaName],
+  TTable extends MapeoDocTables,
+  TSchemaName extends TTable['_']['name'],
   TDoc extends MapeoDocMap[TSchemaName],
   TValue extends MapeoValueMap[TSchemaName]
 > {

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -3,6 +3,7 @@ import { validate } from '@mapeo/schema'
 import { getTableConfig } from 'drizzle-orm/sqlite-core'
 import { eq, placeholder } from 'drizzle-orm'
 import { randomBytes } from 'node:crypto'
+import { deNullify } from '../utils.js'
 
 /**
  * @typedef {import('@mapeo/schema').MapeoDoc} MapeoDoc
@@ -186,21 +187,4 @@ export class DataType {
     }
     return { docId, createdAt }
   }
-}
-
-/**
- * When reading from SQLite, any optional properties are set to `null`. This
- * converts `null` back to `undefined` to match the input types (e.g. the types
- * defined in @mapeo/schema)
- * @template {{}} T
- * @param {T} obj
- * @returns {import('../types.js').NullableToOptional<T>}
- */
-export function deNullify(obj) {
-  /** @type {Record<string, any>} */
-  const objNoNulls = {}
-  for (const [key, value] of Object.entries(obj)) {
-    objNoNulls[key] = value === null ? undefined : value
-  }
-  return /** @type {import('../types.js').NullableToOptional<T>} */ (objNoNulls)
 }

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -6,7 +6,7 @@ import { CoreManager } from './core-manager/index.js'
 import { DataStore } from './datastore/index.js'
 import { DataType } from './datatype/index.js'
 import { IndexWriter } from './index-writer/index.js'
-import { observationTable } from './schema/project.js'
+import { fieldTable, observationTable, presetTable } from './schema/project.js'
 import RandomAccessFile from 'random-access-file'
 import RAM from 'random-access-memory'
 import Database from 'better-sqlite3'
@@ -79,10 +79,16 @@ export class MapeoProject {
       sqlite,
     })
     const indexWriter = new IndexWriter({
-      tables: [observationTable],
+      tables: [observationTable, presetTable, fieldTable],
       sqlite,
     })
     this.#dataStores = {
+      config: new DataStore({
+        coreManager: this.#coreManager,
+        namespace: 'config',
+        indexWriter,
+        storage: indexerStorage,
+      }),
       data: new DataStore({
         coreManager: this.#coreManager,
         namespace: 'data',
@@ -96,10 +102,26 @@ export class MapeoProject {
         table: observationTable,
         db,
       }),
+      preset: new DataType({
+        dataStore: this.#dataStores.config,
+        table: presetTable,
+        db,
+      }),
+      field: new DataType({
+        dataStore: this.#dataStores.config,
+        table: fieldTable,
+        db,
+      }),
     }
   }
 
   get observation() {
     return this.#dataTypes.observation
+  }
+  get preset() {
+    return this.#dataTypes.preset
+  }
+  get field() {
+    return this.#dataTypes.field
   }
 }

--- a/src/schema/schema-to-drizzle.js
+++ b/src/schema/schema-to-drizzle.js
@@ -80,12 +80,13 @@ export function jsonSchemaToDrizzleColumns(schema) {
         continue
       }
     }
-    const defaultValue = getDefault(value)
-    if (typeof defaultValue !== 'undefined') {
-      columns[key] = columns[key].default(defaultValue)
-    }
     if (isRequired(schema, key)) {
       columns[key] = columns[key].notNull()
+      // Only set defaults for required fields
+      const defaultValue = getDefault(value)
+      if (typeof defaultValue !== 'undefined') {
+        columns[key] = columns[key].default(defaultValue)
+      }
     }
   }
   // Not yet in @mapeo/schema

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,3 +161,10 @@ export { Duplex }
 
 export { NoiseStream }
 export type ProtocolStream = NoiseStream & { userData: Protomux }
+
+// Unsafe type for Object.entries - you must be sure that the object does not
+// have additional properties that are not defined in the type, e.g. when using
+// a const value
+export type Entries<T> = {
+  [K in keyof T]: [K, T[K]]
+}[keyof T][]

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,3 +61,21 @@ export async function openedNoiseSecretStream(stream) {
   await stream.opened
   return /** @type {OpenedNoiseStream | DestroyedNoiseStream} */ (stream)
 }
+
+/**
+ * When reading from SQLite, any optional properties are set to `null`. This
+ * converts `null` back to `undefined` to match the input types (e.g. the types
+ * defined in @mapeo/schema)
+ * @template {{}} T
+ * @param {T} obj
+ * @returns {import('./types.js').NullableToOptional<T>}
+ */
+
+export function deNullify(obj) {
+  /** @type {Record<string, any>} */
+  const objNoNulls = {}
+  for (const [key, value] of Object.entries(obj)) {
+    objNoNulls[key] = value === null ? undefined : value
+  }
+  return /** @type {import('./types.js').NullableToOptional<T>} */ (objNoNulls)
+}

--- a/test-e2e/project-crud.js
+++ b/test-e2e/project-crud.js
@@ -149,7 +149,6 @@ function stripUndef(obj) {
  *
  * @param {number} value
  * @param {number} decimalPlaces
- * @returns
  */
 function round(value, decimalPlaces) {
   return Math.round(value * 10 ** decimalPlaces) / 10 ** decimalPlaces

--- a/test-e2e/project-crud.js
+++ b/test-e2e/project-crud.js
@@ -3,54 +3,116 @@ import { randomBytes } from 'crypto'
 import { KeyManager } from '@mapeo/crypto'
 import { MapeoProject } from '../src/mapeo-project.js'
 
-/** @type {import('@mapeo/schema').ObservationValue} */
-const obsValue = {
-  schemaName: 'observation',
-  refs: [],
-  tags: {},
-  attachments: [],
-  metadata: {},
+/** @satisfies {Array<import('@mapeo/schema').MapeoValue>} */
+const fixtures = [
+  {
+    schemaName: 'observation',
+    refs: [],
+    tags: {},
+    attachments: [],
+    metadata: {},
+  },
+  {
+    schemaName: 'preset',
+    name: 'myPreset',
+    tags: {},
+    geometry: ['point'],
+    addTags: {},
+    removeTags: {},
+    fieldIds: [],
+    terms: [],
+  },
+  {
+    schemaName: 'field',
+    type: 'text',
+    tagKey: 'foo',
+    label: 'my label',
+  },
+]
+
+/**
+ * Add some random data to each fixture to test updates
+ *
+ * @template {import('@mapeo/schema').MapeoValue} T
+ * @param {T} value
+ * @returns {T}
+ */
+function getUpdateFixture(value) {
+  switch (value.schemaName) {
+    case 'observation':
+      return {
+        ...value,
+        lon: round(Math.random() * 180, 6),
+        lat: round(Math.random() * 90, 6),
+      }
+    case 'preset':
+      return {
+        ...value,
+        fieldIds: [randomBytes(32).toString('hex')],
+      }
+    case 'field':
+      return {
+        ...value,
+        label: randomBytes(10).toString('hex'),
+      }
+    default:
+      return { ...value }
+  }
 }
 
-test('create and read', async (t) => {
-  const project = await createProject()
-  const written = await project.observation.create(obsValue)
-  const read = await project.observation.getByDocId(written.docId)
-  t.alike(written, read)
-})
-
-test('update', async (t) => {
-  const project = await createProject()
-  const written = await project.observation.create(obsValue)
-  const writtenValue = valueOf(written)
-  const updated = await project.observation.update(written.versionId, {
-    ...writtenValue,
-    lon: 0.573453,
-    lat: 50.854259,
-  })
-  const updatedReRead = await project.observation.getByDocId(written.docId)
-  t.alike(updated, updatedReRead)
-  // Floating-point errors
-  t.ok((updated.lon || 0) - 0.573453 < 0.000001)
-  t.ok((updated.lat || 0) - 50.854259 < 0.000001)
-  t.not(written.updatedAt, updated.updatedAt, 'updatedAt has changed')
-  t.is(written.createdAt, updated.createdAt, 'createdAt does not change')
-})
-
-test('getMany', async (t) => {
-  const project = await createProject()
-  const obs = new Array(5).fill(null).map((value, index) => {
-    return {
-      ...obsValue,
-      tags: { index },
-    }
-  })
-  for (const value of obs) {
-    await project.observation.create(value)
+test('CRUD operations', async (t) => {
+  for (const value of fixtures) {
+    const { schemaName } = value
+    t.test(`create and read ${schemaName}`, async (t) => {
+      const project = await createProject()
+      // @ts-ignore - TS can't figure this out, but we're not testing types here to ok to ignore
+      const written = await project[schemaName].create(value)
+      const read = await project[schemaName].getByDocId(written.docId)
+      t.alike(valueOf(stripUndef(written)), value, 'expected value is written')
+      t.alike(written, read, 'return create() matches return of getByDocId()')
+    })
+    t.test('update', async (t) => {
+      const project = await createProject()
+      // @ts-ignore
+      const written = await project[schemaName].create(value)
+      const updateValue = getUpdateFixture(value)
+      // @ts-ignore
+      const updated = await project[schemaName].update(
+        written.versionId,
+        updateValue
+      )
+      const updatedReRead = await project[schemaName].getByDocId(written.docId)
+      t.alike(
+        updated,
+        updatedReRead,
+        'return of update() matched return of getByDocId()'
+      )
+      t.alike(
+        valueOf(stripUndef(updated)),
+        updateValue,
+        'expected value is updated'
+      )
+      t.not(written.updatedAt, updated.updatedAt, 'updatedAt has changed')
+      t.is(written.createdAt, updated.createdAt, 'createdAt does not change')
+    })
+    t.test('getMany', async (t) => {
+      const project = await createProject()
+      const values = new Array(5).fill(null).map(() => {
+        return getUpdateFixture(value)
+      })
+      for (const value of values) {
+        // @ts-ignore
+        await project[schemaName].create(value)
+      }
+      const many = await project[schemaName].getMany()
+      const manyValues = many.map((doc) => valueOf(doc))
+      t.alike(
+        stripUndef(manyValues),
+        values,
+        'expected values returns from getMany()'
+      )
+    })
   }
-  const many = await project.observation.getMany()
-  const manyValues = many.map((doc) => valueOf(doc))
-  t.alike(stripUndef(manyValues), obs)
 })
 
 /**
@@ -81,4 +143,14 @@ function createProject({
  */
 function stripUndef(obj) {
   return JSON.parse(JSON.stringify(obj))
+}
+
+/**
+ *
+ * @param {number} value
+ * @param {number} decimalPlaces
+ * @returns
+ */
+function round(value, decimalPlaces) {
+  return Math.round(value * 10 ** decimalPlaces) / 10 ** decimalPlaces
 }

--- a/test-e2e/project-crud.js
+++ b/test-e2e/project-crud.js
@@ -65,7 +65,7 @@ test('CRUD operations', async (t) => {
     const { schemaName } = value
     t.test(`create and read ${schemaName}`, async (t) => {
       const project = await createProject()
-      // @ts-ignore - TS can't figure this out, but we're not testing types here to ok to ignore
+      // @ts-ignore - TS can't figure this out, but we're not testing types here so ok to ignore
       const written = await project[schemaName].create(value)
       const read = await project[schemaName].getByDocId(written.docId)
       t.alike(valueOf(stripUndef(written)), value, 'expected value is written')

--- a/test-types/data-types.ts
+++ b/test-types/data-types.ts
@@ -1,30 +1,36 @@
 import { MapeoProject } from '../dist/index.js'
 import { randomBytes } from 'crypto'
 import { KeyManager } from '@mapeo/crypto'
-import { Observation, ObservationValue } from '@mapeo/schema'
+import {
+  Field,
+  FieldValue,
+  Observation,
+  ObservationValue,
+  Preset,
+  PresetValue,
+} from '@mapeo/schema'
 import { Expect, type Equal } from './utils.js'
 
-type ObservationWithForks = Observation & { forks: string[] }
-
-const obsValue: ObservationValue = {
-  schemaName: 'observation',
-  refs: [],
-  tags: {},
-  attachments: [],
-  metadata: {},
-}
+type Forks = { forks: string[] }
+type ObservationWithForks = Observation & Forks
+type PresetWithForks = Preset & Forks
+type FieldWithForks = Field & Forks
 
 const mapeoProject = new MapeoProject({
   keyManager: new KeyManager(randomBytes(32)),
   projectKey: randomBytes(32),
 })
 
-const createdObservation = await mapeoProject.observation.create(obsValue)
+///// Observations
+
+const createdObservation = await mapeoProject.observation.create(
+  {} as ObservationValue
+)
 Expect<Equal<ObservationWithForks, typeof createdObservation>>
 
 const updatedObservation = await mapeoProject.observation.update(
   'abc',
-  obsValue
+  {} as ObservationValue
 )
 Expect<Equal<ObservationWithForks, typeof updatedObservation>>
 
@@ -35,3 +41,31 @@ const observationByVersionId = await mapeoProject.observation.getByVersionId(
   'abc'
 )
 Expect<Equal<Observation, typeof observationByVersionId>>
+
+///// Presets
+
+const createdPreset = await mapeoProject.preset.create({} as PresetValue)
+Expect<Equal<PresetWithForks, typeof createdPreset>>
+
+const updatedPreset = await mapeoProject.preset.update('abc', {} as PresetValue)
+Expect<Equal<PresetWithForks, typeof updatedPreset>>
+
+const manyPresets = await mapeoProject.preset.getMany()
+Expect<Equal<PresetWithForks[], typeof manyPresets>>
+
+const presetByVersionId = await mapeoProject.preset.getByVersionId('abc')
+Expect<Equal<Preset, typeof presetByVersionId>>
+
+///// Fields
+
+const createdField = await mapeoProject.field.create({} as FieldValue)
+Expect<Equal<FieldWithForks, typeof createdField>>
+
+const updatedField = await mapeoProject.field.update('abc', {} as FieldValue)
+Expect<Equal<FieldWithForks, typeof updatedField>>
+
+const manyFields = await mapeoProject.field.getMany()
+Expect<Equal<FieldWithForks[], typeof manyFields>>
+
+const fieldByVersionId = await mapeoProject.field.getByVersionId('abc')
+Expect<Equal<Field, typeof fieldByVersionId>>

--- a/tests/schema.js
+++ b/tests/schema.js
@@ -46,7 +46,11 @@ test('Expected table config', (t) => {
         jsonSchema.required.includes(key),
         'NOT NULL matches `required`'
       )
-      t.is(columnConfig.default, value.default, 'Default is correct')
+      // Only fields that are required should have a default set in the SQLite column
+      const expectedDefault =
+        // @ts-ignore
+        jsonSchema.required.includes(key) ? value.default : undefined
+      t.is(columnConfig.default, expectedDefault, 'Default is correct')
     }
   }
 })

--- a/tests/schema.js
+++ b/tests/schema.js
@@ -10,7 +10,7 @@ import {
   BACKLINK_TABLE_POSTFIX,
   getBacklinkTableName,
 } from '../src/schema/utils.js'
-import { deNullify } from '../src/datatype/index.js'
+import { deNullify } from '../src/utils.js'
 
 test('Expected table config', (t) => {
   const allTableSchemas = [

--- a/types/brittle.d.ts
+++ b/types/brittle.d.ts
@@ -42,18 +42,17 @@ declare module 'brittle' {
     timeout(ms: number): void
     comment(message: string): void
     end(): void
-  }
-
-  interface SubTestInstance extends TestInstance {
     test(
       name: string,
       options: TestOptions,
       callback: (t: TestInstance) => void | Promise<void>
-    ): TestInstance
+    ): Promise<boolean>
     test(
       name: string,
       callback: (t: TestInstance) => void | Promise<void>
-    ): TestInstance
+    ): Promise<boolean>
+    test(name: string, options: TestOptions): TestInstance
+    test(options: TestOptions): TestInstance
   }
 
   type TestCallback = (t: TestInstance) => void | Promise<void>
@@ -62,21 +61,22 @@ declare module 'brittle' {
     name: string,
     options: TestOptions,
     callback: TestCallback
-  ): TestInstance
-  function test(name: string, callback: TestCallback): TestInstance
-  function test(options: TestOptions): SubTestInstance
+  ): Promise<boolean>
+  function test(name: string, callback: TestCallback): Promise<boolean>
+  function test(name: string, options: TestOptions): TestInstance
+  function test(options: TestOptions): TestInstance
   function solo(
     name: string,
     options: TestOptions,
     callback: TestCallback
-  ): TestInstance
-  function solo(name: string, callback: TestCallback): TestInstance
-  function solo(options: TestOptions): SubTestInstance
+  ): Promise<boolean>
+  function solo(name: string, callback: TestCallback): Promise<boolean>
+  function solo(options: TestOptions): TestInstance
   function skip(
     name: string,
     options: TestOptions,
     callback: TestCallback
-  ): void
+  ): Promise<boolean>
   function skip(name: string, callback: TestCallback): void
   function configure(options: TestOptions): void
 


### PR DESCRIPTION
~~Currently depends on https://github.com/digidem/mapeo-schema/pull/117 and a new version of @mapeo/schema being published.~~

This adds two new data types: preset and field. They are stored in a new namespace called "config". The reason for keeping these data types in a separate namespace is to allow sync of only the config prior to syncing the rest of the data. We're not using the auth namespace because Mapeo Cloud needs the encryption key for that namespace, and we want to minimise the data that a server can see as unencrypted.