### PR TITLE
feat: share all core keys via extension messages

### DIFF
--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -13,5 +13,5 @@ plugins:
       - exportCommonSymbols=false
       - outputJsonMethods=false
       - useOptionals=none
-      - outputPartialMethods=false
+      - outputPartialMethods=true
       - stringEnums=true

--- a/proto/extensions.proto
+++ b/proto/extensions.proto
@@ -1,6 +1,11 @@
 syntax = "proto3";
 
 message ProjectExtension {
-  repeated bytes authCoreKeys = 1;
-  repeated bytes wantCoreKeys = 2;
+  repeated bytes wantCoreKeys = 1;
+
+  repeated bytes authCoreKeys = 2;
+  repeated bytes configCoreKeys = 3;
+  repeated bytes dataCoreKeys = 4;
+  repeated bytes blobIndexCoreKeys = 5;
+  repeated bytes blobCoreKeys = 6;
 }

--- a/src/generated/extensions.d.ts
+++ b/src/generated/extensions.d.ts
@@ -1,10 +1,44 @@
 /// <reference types="node" />
 import _m0 from "protobufjs/minimal.js";
 export interface ProjectExtension {
-    authCoreKeys: Buffer[];
     wantCoreKeys: Buffer[];
+    authCoreKeys: Buffer[];
+    configCoreKeys: Buffer[];
+    dataCoreKeys: Buffer[];
+    blobIndexCoreKeys: Buffer[];
+    blobCoreKeys: Buffer[];
 }
 export declare const ProjectExtension: {
     encode(message: ProjectExtension, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): ProjectExtension;
+    create<I extends {
+        wantCoreKeys?: Buffer[];
+        authCoreKeys?: Buffer[];
+        configCoreKeys?: Buffer[];
+        dataCoreKeys?: Buffer[];
+        blobIndexCoreKeys?: Buffer[];
+        blobCoreKeys?: Buffer[];
+    } & {
+        wantCoreKeys?: Buffer[] & Buffer[] & { [K in Exclude<keyof I["wantCoreKeys"], keyof Buffer[]>]: never; };
+        authCoreKeys?: Buffer[] & Buffer[] & { [K_1 in Exclude<keyof I["authCoreKeys"], keyof Buffer[]>]: never; };
+        configCoreKeys?: Buffer[] & Buffer[] & { [K_2 in Exclude<keyof I["configCoreKeys"], keyof Buffer[]>]: never; };
+        dataCoreKeys?: Buffer[] & Buffer[] & { [K_3 in Exclude<keyof I["dataCoreKeys"], keyof Buffer[]>]: never; };
+        blobIndexCoreKeys?: Buffer[] & Buffer[] & { [K_4 in Exclude<keyof I["blobIndexCoreKeys"], keyof Buffer[]>]: never; };
+        blobCoreKeys?: Buffer[] & Buffer[] & { [K_5 in Exclude<keyof I["blobCoreKeys"], keyof Buffer[]>]: never; };
+    } & { [K_6 in Exclude<keyof I, keyof ProjectExtension>]: never; }>(base?: I): ProjectExtension;
+    fromPartial<I_1 extends {
+        wantCoreKeys?: Buffer[];
+        authCoreKeys?: Buffer[];
+        configCoreKeys?: Buffer[];
+        dataCoreKeys?: Buffer[];
+        blobIndexCoreKeys?: Buffer[];
+        blobCoreKeys?: Buffer[];
+    } & {
+        wantCoreKeys?: Buffer[] & Buffer[] & { [K_7 in Exclude<keyof I_1["wantCoreKeys"], keyof Buffer[]>]: never; };
+        authCoreKeys?: Buffer[] & Buffer[] & { [K_8 in Exclude<keyof I_1["authCoreKeys"], keyof Buffer[]>]: never; };
+        configCoreKeys?: Buffer[] & Buffer[] & { [K_9 in Exclude<keyof I_1["configCoreKeys"], keyof Buffer[]>]: never; };
+        dataCoreKeys?: Buffer[] & Buffer[] & { [K_10 in Exclude<keyof I_1["dataCoreKeys"], keyof Buffer[]>]: never; };
+        blobIndexCoreKeys?: Buffer[] & Buffer[] & { [K_11 in Exclude<keyof I_1["blobIndexCoreKeys"], keyof Buffer[]>]: never; };
+        blobCoreKeys?: Buffer[] & Buffer[] & { [K_12 in Exclude<keyof I_1["blobCoreKeys"], keyof Buffer[]>]: never; };
+    } & { [K_13 in Exclude<keyof I_1, keyof ProjectExtension>]: never; }>(object: I_1): ProjectExtension;
 };

