### PR TITLE
initial implementation of invite method for MemberApi

### DIFF
--- a/src/member-api.js
+++ b/src/member-api.js
@@ -1,6 +1,8 @@
 import { TypedEmitter } from 'tiny-typed-emitter'
+import { InviteResponse_Decision } from './generated/rpc.js'
 
 export class MemberApi extends TypedEmitter {
+  #capabilities
   #encryptionKeys
   #getProjectInfo
   #projectKey
@@ -8,29 +10,37 @@ export class MemberApi extends TypedEmitter {
 
   /**
    * @param {Object} opts
+   * @param {import('./capabilities.js').Capabilities} opts.capabilities
    * @param {import('./generated/keys.js').EncryptionKeys} opts.encryptionKeys
    * @param {() => Promise<import('./generated/rpc.js').Invite_ProjectInfo>} opts.getProjectInfo
    * @param {Buffer} opts.projectKey
    * @param {import('./rpc/index.js').MapeoRPC} opts.rpc
    */
-  constructor({ encryptionKeys, getProjectInfo, projectKey, rpc }) {
+  constructor({
+    capabilities,
+    encryptionKeys,
+    getProjectInfo,
+    projectKey,
+    rpc,
+  }) {
     super()
     this.#encryptionKeys = encryptionKeys
     this.#getProjectInfo = getProjectInfo
     this.#projectKey = projectKey
     this.#rpc = rpc
+    this.#capabilities = capabilities
   }
 
   /**
    * @param {string} deviceId
    *
    * @param {Object} opts
-   * @param {string} opts.roleId
+   * @param {import('./capabilities.js').RoleId} opts.roleId
    * @param {number} [opts.timeout]
    *
    * @returns {Promise<import('./generated/rpc.js').InviteResponse_Decision>}
    */
-  async invite(deviceId, { timeout }) {
+  async invite(deviceId, { roleId, timeout }) {
     const projectInfo = await this.#getProjectInfo()
 
     const response = await this.#rpc.invite(deviceId, {
@@ -40,7 +50,9 @@ export class MemberApi extends TypedEmitter {
       timeout,
     })
 
-    // TODO: If response is ACCEPT, write to capabilities
+    if (response === InviteResponse_Decision.ACCEPT) {
+      await this.#capabilities.assignRole(deviceId, roleId)
+    }
 
     return response
   }

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -25,7 +25,7 @@ export class MemberApi extends TypedEmitter {
    * @param {string} deviceId
    *
    * @param {Object} opts
-   * @param {string} opts.role
+   * @param {string} opts.roleId
    * @param {number} [opts.timeout]
    *
    * @returns {Promise<import('./generated/rpc.js').InviteResponse_Decision>}
@@ -33,11 +33,15 @@ export class MemberApi extends TypedEmitter {
   async invite(deviceId, { timeout }) {
     const projectInfo = await this.#getProjectInfo()
 
-    return this.#rpc.invite(deviceId, {
+    const response = await this.#rpc.invite(deviceId, {
       projectKey: this.#projectKey,
       encryptionKeys: this.#encryptionKeys,
       projectInfo,
       timeout,
     })
+
+    // TODO: If response is ACCEPT, write to capabilities
+
+    return response
   }
 }

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -24,11 +24,11 @@ export class MemberApi extends TypedEmitter {
     rpc,
   }) {
     super()
+    this.#capabilities = capabilities
     this.#encryptionKeys = encryptionKeys
     this.#getProjectInfo = getProjectInfo
     this.#projectKey = projectKey
     this.#rpc = rpc
-    this.#capabilities = capabilities
   }
 
   /**

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -1,5 +1,4 @@
 import { TypedEmitter } from 'tiny-typed-emitter'
-import { MapeoRPC } from './rpc/index.js'
 
 export class MemberApi extends TypedEmitter {
   #encryptionKeys
@@ -12,7 +11,7 @@ export class MemberApi extends TypedEmitter {
    * @param {import('./generated/keys.js').EncryptionKeys} opts.encryptionKeys
    * @param {() => Promise<import('./generated/rpc.js').Invite_ProjectInfo>} opts.getProjectInfo
    * @param {Buffer} opts.projectKey
-   * @param {MapeoRPC} opts.rpc
+   * @param {import('./rpc/index.js').MapeoRPC} opts.rpc
    */
   constructor({ encryptionKeys, getProjectInfo, projectKey, rpc }) {
     super()
@@ -31,7 +30,7 @@ export class MemberApi extends TypedEmitter {
    *
    * @returns {Promise<import('./generated/rpc.js').InviteResponse_Decision>}
    */
-  async invite(deviceId, { role, timeout }) {
+  async invite(deviceId, { timeout }) {
     const projectInfo = await this.#getProjectInfo()
 
     return this.#rpc.invite(deviceId, {

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -1,0 +1,44 @@
+import { TypedEmitter } from 'tiny-typed-emitter'
+import { MapeoRPC } from './rpc/index.js'
+
+export class MemberApi extends TypedEmitter {
+  #encryptionKeys
+  #getProjectInfo
+  #projectKey
+  #rpc
+
+  /**
+   * @param {Object} opts
+   * @param {import('./generated/keys.js').EncryptionKeys} opts.encryptionKeys
+   * @param {() => Promise<import('./generated/rpc.js').Invite_ProjectInfo>} opts.getProjectInfo
+   * @param {Buffer} opts.projectKey
+   * @param {MapeoRPC} opts.rpc
+   */
+  constructor({ encryptionKeys, getProjectInfo, projectKey, rpc }) {
+    super()
+    this.#encryptionKeys = encryptionKeys
+    this.#getProjectInfo = getProjectInfo
+    this.#projectKey = projectKey
+    this.#rpc = rpc
+  }
+
+  /**
+   * @param {string} deviceId
+   *
+   * @param {Object} opts
+   * @param {string} opts.role
+   * @param {number} [opts.timeout]
+   *
+   * @returns {Promise<import('./generated/rpc.js').InviteResponse_Decision>}
+   */
+  async invite(deviceId, { role, timeout }) {
+    const projectInfo = await this.#getProjectInfo()
+
+    return this.#rpc.invite(deviceId, {
+      projectKey: this.#projectKey,
+      encryptionKeys: this.#encryptionKeys,
+      projectInfo,
+      timeout,
+    })
+  }
+}

--- a/tests/helpers/rpc.js
+++ b/tests/helpers/rpc.js
@@ -1,0 +1,34 @@
+import NoiseSecretStream from '@hyperswarm/secret-stream'
+
+export function replicate(rpc1, rpc2) {
+  const n1 = new NoiseSecretStream(true, undefined, {
+    // Keep keypairs deterministic for tests, since we use peer.publicKey as an identifier.
+    keyPair: NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(0)),
+  })
+  const n2 = new NoiseSecretStream(false, undefined, {
+    keyPair: NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(1)),
+  })
+  n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
+
+  rpc1.connect(n1)
+  rpc2.connect(n2)
+
+  return async function destroy() {
+    return Promise.all([
+      /** @type {Promise<void>} */
+      (
+        new Promise((res) => {
+          n1.on('close', res)
+          n1.destroy()
+        })
+      ),
+      /** @type {Promise<void>} */
+      (
+        new Promise((res) => {
+          n2.on('close', res)
+          n2.destroy()
+        })
+      ),
+    ])
+  }
+}

--- a/tests/member-api.js
+++ b/tests/member-api.js
@@ -4,10 +4,11 @@ import { KeyManager } from '@mapeo/crypto'
 
 import { MapeoRPC } from '../src/rpc/index.js'
 import { MemberApi } from '../src/member-api.js'
+import { InviteResponse_Decision } from '../src/generated/rpc.js'
 import { replicate } from './helpers/rpc.js'
 
 test('Invite sends expected project-related details', async (t) => {
-  t.plan(3)
+  t.plan(4)
 
   const projectKey = KeyManager.generateProjectKeypair().publicKey
   const encryptionKeys = { auth: randomBytes(32) }
@@ -23,16 +24,23 @@ test('Invite sends expected project-related details', async (t) => {
     rpc: r1,
   })
 
-  r1.on('peers', (peers) => {
-    memberApi.invite(peers[0].id, {
+  r1.on('peers', async (peers) => {
+    const response = await memberApi.invite(peers[0].id, {
       role: 'member',
     })
+
+    t.is(response, InviteResponse_Decision.ACCEPT)
   })
 
-  r2.on('invite', async (_peerId, invite) => {
+  r2.on('invite', async (peerId, invite) => {
     t.alike(invite.projectKey, projectKey)
     t.alike(invite.encryptionKeys, encryptionKeys)
     t.alike(invite.projectInfo, projectInfo)
+
+    r2.inviteResponse(peerId, {
+      projectKey: invite.projectKey,
+      decision: InviteResponse_Decision.ACCEPT,
+    })
   })
 
   replicate(r1, r2)

--- a/tests/member-api.js
+++ b/tests/member-api.js
@@ -1,0 +1,39 @@
+import { test } from 'brittle'
+import { randomBytes } from 'crypto'
+import { KeyManager } from '@mapeo/crypto'
+
+import { MapeoRPC } from '../src/rpc/index.js'
+import { MemberApi } from '../src/member-api.js'
+import { replicate } from './helpers/rpc.js'
+
+test('Invite sends expected project-related details', async (t) => {
+  t.plan(3)
+
+  const projectKey = KeyManager.generateProjectKeypair().publicKey
+  const encryptionKeys = { auth: randomBytes(32) }
+  const projectInfo = { name: 'mapeo' }
+
+  const r1 = new MapeoRPC()
+  const r2 = new MapeoRPC()
+
+  const memberApi = new MemberApi({
+    encryptionKeys,
+    getProjectInfo: async () => projectInfo,
+    projectKey,
+    rpc: r1,
+  })
+
+  r1.on('peers', (peers) => {
+    memberApi.invite(peers[0].id, {
+      role: 'member',
+    })
+  })
+
+  r2.on('invite', async (_peerId, invite) => {
+    t.alike(invite.projectKey, projectKey)
+    t.alike(invite.encryptionKeys, encryptionKeys)
+    t.alike(invite.projectInfo, projectInfo)
+  })
+
+  replicate(r1, r2)
+})

--- a/tests/member-api.js
+++ b/tests/member-api.js
@@ -99,7 +99,7 @@ test('invite() does not assign role to invited device if invite is not accepted'
   ).filter((d) => d !== InviteResponse_Decision.ACCEPT)
 
   for (const decision of nonAcceptInviteDecisions) {
-    t.test(`${decision}`, (t) => {
+    t.test(decision, (t) => {
       t.plan(1)
 
       const r1 = new MapeoRPC()

--- a/tests/member-api.js
+++ b/tests/member-api.js
@@ -7,7 +7,7 @@ import { MemberApi } from '../src/member-api.js'
 import { InviteResponse_Decision } from '../src/generated/rpc.js'
 import { replicate } from './helpers/rpc.js'
 
-test('Invite sends expected project-related details', async (t) => {
+test('invite() sends expected project-related details', async (t) => {
   t.plan(4)
 
   const projectKey = KeyManager.generateProjectKeypair().publicKey
@@ -18,6 +18,7 @@ test('Invite sends expected project-related details', async (t) => {
   const r2 = new MapeoRPC()
 
   const memberApi = new MemberApi({
+    capabilities: { async assignRole() {} },
     encryptionKeys,
     getProjectInfo: async () => projectInfo,
     projectKey,
@@ -32,7 +33,7 @@ test('Invite sends expected project-related details', async (t) => {
     t.is(response, InviteResponse_Decision.ACCEPT)
   })
 
-  r2.on('invite', async (peerId, invite) => {
+  r2.on('invite', (peerId, invite) => {
     t.alike(invite.projectKey, projectKey)
     t.alike(invite.encryptionKeys, encryptionKeys)
     t.alike(invite.projectInfo, projectInfo)
@@ -44,4 +45,99 @@ test('Invite sends expected project-related details', async (t) => {
   })
 
   replicate(r1, r2)
+})
+
+test('invite() assigns role to invited device after invite accepted', async (t) => {
+  t.plan(4)
+
+  const r1 = new MapeoRPC()
+  const r2 = new MapeoRPC()
+
+  const expectedRoleId = randomBytes(8).toString('hex')
+  let expectedDeviceId = null
+
+  // We're only testing that this gets called with the expected arguments
+  const capabilities = {
+    async assignRole(deviceId, roleId) {
+      t.ok(expectedDeviceId)
+      t.is(deviceId, expectedDeviceId)
+      t.is(roleId, expectedRoleId)
+    },
+  }
+
+  const memberApi = new MemberApi({
+    capabilities,
+    encryptionKeys: { auth: randomBytes(32) },
+    getProjectInfo: async () => {},
+    projectKey: KeyManager.generateProjectKeypair().publicKey,
+    rpc: r1,
+  })
+
+  r1.on('peers', async (peers) => {
+    expectedDeviceId = peers[0].id
+
+    const response = await memberApi.invite(expectedDeviceId, {
+      roleId: expectedRoleId,
+    })
+
+    t.is(response, InviteResponse_Decision.ACCEPT)
+  })
+
+  r2.on('invite', (peerId, invite) => {
+    r2.inviteResponse(peerId, {
+      projectKey: invite.projectKey,
+      decision: InviteResponse_Decision.ACCEPT,
+    })
+  })
+
+  replicate(r1, r2)
+})
+
+test('invite() does not assign role to invited device if invite is not accepted', async (t) => {
+  const nonAcceptInviteDecisions = Object.values(
+    InviteResponse_Decision
+  ).filter((d) => d !== InviteResponse_Decision.ACCEPT)
+
+  for (const decision of nonAcceptInviteDecisions) {
+    t.test(`${decision}`, (t) => {
+      t.plan(1)
+
+      const r1 = new MapeoRPC()
+      const r2 = new MapeoRPC()
+
+      const capabilities = {
+        // This should not be called at any point in this test
+        async assignRole() {
+          t.fail(
+            'Attempted to assign role despite decision being non-acceptance'
+          )
+        },
+      }
+
+      const memberApi = new MemberApi({
+        capabilities,
+        encryptionKeys: { auth: randomBytes(32) },
+        getProjectInfo: async () => {},
+        projectKey: KeyManager.generateProjectKeypair().publicKey,
+        rpc: r1,
+      })
+
+      r1.on('peers', async (peers) => {
+        const response = await memberApi.invite(peers[0].id, {
+          roleId: randomBytes(8).toString('hex'),
+        })
+
+        t.is(response, decision)
+      })
+
+      r2.on('invite', (peerId, invite) => {
+        r2.inviteResponse(peerId, {
+          projectKey: invite.projectKey,
+          decision,
+        })
+      })
+
+      replicate(r1, r2)
+    })
+  }
 })

--- a/tests/member-api.js
+++ b/tests/member-api.js
@@ -26,7 +26,7 @@ test('Invite sends expected project-related details', async (t) => {
 
   r1.on('peers', async (peers) => {
     const response = await memberApi.invite(peers[0].id, {
-      role: 'member',
+      roleId: randomBytes(8).toString('hex'),
     })
 
     t.is(response, InviteResponse_Decision.ACCEPT)

--- a/tests/rpc.js
+++ b/tests/rpc.js
@@ -1,6 +1,5 @@
 // @ts-check
 import test from 'brittle'
-import NoiseSecretStream from '@hyperswarm/secret-stream'
 import {
   MapeoRPC,
   PeerDisconnectedError,
@@ -10,6 +9,7 @@ import {
 import FakeTimers from '@sinonjs/fake-timers'
 import { once } from 'events'
 import { Duplex } from 'streamx'
+import { replicate } from './helpers/rpc.js'
 
 test('Send invite and accept', async (t) => {
   t.plan(3)
@@ -365,36 +365,3 @@ test('invalid stream', (t) => {
   const regularStream = new Duplex()
   t.exception(() => r1.connect(regularStream), 'Invalid stream')
 })
-
-function replicate(rpc1, rpc2) {
-  const n1 = new NoiseSecretStream(true, undefined, {
-    // Keep keypairs deterministic for tests, since we use peer.publicKey as an identifier.
-    keyPair: NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(0)),
-  })
-  const n2 = new NoiseSecretStream(false, undefined, {
-    keyPair: NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(1)),
-  })
-  n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
-
-  rpc1.connect(n1)
-  rpc2.connect(n2)
-
-  return async function destroy() {
-    return Promise.all([
-      /** @type {Promise<void>} */
-      (
-        new Promise((res) => {
-          n1.on('close', res)
-          n1.destroy()
-        })
-      ),
-      /** @type {Promise<void>} */
-      (
-        new Promise((res) => {
-          n2.on('close', res)
-          n2.destroy()
-        })
-      ),
-    ])
-  }
-}


### PR DESCRIPTION
Towards #225 

- Introduces the `MemberApi` class
- Implements the `invite` method

TODO:

- [X] What is `role` here and how does it work with MapeoRPC? Our original documentation suggests that it's some human-readable string, but given the recent work on capabilities, wondering if that changes to a role id or something like that. EDIT: answered in https://github.com/digidem/mapeo-core-next/pull/232#discussion_r1310386163
- [ ] Does this class need to keep track of pending invites? I know MapeoRPC does that internally but how about at this level?
- [ ] What happens when you send multiple invites to the same device id?
- [x] integrate capabilities to write the capability when invite accepted #231 