### PR TITLE
expose member namespace in MapeoProject

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -17,6 +17,7 @@ import {
   projectKeyToPublicId,
 } from './utils.js'
 import { RandomAccessFilePool } from './core-manager/random-access-file-pool.js'
+import { MapeoRPC } from './rpc/index.js'
 
 /** @typedef {import("@mapeo/schema").ProjectValue} ProjectValue */
 /** @typedef {import('./types.js').ProjectId} ProjectId */
@@ -39,6 +40,7 @@ export class MapeoManager {
   /** @type {import('./types.js').CoreStorage} */
   #coreStorage
   #dbFolder
+  #rpc
 
   /**
    * @param {Object} opts
@@ -56,6 +58,7 @@ export class MapeoManager {
     this.#db = drizzle(sqlite)
     migrate(this.#db, { migrationsFolder: './drizzle/client' })
 
+    this.#rpc = new MapeoRPC()
     this.#keyManager = new KeyManager(rootKey)
     this.#projectSettingsIndexWriter = new IndexWriter({
       tables: [projectTable],
@@ -173,6 +176,7 @@ export class MapeoManager {
       projectSecretKey: projectKeypair.secretKey,
       sharedDb: this.#db,
       sharedIndexWriter: this.#projectSettingsIndexWriter,
+      rpc: this.#rpc,
     })
 
     // 5. Write project name and any other relevant metadata to project instance
@@ -224,6 +228,7 @@ export class MapeoManager {
       keyManager: this.#keyManager,
       sharedDb: this.#db,
       sharedIndexWriter: this.#projectSettingsIndexWriter,
+      rpc: this.#rpc,
     })
 
     // 3. Keep track of project instance as we know it's a properly existing project

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -209,11 +209,13 @@ export class MapeoProject {
       // @ts-expect-error
       encryptionKeys,
       projectKey,
-      getProjectInfo: async () => {
-        const settings = await this.$getProjectSettings()
-        return { name: settings.name }
-      },
       rpc,
+      queries: {
+        getProjectInfo: async () => {
+          const settings = await this.$getProjectSettings()
+          return { name: settings.name }
+        },
+      },
     })
 
     ///////// 4. Write core ownership record

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -28,6 +28,7 @@ import {
 } from './core-ownership.js'
 import { Capabilities } from './capabilities.js'
 import { projectKeyToId, valueOf } from './utils.js'
+import { MemberApi } from './member-api.js'
 
 /** @typedef {Omit<import('@mapeo/schema').ProjectValue, 'schemaName'>} EditableProjectSettings */
 
@@ -46,6 +47,7 @@ export class MapeoProject {
   #coreOwnership
   #capabilities
   #ownershipWriteDone
+  #memberApi
 
   /**
    * @param {Object} opts
@@ -57,6 +59,7 @@ export class MapeoProject {
    * @param {import('drizzle-orm/better-sqlite3').BetterSQLite3Database} opts.sharedDb
    * @param {IndexWriter} opts.sharedIndexWriter
    * @param {import('./types.js').CoreStorage} opts.coreStorage Folder to store all hypercore data
+   * @param {import('./rpc/index.js').MapeoRPC} opts.rpc
    *
    */
   constructor({
@@ -68,6 +71,7 @@ export class MapeoProject {
     projectKey,
     projectSecretKey,
     encryptionKeys,
+    rpc,
   }) {
     this.#projectId = projectKeyToId(projectKey)
 
@@ -200,6 +204,18 @@ export class MapeoProject {
       deviceKey: keyManager.getIdentityKeypair().publicKey,
     })
 
+    this.#memberApi = new MemberApi({
+      capabilities: this.#capabilities,
+      // @ts-expect-error
+      encryptionKeys,
+      projectKey,
+      getProjectInfo: async () => {
+        const settings = await this.$getProjectSettings()
+        return { name: settings.name }
+      },
+      rpc,
+    })
+
     ///////// 4. Write core ownership record
 
     const deferred = pDefer()
@@ -285,6 +301,10 @@ export class MapeoProject {
   }
   get field() {
     return this.#dataTypes.field
+  }
+
+  get $member() {
+    return this.#memberApi
   }
 
   /**

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -4,29 +4,24 @@ import { InviteResponse_Decision } from './generated/rpc.js'
 export class MemberApi extends TypedEmitter {
   #capabilities
   #encryptionKeys
-  #getProjectInfo
   #projectKey
   #rpc
+  #queries
 
   /**
    * @param {Object} opts
    * @param {import('./capabilities.js').Capabilities} opts.capabilities
    * @param {import('./generated/keys.js').EncryptionKeys} opts.encryptionKeys
-   * @param {() => Promise<import('./generated/rpc.js').Invite_ProjectInfo>} opts.getProjectInfo
    * @param {Buffer} opts.projectKey
    * @param {import('./rpc/index.js').MapeoRPC} opts.rpc
+   * @param {Object} opts.queries
+   * @param {() => Promise<import('./generated/rpc.js').Invite_ProjectInfo>} opts.queries.getProjectInfo
    */
-  constructor({
-    capabilities,
-    encryptionKeys,
-    getProjectInfo,
-    projectKey,
-    rpc,
-  }) {
+  constructor({ capabilities, encryptionKeys, projectKey, rpc, queries }) {
     super()
     this.#capabilities = capabilities
     this.#encryptionKeys = encryptionKeys
-    this.#getProjectInfo = getProjectInfo
+    this.#queries = queries
     this.#projectKey = projectKey
     this.#rpc = rpc
   }
@@ -41,7 +36,7 @@ export class MemberApi extends TypedEmitter {
    * @returns {Promise<import('./generated/rpc.js').InviteResponse_Decision>}
    */
   async invite(deviceId, { roleId, timeout }) {
-    const projectInfo = await this.#getProjectInfo()
+    const projectInfo = await this.#queries.getProjectInfo()
 
     const response = await this.#rpc.invite(deviceId, {
       projectKey: this.#projectKey,

--- a/test-types/data-types.ts
+++ b/test-types/data-types.ts
@@ -14,6 +14,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3'
 import RAM from 'random-access-memory'
 import { IndexWriter } from '../dist/index-writer/index.js'
 import { projectTable } from '../dist/schema/client.js'
+import { MapeoRPC } from '../dist/rpc/index.js'
 import { Expect, type Equal } from './utils.js'
 
 type Forks = { forks: string[] }
@@ -35,6 +36,7 @@ const mapeoProject = new MapeoProject({
     tables: [projectTable],
     sqlite,
   }),
+  rpc: new MapeoRPC(),
 })
 
 ///// Observations

--- a/tests/member-api.js
+++ b/tests/member-api.js
@@ -20,9 +20,9 @@ test('invite() sends expected project-related details', async (t) => {
   const memberApi = new MemberApi({
     capabilities: { async assignRole() {} },
     encryptionKeys,
-    getProjectInfo: async () => projectInfo,
     projectKey,
     rpc: r1,
+    queries: { getProjectInfo: async () => projectInfo },
   })
 
   r1.on('peers', async (peers) => {
@@ -68,9 +68,9 @@ test('invite() assigns role to invited device after invite accepted', async (t) 
   const memberApi = new MemberApi({
     capabilities,
     encryptionKeys: { auth: randomBytes(32) },
-    getProjectInfo: async () => {},
     projectKey: KeyManager.generateProjectKeypair().publicKey,
     rpc: r1,
+    queries: { getProjectInfo: async () => {} },
   })
 
   r1.on('peers', async (peers) => {
@@ -117,9 +117,9 @@ test('invite() does not assign role to invited device if invite is not accepted'
       const memberApi = new MemberApi({
         capabilities,
         encryptionKeys: { auth: randomBytes(32) },
-        getProjectInfo: async () => {},
         projectKey: KeyManager.generateProjectKeypair().publicKey,
         rpc: r1,
+        queries: { getProjectInfo: async () => {} },
       })
 
       r1.on('peers', async (peers) => {


### PR DESCRIPTION
Opening because #248 was accidentally closed 😅 

Closes https://github.com/digidem/mapeo-core-next/issues/225

May be easier to write tests for this once the invite namespace is more available

Also updates the constructor param for MemberApi to follow the queries convention used in InviteApi. Can move this bit of work to a separate PR if preferred