--- a/src/generated/extensions.js
+++ b/src/generated/extensions.js
@@ -1,18 +1,41 @@
 /* eslint-disable */
 import _m0 from "protobufjs/minimal.js";
 function createBaseProjectExtension() {
-    return { authCoreKeys: [], wantCoreKeys: [] };
+    return {
+        wantCoreKeys: [],
+        authCoreKeys: [],
+        configCoreKeys: [],
+        dataCoreKeys: [],
+        blobIndexCoreKeys: [],
+        blobCoreKeys: [],
+    };
 }
 export var ProjectExtension = {
     encode: function (message, writer) {
         if (writer === void 0) { writer = _m0.Writer.create(); }
-        for (var _i = 0, _a = message.authCoreKeys; _i < _a.length; _i++) {
+        for (var _i = 0, _a = message.wantCoreKeys; _i < _a.length; _i++) {
             var v = _a[_i];
             writer.uint32(10).bytes(v);
         }
-        for (var _b = 0, _c = message.wantCoreKeys; _b < _c.length; _b++) {
+        for (var _b = 0, _c = message.authCoreKeys; _b < _c.length; _b++) {
             var v = _c[_b];
             writer.uint32(18).bytes(v);
+        }
+        for (var _d = 0, _e = message.configCoreKeys; _d < _e.length; _d++) {
+            var v = _e[_d];
+            writer.uint32(26).bytes(v);
+        }
+        for (var _f = 0, _g = message.dataCoreKeys; _f < _g.length; _f++) {
+            var v = _g[_f];
+            writer.uint32(34).bytes(v);
+        }
+        for (var _h = 0, _j = message.blobIndexCoreKeys; _h < _j.length; _h++) {
+            var v = _j[_h];
+            writer.uint32(42).bytes(v);
+        }
+        for (var _k = 0, _l = message.blobCoreKeys; _k < _l.length; _k++) {
+            var v = _l[_k];
+            writer.uint32(50).bytes(v);
         }
         return writer;
     },
@@ -27,13 +50,37 @@ export var ProjectExtension = {
                     if (tag !== 10) {
                         break;
                     }
-                    message.authCoreKeys.push(reader.bytes());
+                    message.wantCoreKeys.push(reader.bytes());
                     continue;
                 case 2:
                     if (tag !== 18) {
                         break;
                     }
-                    message.wantCoreKeys.push(reader.bytes());
+                    message.authCoreKeys.push(reader.bytes());
+                    continue;
+                case 3:
+                    if (tag !== 26) {
+                        break;
+                    }
+                    message.configCoreKeys.push(reader.bytes());
+                    continue;
+                case 4:
+                    if (tag !== 34) {
+                        break;
+                    }
+                    message.dataCoreKeys.push(reader.bytes());
+                    continue;
+                case 5:
+                    if (tag !== 42) {
+                        break;
+                    }
+                    message.blobIndexCoreKeys.push(reader.bytes());
+                    continue;
+                case 6:
+                    if (tag !== 50) {
+                        break;
+                    }
+                    message.blobCoreKeys.push(reader.bytes());
                     continue;
             }
             if ((tag & 7) === 4 || tag === 0) {
@@ -41,6 +88,20 @@ export var ProjectExtension = {
             }
             reader.skipType(tag & 7);
         }
+        return message;
+    },
+    create: function (base) {
+        return ProjectExtension.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a, _b, _c, _d, _e, _f;
+        var message = createBaseProjectExtension();
+        message.wantCoreKeys = ((_a = object.wantCoreKeys) === null || _a === void 0 ? void 0 : _a.map(function (e) { return e; })) || [];
+        message.authCoreKeys = ((_b = object.authCoreKeys) === null || _b === void 0 ? void 0 : _b.map(function (e) { return e; })) || [];
+        message.configCoreKeys = ((_c = object.configCoreKeys) === null || _c === void 0 ? void 0 : _c.map(function (e) { return e; })) || [];
+        message.dataCoreKeys = ((_d = object.dataCoreKeys) === null || _d === void 0 ? void 0 : _d.map(function (e) { return e; })) || [];
+        message.blobIndexCoreKeys = ((_e = object.blobIndexCoreKeys) === null || _e === void 0 ? void 0 : _e.map(function (e) { return e; })) || [];
+        message.blobCoreKeys = ((_f = object.blobCoreKeys) === null || _f === void 0 ? void 0 : _f.map(function (e) { return e; })) || [];
         return message;
     },
 };

--- a/src/generated/extensions.ts
+++ b/src/generated/extensions.ts
@@ -2,21 +2,44 @@
 import _m0 from "protobufjs/minimal.js";
 
 export interface ProjectExtension {
-  authCoreKeys: Buffer[];
   wantCoreKeys: Buffer[];
+  authCoreKeys: Buffer[];
+  configCoreKeys: Buffer[];
+  dataCoreKeys: Buffer[];
+  blobIndexCoreKeys: Buffer[];
+  blobCoreKeys: Buffer[];
 }
 
 function createBaseProjectExtension(): ProjectExtension {
-  return { authCoreKeys: [], wantCoreKeys: [] };
+  return {
+    wantCoreKeys: [],
+    authCoreKeys: [],
+    configCoreKeys: [],
+    dataCoreKeys: [],
+    blobIndexCoreKeys: [],
+    blobCoreKeys: [],
+  };
 }
 
 export const ProjectExtension = {
   encode(message: ProjectExtension, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.authCoreKeys) {
+    for (const v of message.wantCoreKeys) {
       writer.uint32(10).bytes(v!);
     }
-    for (const v of message.wantCoreKeys) {
+    for (const v of message.authCoreKeys) {
       writer.uint32(18).bytes(v!);
+    }
+    for (const v of message.configCoreKeys) {
+      writer.uint32(26).bytes(v!);
+    }
+    for (const v of message.dataCoreKeys) {
+      writer.uint32(34).bytes(v!);
+    }
+    for (const v of message.blobIndexCoreKeys) {
+      writer.uint32(42).bytes(v!);
+    }
+    for (const v of message.blobCoreKeys) {
+      writer.uint32(50).bytes(v!);
     }
     return writer;
   },
@@ -33,14 +56,42 @@ export const ProjectExtension = {
             break;
           }
 
-          message.authCoreKeys.push(reader.bytes() as Buffer);
+          message.wantCoreKeys.push(reader.bytes() as Buffer);
           continue;
         case 2:
           if (tag !== 18) {
             break;
           }
 
-          message.wantCoreKeys.push(reader.bytes() as Buffer);
+          message.authCoreKeys.push(reader.bytes() as Buffer);
+          continue;
+        case 3:
+          if (tag !== 26) {
+            break;
+          }
+
+          message.configCoreKeys.push(reader.bytes() as Buffer);
+          continue;
+        case 4:
+          if (tag !== 34) {
+            break;
+          }
+
+          message.dataCoreKeys.push(reader.bytes() as Buffer);
+          continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.blobIndexCoreKeys.push(reader.bytes() as Buffer);
+          continue;
+        case 6:
+          if (tag !== 50) {
+            break;
+          }
+
+          message.blobCoreKeys.push(reader.bytes() as Buffer);
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -50,4 +101,29 @@ export const ProjectExtension = {
     }
     return message;
   },
+
+  create<I extends Exact<DeepPartial<ProjectExtension>, I>>(base?: I): ProjectExtension {
+    return ProjectExtension.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ProjectExtension>, I>>(object: I): ProjectExtension {
+    const message = createBaseProjectExtension();
+    message.wantCoreKeys = object.wantCoreKeys?.map((e) => e) || [];
+    message.authCoreKeys = object.authCoreKeys?.map((e) => e) || [];
+    message.configCoreKeys = object.configCoreKeys?.map((e) => e) || [];
+    message.dataCoreKeys = object.dataCoreKeys?.map((e) => e) || [];
+    message.blobIndexCoreKeys = object.blobIndexCoreKeys?.map((e) => e) || [];
+    message.blobCoreKeys = object.blobCoreKeys?.map((e) => e) || [];
+    return message;
+  },
 };
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };

--- a/src/generated/keys.d.ts
+++ b/src/generated/keys.d.ts
@@ -15,8 +15,88 @@ export interface ProjectKeys {
 export declare const EncryptionKeys: {
     encode(message: EncryptionKeys, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): EncryptionKeys;
+    create<I extends {
+        auth?: Buffer;
+        data?: Buffer | undefined;
+        config?: Buffer | undefined;
+        blobIndex?: Buffer | undefined;
+        blob?: Buffer | undefined;
+    } & {
+        auth?: Buffer;
+        data?: Buffer | undefined;
+        config?: Buffer | undefined;
+        blobIndex?: Buffer | undefined;
+        blob?: Buffer | undefined;
+    } & { [K in Exclude<keyof I, keyof EncryptionKeys>]: never; }>(base?: I): EncryptionKeys;
+    fromPartial<I_1 extends {
+        auth?: Buffer;
+        data?: Buffer | undefined;
+        config?: Buffer | undefined;
+        blobIndex?: Buffer | undefined;
+        blob?: Buffer | undefined;
+    } & {
+        auth?: Buffer;
+        data?: Buffer | undefined;
+        config?: Buffer | undefined;
+        blobIndex?: Buffer | undefined;
+        blob?: Buffer | undefined;
+    } & { [K_1 in Exclude<keyof I_1, keyof EncryptionKeys>]: never; }>(object: I_1): EncryptionKeys;
 };
 export declare const ProjectKeys: {
     encode(message: ProjectKeys, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): ProjectKeys;
+    create<I extends {
+        projectKey?: Buffer;
+        projectSecretKey?: Buffer | undefined;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer | undefined;
+            config?: Buffer | undefined;
+            blobIndex?: Buffer | undefined;
+            blob?: Buffer | undefined;
+        };
+    } & {
+        projectKey?: Buffer;
+        projectSecretKey?: Buffer | undefined;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer | undefined;
+            config?: Buffer | undefined;
+            blobIndex?: Buffer | undefined;
+            blob?: Buffer | undefined;
+        } & {
+            auth?: Buffer;
+            data?: Buffer | undefined;
+            config?: Buffer | undefined;
+            blobIndex?: Buffer | undefined;
+            blob?: Buffer | undefined;
+        } & { [K in Exclude<keyof I["encryptionKeys"], keyof EncryptionKeys>]: never; };
+    } & { [K_1 in Exclude<keyof I, keyof ProjectKeys>]: never; }>(base?: I): ProjectKeys;
+    fromPartial<I_1 extends {
+        projectKey?: Buffer;
+        projectSecretKey?: Buffer | undefined;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer | undefined;
+            config?: Buffer | undefined;
+            blobIndex?: Buffer | undefined;
+            blob?: Buffer | undefined;
+        };
+    } & {
+        projectKey?: Buffer;
+        projectSecretKey?: Buffer | undefined;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer | undefined;
+            config?: Buffer | undefined;
+            blobIndex?: Buffer | undefined;
+            blob?: Buffer | undefined;
+        } & {
+            auth?: Buffer;
+            data?: Buffer | undefined;
+            config?: Buffer | undefined;
+            blobIndex?: Buffer | undefined;
+            blob?: Buffer | undefined;
+        } & { [K_2 in Exclude<keyof I_1["encryptionKeys"], keyof EncryptionKeys>]: never; };
+    } & { [K_3 in Exclude<keyof I_1, keyof ProjectKeys>]: never; }>(object: I_1): ProjectKeys;
 };

