### PR TITLE
feat: disable namespace replication

### DIFF
--- a/src/core-manager/replication-state-machine.js
+++ b/src/core-manager/replication-state-machine.js
@@ -17,7 +17,7 @@ import { TypedEmitter } from 'tiny-typed-emitter'
 export class ReplicationStateMachine extends TypedEmitter {
   /** @type {ReplicationState} */
   #state = {
-    enabledNamespaces: new Set(['auth']),
+    enabledNamespaces: new Set(),
   }
   #enableNamespace
   #disableNamespace

--- a/src/core-manager/replication-state-machine.js
+++ b/src/core-manager/replication-state-machine.js
@@ -7,7 +7,6 @@ import { TypedEmitter } from 'tiny-typed-emitter'
 /**
  * @typedef {object} StateMachineEvents
  * @property {(state: ReplicationState) => void } state
- * @property {(namespace: Namespace) => void} enable-namespace Fired whenever a namespace is enabled for replication
  */
 
 /**
@@ -19,6 +18,20 @@ export class ReplicationStateMachine extends TypedEmitter {
   /** @type {ReplicationState} */
   #state = {
     enabledNamespaces: new Set(['auth']),
+  }
+  #enableNamespace
+  #disableNamespace
+
+  /**
+   *
+   * @param {object} opts
+   * @param {(namespace: Namespace) => void} opts.enableNamespace
+   * @param {(namespace: Namespace) => void} opts.disableNamespace
+   */
+  constructor({ enableNamespace, disableNamespace }) {
+    super()
+    this.#enableNamespace = enableNamespace
+    this.#disableNamespace = disableNamespace
   }
 
   get state() {
@@ -33,18 +46,22 @@ export class ReplicationStateMachine extends TypedEmitter {
   enableNamespace(namespace) {
     if (this.#state.enabledNamespaces.has(namespace)) return
     this.#state.enabledNamespaces.add(namespace)
-    this.emit('enable-namespace', namespace)
+    this.#enableNamespace(namespace)
     this.emit('state', this.#state)
   }
 
-  // No obvious way to implement this
-  // /** @param {Namespace} namespace */
-  // disableNamespace (namespace) {
-  //   if (!this.#state.enabledNamespaces.has(namespace)) return
-  //   this.#state.enabledNamespaces.delete(namespace)
-  //   this.emit('disable-namespace', namespace)
-  //   this.emit('state', this.#state)
-  // }
+  /**
+   * Disable a namespace for replication - will remove cores in the namespace
+   * from  the replication stream
+   *
+   * @param {Namespace} namespace
+   */
+  disableNamespace(namespace) {
+    if (!this.#state.enabledNamespaces.has(namespace)) return
+    this.#state.enabledNamespaces.delete(namespace)
+    this.#disableNamespace(namespace)
+    this.emit('state', this.#state)
+  }
 
   /**
    * @internal


### PR DESCRIPTION
This enables the sync API for disabling sync by adding an "unreplicate"
function that removes a core from the replication stream, without
closing the stream. Unreplicating a core from a replication with a peer
is currently the only way to stop a peer from receiving data from you -
Hypercore has no API yet for blocking uploads to peers when they request
data.

TODO:
- [x] Add tests for CoreManager & ReplicationStateMachine
