### PR TITLE
fix: change version IDs to use the discovery keys

### DIFF
--- a/drizzle/client/0000_tidy_micromacro.sql
+++ b/drizzle/client/0000_tidy_micromacro.sql
@@ -3,10 +3,6 @@ CREATE TABLE `localDeviceInfo` (
 	`deviceInfo` text NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE `project_backlink` (
-	`versionId` text PRIMARY KEY NOT NULL
-);
---> statement-breakpoint
 CREATE TABLE `projectKeys` (
 	`projectId` text PRIMARY KEY NOT NULL,
 	`projectPublicId` text NOT NULL,
@@ -14,7 +10,11 @@ CREATE TABLE `projectKeys` (
 	`projectInfo` text DEFAULT '{}' NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE `project` (
+CREATE TABLE `projectSettings_backlink` (
+	`versionId` text PRIMARY KEY NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `projectSettings` (
 	`docId` text PRIMARY KEY NOT NULL,
 	`versionId` text NOT NULL,
 	`schemaName` text NOT NULL,

--- a/drizzle/client/meta/0000_snapshot.json
+++ b/drizzle/client/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "518b4a6e-b310-4f08-a39e-5a046c1e1da9",
+  "id": "1cf10430-19d0-4f27-b369-f31ca4215b15",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "localDeviceInfo": {
@@ -31,22 +31,6 @@
           "isUnique": true
         }
       },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {}
-    },
-    "project_backlink": {
-      "name": "project_backlink",
-      "columns": {
-        "versionId": {
-          "name": "versionId",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {}
@@ -89,8 +73,24 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {}
     },
-    "project": {
-      "name": "project",
+    "projectSettings_backlink": {
+      "name": "projectSettings_backlink",
+      "columns": {
+        "versionId": {
+          "name": "versionId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectSettings": {
+      "name": "projectSettings",
       "columns": {
         "docId": {
           "name": "docId",

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1694082554479,
-      "tag": "0000_charming_klaw",
+      "when": 1694775192450,
+      "tag": "0000_tidy_micromacro",
       "breakpoints": true
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fastify/type-provider-typebox": "^3.3.0",
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "^1.0.0-alpha.8",
-        "@mapeo/schema": "^3.0.0-next.8",
+        "@mapeo/schema": "file:../mapeo-schema/mapeo-schema-3.0.0-next.8.tgz",
         "@mapeo/sqlite-indexer": "^1.0.0-alpha.6",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
@@ -1617,14 +1617,16 @@
     },
     "node_modules/@mapeo/schema": {
       "version": "3.0.0-next.8",
-      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.8.tgz",
-      "integrity": "sha512-GtN04HUasXAaWUcRQ/FlmS6P9eXdnz7zDr0mhb8QO4q6bxdgD7H74VPL48o8sOGc7vpz26widpyCA4HJhcQ+QA==",
+      "resolved": "file:../mapeo-schema/mapeo-schema-3.0.0-next.8.tgz",
+      "integrity": "sha512-w/wMrWIwTrGS+Ti16P9SId+lSD9vJUdPcjYwmonp1qMHHmSXB7NXu0fnxINBbbGjoDt/SKzU/JRA0UJOuUnIDQ==",
+      "license": "MIT",
       "dependencies": {
         "@json-schema-tools/dereferencer": "^1.6.1",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "compact-encoding": "^2.12.0",
         "glob": "^10.3.3",
+        "protobufjs": "^7.2.5",
         "type-fest": "^4.1.0",
         "typedoc": "^0.24.8",
         "typedoc-plugin-markdown": "^3.15.4"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@fastify/type-provider-typebox": "^3.3.0",
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "^1.0.0-alpha.8",
-    "@mapeo/schema": "^3.0.0-next.8",
+    "@mapeo/schema": "file:../mapeo-schema/mapeo-schema-3.0.0-next.8.tgz",
     "@mapeo/sqlite-indexer": "^1.0.0-alpha.6",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -186,6 +186,19 @@ export class CoreManager extends TypedEmitter {
   }
 
   /**
+   * Get a core by its discovery key
+   *
+   * @param {Buffer} discoveryKey
+   * @returns {Core | undefined}
+   */
+  getCoreByDiscoveryKey(discoveryKey) {
+    const coreRecord = this.#coreIndex.getByDiscoveryId(
+      discoveryKey.toString('hex')
+    )
+    return coreRecord && coreRecord.core
+  }
+
+  /**
    * Close all open cores and end any replication streams
    * TODO: gracefully close replication streams
    */

--- a/src/core-ownership.js
+++ b/src/core-ownership.js
@@ -1,4 +1,5 @@
 import { verifySignature, sign } from '@mapeo/crypto'
+import { discoveryKey } from 'hypercore-crypto'
 import { NAMESPACES } from './core-manager/index.js'
 import { parseVersionId } from '@mapeo/schema'
 import { defaultGetWinner } from '@mapeo/sqlite-indexer'
@@ -97,8 +98,10 @@ export class CoreOwnership {
  * @param {import('@mapeo/schema').VersionIdObject} version
  * @returns {import('@mapeo/schema').CoreOwnership}
  */
-export function mapAndValidateCoreOwnership(doc, { coreKey }) {
-  if (doc.authCoreId !== coreKey.toString('hex')) {
+export function mapAndValidateCoreOwnership(doc, { coreDiscoveryKey }) {
+  if (
+    !coreDiscoveryKey.equals(discoveryKey(Buffer.from(doc.authCoreId, 'hex')))
+  ) {
     throw new Error('Invalid coreOwnership record: mismatched authCoreId')
   }
   if (!verifyCoreOwnership(doc)) {

--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -2,6 +2,7 @@ import { TypedEmitter } from 'tiny-typed-emitter'
 import { encode, decode, getVersionId, parseVersionId } from '@mapeo/schema'
 import MultiCoreIndexer from 'multi-core-indexer'
 import pDefer from 'p-defer'
+import { discoveryKey } from 'hypercore-crypto'
 
 /**
  * @typedef {import('multi-core-indexer').IndexEvents} IndexEvents
@@ -25,7 +26,7 @@ import pDefer from 'p-defer'
 
 const NAMESPACE_SCHEMAS = /** @type {const} */ ({
   data: ['observation'],
-  config: ['preset', 'field', 'project', 'deviceInfo'],
+  config: ['preset', 'field', 'projectSettings', 'deviceInfo'],
   auth: ['coreOwnership', 'role'],
 })
 
@@ -105,7 +106,7 @@ export class DataStore extends TypedEmitter {
     for (const entry of entries) {
       if (!entry.key.equals(this.#writerCore.key)) continue
       const versionId = getVersionId({
-        coreKey: entry.key,
+        coreDiscoveryKey: discoveryKey(entry.key),
         index: entry.index,
       })
       const pending = this.#pending.get(versionId)
@@ -137,14 +138,18 @@ export class DataStore extends TypedEmitter {
 
     const { length } = await this.#writerCore.append(block)
     const index = length - 1
-    const versionId = getVersionId({ coreKey: this.#writerCore.key, index })
+    const coreDiscoveryKey = this.#writerCore.discoveryKey
+    if (!coreDiscoveryKey) {
+      throw new Error('Writer core is not ready')
+    }
+    const versionId = getVersionId({ coreDiscoveryKey, index })
     /** @type {import('p-defer').DeferredPromise<void>} */
     const deferred = pDefer()
     this.#pending.set(versionId, deferred)
     await deferred.promise
 
     return /** @type {Extract<MapeoDoc, TDoc>} */ (
-      decode(block, { coreKey: this.#writerCore.key, index })
+      decode(block, { coreDiscoveryKey, index })
     )
   }
 
@@ -154,11 +159,11 @@ export class DataStore extends TypedEmitter {
    * @returns {Promise<MapeoDoc>}
    */
   async read(versionId) {
-    const { coreKey, index } = parseVersionId(versionId)
-    const core = this.#coreManager.getCoreByKey(coreKey)
+    const { coreDiscoveryKey, index } = parseVersionId(versionId)
+    const core = this.#coreManager.getCoreByDiscoveryKey(coreDiscoveryKey)
     if (!core) throw new Error('Invalid versionId')
     const block = await core.get(index, { wait: false })
     if (!block) throw new Error('Not Found')
-    return decode(block, { coreKey: coreKey, index })
+    return decode(block, { coreDiscoveryKey, index })
   }
 }

--- a/src/index-writer/index.js
+++ b/src/index-writer/index.js
@@ -2,6 +2,7 @@ import { decode } from '@mapeo/schema'
 import SqliteIndexer from '@mapeo/sqlite-indexer'
 import { getTableConfig } from 'drizzle-orm/sqlite-core'
 import { getBacklinkTableName } from '../schema/utils.js'
+import { discoveryKey } from 'hypercore-crypto'
 
 /**
  * @typedef {import('../datatype/index.js').MapeoDocTables} MapeoDocTables
@@ -59,7 +60,7 @@ export class IndexWriter {
     const queued = {}
     for (const { block, key, index } of entries) {
       try {
-        const version = { coreKey: key, index }
+        const version = { coreDiscoveryKey: discoveryKey(key), index }
         var doc = this.#mapDoc(decode(block, version), version)
       } catch (e) {
         // Unknown or invalid entry - silently ignore

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -11,7 +11,7 @@ import { MapeoProject } from './mapeo-project.js'
 import {
   localDeviceInfoTable,
   projectKeysTable,
-  projectTable,
+  projectSettingsTable,
 } from './schema/client.js'
 import { ProjectKeys } from './generated/keys.js'
 import {
@@ -23,7 +23,7 @@ import {
 import { RandomAccessFilePool } from './core-manager/random-access-file-pool.js'
 import { MapeoRPC } from './rpc/index.js'
 
-/** @typedef {import("@mapeo/schema").ProjectValue} ProjectValue */
+/** @typedef {import("@mapeo/schema").ProjectSettingsValue} ProjectValue */
 /** @typedef {import('./types.js').ProjectId} ProjectId */
 /** @typedef {import('./types.js').ProjectPublicId} ProjectPublicId */
 
@@ -69,7 +69,7 @@ export class MapeoManager {
       .getIdentityKeypair()
       .publicKey.toString('hex')
     this.#projectSettingsIndexWriter = new IndexWriter({
-      tables: [projectTable],
+      tables: [projectSettingsTable],
       sqlite,
     })
     this.#activeProjects = new Map()
@@ -263,12 +263,12 @@ export class MapeoManager {
 
     const allProjectsResult = this.#db
       .select({
-        projectId: projectTable.docId,
-        createdAt: projectTable.createdAt,
-        updatedAt: projectTable.updatedAt,
-        name: projectTable.name,
+        projectId: projectSettingsTable.docId,
+        createdAt: projectSettingsTable.createdAt,
+        updatedAt: projectSettingsTable.updatedAt,
+        name: projectSettingsTable.name,
       })
-      .from(projectTable)
+      .from(projectSettingsTable)
       .all()
 
     /** @type {Array<Pick<ProjectValue, 'name'> & { projectId: ProjectPublicId, createdAt?: string, updatedAt?: string }>} */

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -14,8 +14,11 @@ const projectInfoColumn =
 /** @type {import('../generated/rpc.js').Invite_ProjectInfo} */
 const PROJECT_INFO_DEFAULT_VALUE = {}
 
-export const projectTable = sqliteTable('project', toColumns(schemas.project))
-export const projectBacklinkTable = backlinkTable(projectTable)
+export const projectSettingsTable = sqliteTable(
+  'projectSettings',
+  toColumns(schemas.projectSettings)
+)
+export const projectSettingsBacklinkTable = backlinkTable(projectSettingsTable)
 export const projectKeysTable = sqliteTable('projectKeys', {
   projectId: text('projectId').notNull().primaryKey(),
   projectPublicId: text('projectPublicId').notNull(),

--- a/test-e2e/core-ownership.js
+++ b/test-e2e/core-ownership.js
@@ -3,6 +3,7 @@ import { KeyManager } from '@mapeo/crypto'
 import { MapeoManager } from '../src/mapeo-manager.js'
 import { kCoreOwnership } from '../src/mapeo-project.js'
 import { parseVersionId } from '@mapeo/schema'
+import { discoveryKey } from 'hypercore-crypto'
 import RAM from 'random-access-memory'
 
 test('CoreOwnership', async (t) => {
@@ -35,8 +36,8 @@ test('CoreOwnership', async (t) => {
     fieldIds: [],
   })
   t.is(
-    await coreOwnership.getCoreId(deviceId, 'config'),
-    parseVersionId(preset.versionId).coreKey.toString('hex')
+    discoveryId(await coreOwnership.getCoreId(deviceId, 'config')),
+    parseVersionId(preset.versionId).coreDiscoveryKey.toString('hex')
   )
 
   const observation = await project.observation.create({
@@ -47,7 +48,12 @@ test('CoreOwnership', async (t) => {
     metadata: {},
   })
   t.is(
-    await coreOwnership.getCoreId(deviceId, 'data'),
-    parseVersionId(observation.versionId).coreKey.toString('hex')
+    discoveryId(await coreOwnership.getCoreId(deviceId, 'data')),
+    parseVersionId(observation.versionId).coreDiscoveryKey.toString('hex')
   )
 })
+
+/** @param {string} id */
+function discoveryId(id) {
+  return discoveryKey(Buffer.from(id, 'hex')).toString('hex')
+}

--- a/test-types/data-types.ts
+++ b/test-types/data-types.ts
@@ -13,7 +13,7 @@ import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import RAM from 'random-access-memory'
 import { IndexWriter } from '../dist/index-writer/index.js'
-import { projectTable } from '../dist/schema/client.js'
+import { projectSettingsTable } from '../dist/schema/client.js'
 import { MapeoRPC } from '../dist/rpc/index.js'
 import { Expect, type Equal } from './utils.js'
 
@@ -33,7 +33,7 @@ const mapeoProject = new MapeoProject({
   projectKey: randomBytes(32),
   sharedDb: drizzle(sqlite),
   sharedIndexWriter: new IndexWriter({
-    tables: [projectTable],
+    tables: [projectSettingsTable],
     sqlite,
   }),
   rpc: new MapeoRPC(),

--- a/tests/core-ownership.js
+++ b/tests/core-ownership.js
@@ -8,6 +8,7 @@ import {
 } from '../src/core-ownership.js'
 import { randomBytes } from 'node:crypto'
 import { parseVersionId, getVersionId } from '@mapeo/schema'
+import { discoveryKey } from 'hypercore-crypto'
 
 test('Valid coreOwnership record', (t) => {
   const validDoc = generateValidDoc()
@@ -91,7 +92,7 @@ test('Invalid - different coreKey', (t) => {
   const validDoc = generateValidDoc()
   const version = {
     ...parseVersionId(validDoc.versionId),
-    coreKey: randomBytes(32),
+    coreDiscoveryKey: randomBytes(32),
   }
   t.exception(() => mapAndValidateCoreOwnership(validDoc, version))
 })
@@ -152,7 +153,10 @@ function generateValidDoc() {
   /** @type {ReturnType<typeof import('@mapeo/schema').decode>} */
   const validDoc = {
     docId: km.getIdentityKeypair().publicKey.toString('hex'),
-    versionId: getVersionId({ coreKey: coreKeypairs.auth.publicKey, index: 1 }),
+    versionId: getVersionId({
+      coreDiscoveryKey: discoveryKey(coreKeypairs.auth.publicKey),
+      index: 1,
+    }),
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     links: ['5678/0'],

--- a/tests/datastore.js
+++ b/tests/datastore.js
@@ -5,6 +5,7 @@ import { createCoreManager } from './helpers/core-manager.js'
 import { getVersionId } from '@mapeo/schema'
 import { once } from 'events'
 import RAM from 'random-access-memory'
+import { discoveryKey } from 'hypercore-crypto'
 
 /** @type {Omit<import('@mapeo/schema').Observation, 'versionId'>} */
 const obs = {
@@ -29,14 +30,16 @@ test('read and write', async (t) => {
     namespace: 'data',
     batch: async (entries) => {
       for (const { index, key } of entries) {
-        const versionId = getVersionId({ coreKey: key, index })
+        const coreDiscoveryKey = discoveryKey(key)
+        const versionId = getVersionId({ coreDiscoveryKey, index })
         indexedVersionIds.push(versionId)
       }
     },
     storage: () => new RAM(),
   })
   const written = await dataStore.write(obs)
-  const expectedVersionId = getVersionId({ coreKey: writerCore.key, index: 0 })
+  const coreDiscoveryKey = discoveryKey(writerCore.key)
+  const expectedVersionId = getVersionId({ coreDiscoveryKey, index: 0 })
   t.is(
     written.versionId,
     expectedVersionId,


### PR DESCRIPTION
Fixes #265

Depends on https://github.com/digidem/mapeo-schema/pull/145 and
updating mapeo-schema

Contains fixes for @mapeo/schema@3.0.0-next.9
(renamed project -> projectSettings)