--- a/src/generated/keys.js
+++ b/src/generated/keys.js
@@ -68,6 +68,19 @@ export var EncryptionKeys = {
         }
         return message;
     },
+    create: function (base) {
+        return EncryptionKeys.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a, _b, _c, _d, _e;
+        var message = createBaseEncryptionKeys();
+        message.auth = (_a = object.auth) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        message.data = (_b = object.data) !== null && _b !== void 0 ? _b : undefined;
+        message.config = (_c = object.config) !== null && _c !== void 0 ? _c : undefined;
+        message.blobIndex = (_d = object.blobIndex) !== null && _d !== void 0 ? _d : undefined;
+        message.blob = (_e = object.blob) !== null && _e !== void 0 ? _e : undefined;
+        return message;
+    },
 };
 function createBaseProjectKeys() {
     return { projectKey: Buffer.alloc(0), encryptionKeys: undefined };
@@ -117,6 +130,19 @@ export var ProjectKeys = {
             }
             reader.skipType(tag & 7);
         }
+        return message;
+    },
+    create: function (base) {
+        return ProjectKeys.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a, _b;
+        var message = createBaseProjectKeys();
+        message.projectKey = (_a = object.projectKey) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        message.projectSecretKey = (_b = object.projectSecretKey) !== null && _b !== void 0 ? _b : undefined;
+        message.encryptionKeys = (object.encryptionKeys !== undefined && object.encryptionKeys !== null)
+            ? EncryptionKeys.fromPartial(object.encryptionKeys)
+            : undefined;
         return message;
     },
 };

