### PR TITLE
feat: update protobuf for RPC [2/3]

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -2,14 +2,19 @@ syntax = "proto3";
 
 message Invite {
   message EncryptionKeys {
-    optional bytes auth = 1;
+    bytes auth = 1;
     optional bytes data = 2;
-    optional bytes blobIndex = 3;
-    optional bytes blob = 4;
+    optional bytes config = 3;
+    optional bytes blobIndex = 4;
+    optional bytes blob = 5;
+  }
+  // Project info that is displayed to the user receiving the invite
+  message ProjectInfo {
+    optional string name = 1;
   }
   bytes projectKey = 1;
   optional EncryptionKeys encryptionKeys = 2;
-  optional bytes projectConfig = 3;
+  optional ProjectInfo projectInfo = 3;
 }
 message InviteResponse {
   enum Decision {

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -3,13 +3,18 @@ import _m0 from "protobufjs/minimal.js";
 export interface Invite {
     projectKey: Buffer;
     encryptionKeys?: Invite_EncryptionKeys | undefined;
-    projectConfig?: Buffer | undefined;
+    projectInfo?: Invite_ProjectInfo | undefined;
 }
 export interface Invite_EncryptionKeys {
-    auth?: Buffer | undefined;
+    auth: Buffer;
     data?: Buffer | undefined;
+    config?: Buffer | undefined;
     blobIndex?: Buffer | undefined;
     blob?: Buffer | undefined;
+}
+/** Project info that is displayed to the user receiving the invite */
+export interface Invite_ProjectInfo {
+    name?: string | undefined;
 }
 export interface InviteResponse {
     projectKey: Buffer;
@@ -30,6 +35,10 @@ export declare const Invite: {
 export declare const Invite_EncryptionKeys: {
     encode(message: Invite_EncryptionKeys, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): Invite_EncryptionKeys;
+};
+export declare const Invite_ProjectInfo: {
+    encode(message: Invite_ProjectInfo, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): Invite_ProjectInfo;
 };
 export declare const InviteResponse: {
     encode(message: InviteResponse, writer?: _m0.Writer): _m0.Writer;

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -49,8 +49,8 @@ export var Invite = {
         if (message.encryptionKeys !== undefined) {
             Invite_EncryptionKeys.encode(message.encryptionKeys, writer.uint32(18).fork()).ldelim();
         }
-        if (message.projectConfig !== undefined) {
-            writer.uint32(26).bytes(message.projectConfig);
+        if (message.projectInfo !== undefined) {
+            Invite_ProjectInfo.encode(message.projectInfo, writer.uint32(26).fork()).ldelim();
         }
         return writer;
     },
@@ -77,7 +77,7 @@ export var Invite = {
                     if (tag !== 26) {
                         break;
                     }
-                    message.projectConfig = reader.bytes();
+                    message.projectInfo = Invite_ProjectInfo.decode(reader, reader.uint32());
                     continue;
             }
             if ((tag & 7) === 4 || tag === 0) {
@@ -89,22 +89,25 @@ export var Invite = {
     },
 };
 function createBaseInvite_EncryptionKeys() {
-    return {};
+    return { auth: Buffer.alloc(0) };
 }
 export var Invite_EncryptionKeys = {
     encode: function (message, writer) {
         if (writer === void 0) { writer = _m0.Writer.create(); }
-        if (message.auth !== undefined) {
+        if (message.auth.length !== 0) {
             writer.uint32(10).bytes(message.auth);
         }
         if (message.data !== undefined) {
             writer.uint32(18).bytes(message.data);
         }
+        if (message.config !== undefined) {
+            writer.uint32(26).bytes(message.config);
+        }
         if (message.blobIndex !== undefined) {
-            writer.uint32(26).bytes(message.blobIndex);
+            writer.uint32(34).bytes(message.blobIndex);
         }
         if (message.blob !== undefined) {
-            writer.uint32(34).bytes(message.blob);
+            writer.uint32(42).bytes(message.blob);
         }
         return writer;
     },
@@ -131,13 +134,52 @@ export var Invite_EncryptionKeys = {
                     if (tag !== 26) {
                         break;
                     }
-                    message.blobIndex = reader.bytes();
+                    message.config = reader.bytes();
                     continue;
                 case 4:
                     if (tag !== 34) {
                         break;
                     }
+                    message.blobIndex = reader.bytes();
+                    continue;
+                case 5:
+                    if (tag !== 42) {
+                        break;
+                    }
                     message.blob = reader.bytes();
+                    continue;
+            }
+            if ((tag & 7) === 4 || tag === 0) {
+                break;
+            }
+            reader.skipType(tag & 7);
+        }
+        return message;
+    },
+};
+function createBaseInvite_ProjectInfo() {
+    return {};
+}
+export var Invite_ProjectInfo = {
+    encode: function (message, writer) {
+        if (writer === void 0) { writer = _m0.Writer.create(); }
+        if (message.name !== undefined) {
+            writer.uint32(10).string(message.name);
+        }
+        return writer;
+    },
+    decode: function (input, length) {
+        var reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+        var end = length === undefined ? reader.len : reader.pos + length;
+        var message = createBaseInvite_ProjectInfo();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    if (tag !== 10) {
+                        break;
+                    }
+                    message.name = reader.string();
                     continue;
             }
             if ((tag & 7) === 4 || tag === 0) {

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -4,14 +4,20 @@ import _m0 from "protobufjs/minimal.js";
 export interface Invite {
   projectKey: Buffer;
   encryptionKeys?: Invite_EncryptionKeys | undefined;
-  projectConfig?: Buffer | undefined;
+  projectInfo?: Invite_ProjectInfo | undefined;
 }
 
 export interface Invite_EncryptionKeys {
-  auth?: Buffer | undefined;
+  auth: Buffer;
   data?: Buffer | undefined;
+  config?: Buffer | undefined;
   blobIndex?: Buffer | undefined;
   blob?: Buffer | undefined;
+}
+
+/** Project info that is displayed to the user receiving the invite */
+export interface Invite_ProjectInfo {
+  name?: string | undefined;
 }
 
 export interface InviteResponse {
@@ -70,8 +76,8 @@ export const Invite = {
     if (message.encryptionKeys !== undefined) {
       Invite_EncryptionKeys.encode(message.encryptionKeys, writer.uint32(18).fork()).ldelim();
     }
-    if (message.projectConfig !== undefined) {
-      writer.uint32(26).bytes(message.projectConfig);
+    if (message.projectInfo !== undefined) {
+      Invite_ProjectInfo.encode(message.projectInfo, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -102,7 +108,7 @@ export const Invite = {
             break;
           }
 
-          message.projectConfig = reader.bytes() as Buffer;
+          message.projectInfo = Invite_ProjectInfo.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -115,22 +121,25 @@ export const Invite = {
 };
 
 function createBaseInvite_EncryptionKeys(): Invite_EncryptionKeys {
-  return {};
+  return { auth: Buffer.alloc(0) };
 }
 
 export const Invite_EncryptionKeys = {
   encode(message: Invite_EncryptionKeys, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.auth !== undefined) {
+    if (message.auth.length !== 0) {
       writer.uint32(10).bytes(message.auth);
     }
     if (message.data !== undefined) {
       writer.uint32(18).bytes(message.data);
     }
+    if (message.config !== undefined) {
+      writer.uint32(26).bytes(message.config);
+    }
     if (message.blobIndex !== undefined) {
-      writer.uint32(26).bytes(message.blobIndex);
+      writer.uint32(34).bytes(message.blobIndex);
     }
     if (message.blob !== undefined) {
-      writer.uint32(34).bytes(message.blob);
+      writer.uint32(42).bytes(message.blob);
     }
     return writer;
   },
@@ -161,14 +170,57 @@ export const Invite_EncryptionKeys = {
             break;
           }
 
-          message.blobIndex = reader.bytes() as Buffer;
+          message.config = reader.bytes() as Buffer;
           continue;
         case 4:
           if (tag !== 34) {
             break;
           }
 
+          message.blobIndex = reader.bytes() as Buffer;
+          continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.blob = reader.bytes() as Buffer;
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+};
+
+function createBaseInvite_ProjectInfo(): Invite_ProjectInfo {
+  return {};
+}
+
+export const Invite_ProjectInfo = {
+  encode(message: Invite_ProjectInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.name !== undefined) {
+      writer.uint32(10).string(message.name);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Invite_ProjectInfo {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseInvite_ProjectInfo();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {

--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -131,7 +131,7 @@ export class MapeoRPC extends TypedEmitter {
    * @param {object} options
    * @param {Invite['projectKey']} options.projectKey project key
    * @param {Invite['encryptionKeys']} [options.encryptionKeys] project encryption key
-   * @param {Invite['projectConfig']} [options.projectConfig] project config (presets, fields & icons)
+   * @param {Invite['projectInfo']} [options.projectInfo] project info - currently name
    * @param {number} [options.timeout] timeout waiting for invite response before rejecting (default 1 minute)
    * @returns {Promise<InviteResponse['decision']>}
    */

--- a/tests/rpc.js
+++ b/tests/rpc.js
@@ -139,30 +139,26 @@ test('Send invite with encryption key', async (t) => {
   replicate(r1, r2)
 })
 
-test('Send invite with project config', async (t) => {
+test('Send invite with project info', async (t) => {
   t.plan(4)
   const r1 = new MapeoRPC()
   const r2 = new MapeoRPC()
 
   const projectKey = Buffer.allocUnsafe(32).fill(0)
-  const projectConfig = Buffer.allocUnsafe(1024).fill(1)
+  const projectInfo = { name: 'MyProject' }
 
   r1.on('peers', async (peers) => {
     t.is(peers.length, 1)
     const response = await r1.invite(peers[0].id, {
       projectKey,
-      projectConfig,
+      projectInfo,
     })
     t.is(response, MapeoRPC.InviteResponse.ACCEPT)
   })
 
   r2.on('invite', (peerId, invite) => {
     t.ok(invite.projectKey.equals(projectKey), 'invite project key correct')
-    t.alike(
-      invite.projectConfig,
-      projectConfig,
-      'project config is sent with invite'
-    )
+    t.alike(invite.projectInfo, projectInfo, 'project info is sent with invite')
     r2.inviteResponse(peerId, {
       projectKey: invite.projectKey,
       decision: MapeoRPC.InviteResponse.ACCEPT,


### PR DESCRIPTION
- add `config` namespace to encryptionKeys
- remove support for sending projectConfig
    (now synced in db, not sent in invite)
- add projectInfo to invite - currently `name`
- make auth encryption key mandatory