### PR TITLE
feat: Add internal `dataType.createWithDocId()`

### DIFF
--- a/src/datatype/index.d.ts
+++ b/src/datatype/index.d.ts
@@ -4,7 +4,6 @@
 
 import { type MapeoDoc, type MapeoValue } from '@mapeo/schema'
 import { type MapeoDocMap, type MapeoValueMap } from '../types.js'
-import { kCreateWithDocId } from './index.js'
 
 type MapeoDocTableName = `${MapeoDoc['schemaName']}Table`
 type GetMapeoDocTables<T> = T[keyof T & MapeoDocTableName]
@@ -18,6 +17,8 @@ type MapeoDocTablesMap = {
     { _: { name: K } }
   >
 }
+
+export const kCreateWithDocId: unique symbol
 
 type OmitUnion<T, K extends keyof any> = T extends any ? Omit<T, K> : never
 

--- a/src/datatype/index.d.ts
+++ b/src/datatype/index.d.ts
@@ -4,6 +4,7 @@
 
 import { type MapeoDoc, type MapeoValue } from '@mapeo/schema'
 import { type MapeoDocMap, type MapeoValueMap } from '../types.js'
+import { kCreateWithDocId } from './index.js'
 
 type MapeoDocTableName = `${MapeoDoc['schemaName']}Table`
 type GetMapeoDocTables<T> = T[keyof T & MapeoDocTableName]
@@ -38,6 +39,11 @@ export class DataType<
     db: import('drizzle-orm/better-sqlite3').BetterSQLite3Database
     getPermissions?: () => any
   })
+
+  [kCreateWithDocId]<T extends import('type-fest').Exact<TValue, T>>(
+    docId: string,
+    value: T
+  ): Promise<TDoc & { forks: string[] }>
 
   create<T extends import('type-fest').Exact<TValue, T>>(
     value: T

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -43,6 +43,7 @@ function generateId() {
 function generateDate() {
   return new Date().toISOString()
 }
+export const kCreateWithDocId = Symbol('kCreateWithDocId')
 
 /**
  * @template {import('../datastore/index.js').DataStore} TDataStore
@@ -86,6 +87,16 @@ export class DataType {
    * @param {T} value
    */
   async create(value) {
+    const docId = generateId()
+    return this[kCreateWithDocId](docId, value)
+  }
+
+  /**
+   * @template {import('type-fest').Exact<TValue, T>} T
+   * @param {string} docId
+   * @param {T} value
+   */
+  async [kCreateWithDocId](docId, value) {
     if (!validate(this.#schemaName, value)) {
       // TODO: pass through errors from validate functions
       throw new Error('Invalid value ' + value)
@@ -94,7 +105,7 @@ export class DataType {
     /** @type {OmitUnion<MapeoDoc, 'versionId'>} */
     const doc = {
       ...value,
-      docId: generateId(),
+      docId,
       createdAt: nowDateString,
       updatedAt: nowDateString,
       links: [],

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -1,0 +1,51 @@
+// @ts-check
+import test from 'brittle'
+import { DataStore } from '../src/datastore/index.js'
+import { createCoreManager } from './helpers/core-manager.js'
+import RAM from 'random-access-memory'
+import { observationTable } from '../src/schema/project.js'
+import { DataType, kCreateWithDocId } from '../src/datatype/index.js'
+import { IndexWriter } from '../src/index-writer/index.js'
+
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { randomBytes } from 'crypto'
+
+const obsFixture = {
+  schemaName: 'observation',
+  refs: [],
+  tags: {},
+  attachments: [],
+  metadata: {},
+}
+
+test('private createWithDocId() method', async (t) => {
+  const sqlite = new Database(':memory:')
+  const db = drizzle(sqlite)
+  migrate(db, { migrationsFolder: './drizzle/project' })
+  const coreManager = createCoreManager()
+  const indexWriter = new IndexWriter({
+    tables: [observationTable],
+    sqlite,
+  })
+  const dataStore = new DataStore({
+    coreManager,
+    namespace: 'data',
+    batch: async (entries) => {
+      return indexWriter.batch(entries)
+    },
+    storage: () => new RAM(),
+  })
+  const dataType = new DataType({
+    dataStore,
+    table: observationTable,
+    db,
+  })
+  const customId = randomBytes(8).toString('hex')
+  // @ts-ignore - not sure why this is failing, ignoring for now
+  const obs = await dataType[kCreateWithDocId](customId, obsFixture)
+  t.is(obs.docId, customId)
+  const read = await dataType.getByDocId(customId)
+  t.is(read.docId, customId)
+})

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -12,6 +12,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import { randomBytes } from 'crypto'
 
+/** @type {import('@mapeo/schema').ObservationValue} */
 const obsFixture = {
   schemaName: 'observation',
   refs: [],
@@ -43,7 +44,6 @@ test('private createWithDocId() method', async (t) => {
     db,
   })
   const customId = randomBytes(8).toString('hex')
-  // @ts-ignore - not sure why this is failing, ignoring for now
   const obs = await dataType[kCreateWithDocId](customId, obsFixture)
   t.is(obs.docId, customId)
   const read = await dataType.getByDocId(customId)


### PR DESCRIPTION
Fixes Add `dataType.createWithDocId()` method #190

TODO:

- [x] Add tests
- [x] Add types

~~The type signature for [kCreateWithDocId]() is not quite right, but otherwise good to go.~~

Fixed the type issues, all ready for review & merge :)