--- a/src/generated/keys.ts
+++ b/src/generated/keys.ts
@@ -89,6 +89,19 @@ export const EncryptionKeys = {
     }
     return message;
   },
+
+  create<I extends Exact<DeepPartial<EncryptionKeys>, I>>(base?: I): EncryptionKeys {
+    return EncryptionKeys.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<EncryptionKeys>, I>>(object: I): EncryptionKeys {
+    const message = createBaseEncryptionKeys();
+    message.auth = object.auth ?? Buffer.alloc(0);
+    message.data = object.data ?? undefined;
+    message.config = object.config ?? undefined;
+    message.blobIndex = object.blobIndex ?? undefined;
+    message.blob = object.blob ?? undefined;
+    return message;
+  },
 };
 
 function createBaseProjectKeys(): ProjectKeys {
@@ -145,4 +158,28 @@ export const ProjectKeys = {
     }
     return message;
   },
+
+  create<I extends Exact<DeepPartial<ProjectKeys>, I>>(base?: I): ProjectKeys {
+    return ProjectKeys.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ProjectKeys>, I>>(object: I): ProjectKeys {
+    const message = createBaseProjectKeys();
+    message.projectKey = object.projectKey ?? Buffer.alloc(0);
+    message.projectSecretKey = object.projectSecretKey ?? undefined;
+    message.encryptionKeys = (object.encryptionKeys !== undefined && object.encryptionKeys !== null)
+      ? EncryptionKeys.fromPartial(object.encryptionKeys)
+      : undefined;
+    return message;
+  },
 };
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -25,12 +25,102 @@ export declare function inviteResponse_DecisionToNumber(object: InviteResponse_D
 export declare const Invite: {
     encode(message: Invite, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): Invite;
+    create<I extends {
+        projectKey?: Buffer;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer;
+            config?: Buffer;
+            blobIndex?: Buffer;
+            blob?: Buffer;
+        };
+        projectInfo?: {
+            name?: string | undefined;
+        };
+    } & {
+        projectKey?: Buffer;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer;
+            config?: Buffer;
+            blobIndex?: Buffer;
+            blob?: Buffer;
+        } & {
+            auth?: Buffer;
+            data?: Buffer;
+            config?: Buffer;
+            blobIndex?: Buffer;
+            blob?: Buffer;
+        } & { [K in Exclude<keyof I["encryptionKeys"], keyof EncryptionKeys>]: never; };
+        projectInfo?: {
+            name?: string | undefined;
+        } & {
+            name?: string | undefined;
+        } & { [K_1 in Exclude<keyof I["projectInfo"], "name">]: never; };
+    } & { [K_2 in Exclude<keyof I, keyof Invite>]: never; }>(base?: I): Invite;
+    fromPartial<I_1 extends {
+        projectKey?: Buffer;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer;
+            config?: Buffer;
+            blobIndex?: Buffer;
+            blob?: Buffer;
+        };
+        projectInfo?: {
+            name?: string | undefined;
+        };
+    } & {
+        projectKey?: Buffer;
+        encryptionKeys?: {
+            auth?: Buffer;
+            data?: Buffer;
+            config?: Buffer;
+            blobIndex?: Buffer;
+            blob?: Buffer;
+        } & {
+            auth?: Buffer;
+            data?: Buffer;
+            config?: Buffer;
+            blobIndex?: Buffer;
+            blob?: Buffer;
+        } & { [K_3 in Exclude<keyof I_1["encryptionKeys"], keyof EncryptionKeys>]: never; };
+        projectInfo?: {
+            name?: string | undefined;
+        } & {
+            name?: string | undefined;
+        } & { [K_4 in Exclude<keyof I_1["projectInfo"], "name">]: never; };
+    } & { [K_5 in Exclude<keyof I_1, keyof Invite>]: never; }>(object: I_1): Invite;
 };
 export declare const Invite_ProjectInfo: {
     encode(message: Invite_ProjectInfo, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): Invite_ProjectInfo;
+    create<I extends {
+        name?: string | undefined;
+    } & {
+        name?: string | undefined;
+    } & { [K in Exclude<keyof I, "name">]: never; }>(base?: I): Invite_ProjectInfo;
+    fromPartial<I_1 extends {
+        name?: string | undefined;
+    } & {
+        name?: string | undefined;
+    } & { [K_1 in Exclude<keyof I_1, "name">]: never; }>(object: I_1): Invite_ProjectInfo;
 };
 export declare const InviteResponse: {
     encode(message: InviteResponse, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): InviteResponse;
+    create<I extends {
+        projectKey?: Buffer;
+        decision?: InviteResponse_Decision;
+    } & {
+        projectKey?: Buffer;
+        decision?: InviteResponse_Decision;
+    } & { [K in Exclude<keyof I, keyof InviteResponse>]: never; }>(base?: I): InviteResponse;
+    fromPartial<I_1 extends {
+        projectKey?: Buffer;
+        decision?: InviteResponse_Decision;
+    } & {
+        projectKey?: Buffer;
+        decision?: InviteResponse_Decision;
+    } & { [K_1 in Exclude<keyof I_1, keyof InviteResponse>]: never; }>(object: I_1): InviteResponse;
 };

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -88,6 +88,21 @@ export var Invite = {
         }
         return message;
     },
