### PR TITLE
fix: fix usage of drizzle when core is used as a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "drizzle"
   ],
   "prettier": {
     "semi": false,

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -60,7 +60,9 @@ export class MapeoManager {
         : path.join(dbFolder, CLIENT_SQLITE_FILE_NAME)
     )
     this.#db = drizzle(sqlite)
-    migrate(this.#db, { migrationsFolder: './drizzle/client' })
+    migrate(this.#db, {
+      migrationsFolder: new URL('../drizzle/client', import.meta.url).pathname,
+    })
 
     this.#rpc = new MapeoRPC()
     this.#keyManager = new KeyManager(rootKey)

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -79,7 +79,9 @@ export class MapeoProject {
     ///////// 1. Setup database
     const sqlite = new Database(dbPath)
     const db = drizzle(sqlite)
-    migrate(db, { migrationsFolder: './drizzle/project' })
+    migrate(db, {
+      migrationsFolder: new URL('../drizzle/project', import.meta.url).pathname,
+    })
 
     ///////// 2. Setup random-access-storage functions
 

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -29,7 +29,10 @@ const obsFixture = {
 test('private createWithDocId() method', async (t) => {
   const sqlite = new Database(':memory:')
   const db = drizzle(sqlite)
-  migrate(db, { migrationsFolder: './drizzle/project' })
+  migrate(db, {
+    migrationsFolder: new URL('../drizzle/project', import.meta.url).pathname,
+  })
+
   const coreManager = createCoreManager()
   const indexWriter = new IndexWriter({
     tables: [observationTable],
@@ -109,7 +112,10 @@ async function testenv(opts) {
   const coreManager = createCoreManager(opts)
   const sqlite = new Database(':memory:')
   const db = drizzle(sqlite)
-  migrate(db, { migrationsFolder: './drizzle/project' })
+  migrate(db, {
+    migrationsFolder: new URL('../drizzle/project', import.meta.url).pathname,
+  })
+
   const indexWriter = new IndexWriter({
     tables: [observationTable],
     sqlite,


### PR DESCRIPTION
Towards #278 

Attempting to use `@mapeo/core` as a dep in a separate project breaks because:

1. We don't include the drizzle migration directories when publishing

2. The path string we provide to drizzle's `migrate()` function is not absolute, which breaks when this is being used as dependency (implementation of how Drizzle attempts to find the migration files based on the provided path is [here](https://github.com/drizzle-team/drizzle-orm/blob/a7dc7e8bbdc3784f67ff32ce39bee3283f080751/drizzle-orm/src/migrator.ts#L22))

I encountered these by using `npm pack` on this repo and then importing as a dep in separate project