### PR TITLE
chore: remove usage of opaque ids types related to project ids

### DIFF
--- a/src/ipc-wrapper/client.js
+++ b/src/ipc-wrapper/client.js
@@ -10,7 +10,7 @@ const CLOSE = Symbol('close')
  * @returns {import('rpc-reflector/client.js').ClientApi<import('../mapeo-manager.js').MapeoManager>}
  */
 export function createMapeoClient(messagePort) {
-  /** @type {Map<import('../types.js').ProjectPublicId, Promise<import('rpc-reflector/client.js').ClientApi<import('../mapeo-project.js').MapeoProject>>>} */
+  /** @type {Map<string, Promise<import('rpc-reflector/client.js').ClientApi<import('../mapeo-project.js').MapeoProject>>>} */
   const projectClientPromises = new Map()
 
   const managerChannel = new SubChannel(messagePort, MANAGER_CHANNEL_ID)
@@ -54,7 +54,7 @@ export function createMapeoClient(messagePort) {
   return client
 
   /**
-   * @param {import('../types.js').ProjectPublicId} projectPublicId
+   * @param {string} projectPublicId
    * @returns {Promise<import('rpc-reflector/client.js').ClientApi<import('../mapeo-project.js').MapeoProject>>}
    */
   async function createProjectClient(projectPublicId) {

--- a/src/ipc-wrapper/server.js
+++ b/src/ipc-wrapper/server.js
@@ -70,9 +70,7 @@ export function createMapeoServer(manager, messagePort) {
 
     let project
     try {
-      project = await manager.getProject(
-        /** @type {import('../types.js').ProjectPublicId} */ (id)
-      )
+      project = await manager.getProject(id)
     } catch (err) {
       // TODO: how to respond to client so that method errors?
       projectChannel.close()
@@ -106,9 +104,7 @@ export class MapeoRpcApi {
    * @returns {Promise<boolean>}
    */
   async assertProjectExists(projectId) {
-    const project = await this.#manager.getProject(
-      /** @type {import('../types.js').ProjectPublicId} */ (projectId)
-    )
+    const project = await this.#manager.getProject(projectId)
     return !!project
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,6 @@ import type {
   ValueOf,
   RequireAtLeastOne,
   SetOptional,
-  Opaque,
 } from 'type-fest'
 import { SUPPORTED_BLOB_VARIANTS } from './blob-store/index.js'
 import { MapeoCommon, MapeoDoc, MapeoValue, decode } from '@mapeo/schema'
@@ -143,10 +142,6 @@ export type TopicKey = Buffer
 export type TopicId = string
 /** 52 character base32 encoding of `Topic` Buffer */
 export type MdnsTopicId = string
-/** hex string representation of project key buffer */
-export type ProjectId = Opaque<string, 'ProjectId'>
-/** z32-encoded hash of project key */
-export type ProjectPublicId = Opaque<string, 'ProjectPublicId'>
 
 // TODO: Figure out where those extra fields come from and find more elegant way to represent this
 export type RawDhtConnectionStream = Duplex & {

--- a/src/utils.js
+++ b/src/utils.js
@@ -105,27 +105,23 @@ export function valueOf(doc) {
 /**
  * Create an internal ID from a project key
  * @param {Buffer} projectKey
- * @returns {import('./types.js').ProjectId}
+ * @returns {string}
  */
 export function projectKeyToId(projectKey) {
-  return /** @type {import('./types.js').ProjectId} */ (
-    projectKey.toString('hex')
-  )
+  return projectKey.toString('hex')
 }
 
 /**
  * Create a public ID from a project key
  * @param {Buffer} projectKey
- * @returns {import('./types.js').ProjectPublicId}
+ * @returns {string}
  */
 export function projectKeyToPublicId(projectKey) {
-  return /** @type {import('./types.js').ProjectPublicId} */ (
-    keyToPublicId(projectKey)
-  )
+  return keyToPublicId(projectKey)
 }
 
 /**
- * @param {import('./types.js').ProjectId} projectId
+ * @param {string} projectId Project internal ID
  * @returns {Buffer} 24-byte nonce (same length as sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
  */
 export function projectIdToNonce(projectId) {

--- a/test-e2e/ipc-wrapper.js
+++ b/test-e2e/ipc-wrapper.js
@@ -70,14 +70,11 @@ test('Attempting to get non-existent project fails', async (t) => {
   const { client, cleanup } = setup()
 
   await t.exception(async () => {
-    // @ts-expect-error
     await client.getProject('mapeo')
   })
 
   const results = await Promise.allSettled([
-    // @ts-expect-error
     client.getProject('mapeo'),
-    // @ts-expect-error
     client.getProject('mapeo'),
   ])
 


### PR DESCRIPTION
Towards #278

I had introduced opaque types for project id and project public id, but made the mistake of using those for the public-facing API, which makes their usage more tedious and doesn't bring any major benefit for now. 

Opaque types are useful if usage is kept internally, but maybe that's something to revisit later on.

Doing this towards publishing the IPC wrapper as a separate module, which works with APIs that used to rely on these opaque types.