+    create: function (base) {
+        return Invite.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a;
+        var message = createBaseInvite();
+        message.projectKey = (_a = object.projectKey) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        message.encryptionKeys = (object.encryptionKeys !== undefined && object.encryptionKeys !== null)
+            ? EncryptionKeys.fromPartial(object.encryptionKeys)
+            : undefined;
+        message.projectInfo = (object.projectInfo !== undefined && object.projectInfo !== null)
+            ? Invite_ProjectInfo.fromPartial(object.projectInfo)
+            : undefined;
+        return message;
+    },
 };
 function createBaseInvite_ProjectInfo() {
     return {};
@@ -119,6 +134,15 @@ export var Invite_ProjectInfo = {
             }
             reader.skipType(tag & 7);
         }
+        return message;
+    },
+    create: function (base) {
+        return Invite_ProjectInfo.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a;
+        var message = createBaseInvite_ProjectInfo();
+        message.name = (_a = object.name) !== null && _a !== void 0 ? _a : undefined;
         return message;
     },
 };
@@ -161,6 +185,16 @@ export var InviteResponse = {
             }
             reader.skipType(tag & 7);
         }
+        return message;
+    },
+    create: function (base) {
+        return InviteResponse.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a, _b;
+        var message = createBaseInviteResponse();
+        message.projectKey = (_a = object.projectKey) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        message.decision = (_b = object.decision) !== null && _b !== void 0 ? _b : InviteResponse_Decision.REJECT;
         return message;
     },
 };

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -111,6 +111,21 @@ export const Invite = {
     }
     return message;
   },
+
+  create<I extends Exact<DeepPartial<Invite>, I>>(base?: I): Invite {
+    return Invite.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Invite>, I>>(object: I): Invite {
+    const message = createBaseInvite();
+    message.projectKey = object.projectKey ?? Buffer.alloc(0);
+    message.encryptionKeys = (object.encryptionKeys !== undefined && object.encryptionKeys !== null)
+      ? EncryptionKeys.fromPartial(object.encryptionKeys)
+      : undefined;
+    message.projectInfo = (object.projectInfo !== undefined && object.projectInfo !== null)
+      ? Invite_ProjectInfo.fromPartial(object.projectInfo)
+      : undefined;
+    return message;
+  },
 };
 
 function createBaseInvite_ProjectInfo(): Invite_ProjectInfo {
@@ -145,6 +160,15 @@ export const Invite_ProjectInfo = {
       }
       reader.skipType(tag & 7);
     }
+    return message;
+  },
+
+  create<I extends Exact<DeepPartial<Invite_ProjectInfo>, I>>(base?: I): Invite_ProjectInfo {
+    return Invite_ProjectInfo.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Invite_ProjectInfo>, I>>(object: I): Invite_ProjectInfo {
+    const message = createBaseInvite_ProjectInfo();
+    message.name = object.name ?? undefined;
     return message;
   },
 };
@@ -193,4 +217,25 @@ export const InviteResponse = {
     }
     return message;
   },
+
+  create<I extends Exact<DeepPartial<InviteResponse>, I>>(base?: I): InviteResponse {
+    return InviteResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<InviteResponse>, I>>(object: I): InviteResponse {
+    const message = createBaseInviteResponse();
+    message.projectKey = object.projectKey ?? Buffer.alloc(0);
+    message.decision = object.decision ?? InviteResponse_Decision.REJECT;
+    return message;
+  },
 };
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };

--- a/tests/blob-server.js
+++ b/tests/blob-server.js
@@ -4,7 +4,7 @@ import { readdirSync } from 'fs'
 import { readFile } from 'fs/promises'
 import path from 'path'
 import { BlobStore } from '../src/blob-store/index.js'
-import { createCoreManager } from './helpers/core-manager.js'
+import { createCoreManager, waitForCores } from './helpers/core-manager.js'
 import { createBlobServer } from '../src/blob-server/index.js'
 import BlobServerPlugin from '../src/blob-server/fastify-plugin.js'
 import fastify from 'fastify'
@@ -201,6 +201,7 @@ test('GET photo returns 404 when trying to get non-replicated blob', async (t) =
 
   const { destroy } = replicateBlobs(cm1, cm2)
 
+  await waitForCores(cm2, [Buffer.from(blobId.driveId, 'hex')])
   /** @type {any}*/
   const replicatedCore = cm2.getCoreByKey(Buffer.from(blobId.driveId, 'hex'))
   await replicatedCore.update({ wait: true })

--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -13,6 +13,7 @@ import { exec } from 'child_process'
 import { RandomAccessFilePool } from '../src/core-manager/random-access-file-pool.js'
 import RandomAccessFile from 'random-access-file'
 import path from 'path'
+import { setTimeout as delay } from 'node:timers/promises'
 
 async function createCore(...args) {
   const core = new Hypercore(RAM, ...args)
@@ -36,6 +37,58 @@ test('shares auth cores', async function (t) {
   const cm2Keys = getKeys(cm2, 'auth').sort(Buffer.compare)
 
   t.alike(cm1Keys, cm2Keys, 'Share same auth cores')
+})
+
+test('shares other cores', async function (t) {
+  const projectKey = randomBytes(32)
+  const cm1 = createCoreManager({ projectKey })
+  const cm2 = createCoreManager({ projectKey })
+
+  const {
+    rsm: [rsm1, rsm2],
+  } = replicate(cm1, cm2)
+
+  for (const namespace of ['config', 'data', 'blob', 'blobIndex']) {
+    rsm1.enableNamespace(namespace)
+    rsm2.enableNamespace(namespace)
+    await Promise.all([
+      waitForCores(cm1, getKeys(cm2, namespace)),
+      waitForCores(cm2, getKeys(cm1, namespace)),
+    ])
+    const cm1Keys = getKeys(cm1, namespace).sort(Buffer.compare)
+    const cm2Keys = getKeys(cm2, namespace).sort(Buffer.compare)
+
+    t.alike(cm1Keys, cm2Keys, `Share same ${namespace} cores`)
+  }
+})
+
+// Testing this case because in real-use namespaces are not enabled at the same time
+test('shares cores if namespaces enabled at different times', async function (t) {
+  const projectKey = randomBytes(32)
+  const cm1 = createCoreManager({ projectKey })
+  const cm2 = createCoreManager({ projectKey })
+
+  const {
+    rsm: [rsm1, rsm2],
+  } = replicate(cm1, cm2)
+
+  for (const namespace of ['config', 'data', 'blob', 'blobIndex']) {
+    rsm1.enableNamespace(namespace)
+  }
+
+  await delay(1000)
+
+  for (const namespace of ['config', 'data', 'blob', 'blobIndex']) {
+    rsm2.enableNamespace(namespace)
+    await Promise.all([
+      waitForCores(cm1, getKeys(cm2, namespace)),
+      waitForCores(cm2, getKeys(cm1, namespace)),
+    ])
+    const cm1Keys = getKeys(cm1, namespace).sort(Buffer.compare)
+    const cm2Keys = getKeys(cm2, namespace).sort(Buffer.compare)
+
+    t.alike(cm1Keys, cm2Keys, `Share same ${namespace} cores`)
+  }
 })
 
 test('project creator auth core has project key', async function (t) {

--- a/tests/helpers/blob-store.js
+++ b/tests/helpers/blob-store.js
@@ -22,8 +22,6 @@ export function createBlobStore(options = {}) {
  * @param {import('../../src/core-manager/index.js').CoreManager} cm2
  */
 export function replicateBlobs(cm1, cm2) {
-  cm1.addCore(cm2.getWriterCore('blobIndex').key, 'blobIndex')
-  cm2.addCore(cm1.getWriterCore('blobIndex').key, 'blobIndex')
   const {
     rsm: [rsm1, rsm2],
     destroy,


### PR DESCRIPTION
Fixes #251

This adds new fields to the project extension to share keys for other
namespaces and updates tests which manually added cores (manual adding
is no longer needed, but do need to wait for cores to be added)