### PR TITLE
feat: expose capabilities in MapeoProject and its member api

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -16,6 +16,7 @@ import {
 import { ProjectKeys } from './generated/keys.js'
 import {
   deNullify,
+  getDeviceId,
   projectIdToNonce,
   projectKeyToId,
   projectKeyToPublicId,
@@ -70,9 +71,7 @@ export class MapeoManager {
 
     this.#rpc = new MapeoRPC()
     this.#keyManager = new KeyManager(rootKey)
-    this.#deviceId = this.#keyManager
-      .getIdentityKeypair()
-      .publicKey.toString('hex')
+    this.#deviceId = getDeviceId(this.#keyManager)
     this.#projectSettingsIndexWriter = new IndexWriter({
       tables: [projectSettingsTable],
       sqlite,

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -28,7 +28,7 @@ import {
   mapAndValidateCoreOwnership,
 } from './core-ownership.js'
 import { Capabilities } from './capabilities.js'
-import { projectKeyToId, valueOf } from './utils.js'
+import { getDeviceId, projectKeyToId, valueOf } from './utils.js'
 import { MemberApi } from './member-api.js'
 
 /** @typedef {Omit<import('@mapeo/schema').ProjectSettingsValue, 'schemaName'>} EditableProjectSettings */
@@ -40,6 +40,7 @@ export const kCapabilities = Symbol('capabilities')
 
 export class MapeoProject {
   #projectId
+  #deviceId
   #coreManager
   #dataStores
   #dataTypes
@@ -74,6 +75,7 @@ export class MapeoProject {
     encryptionKeys,
     rpc,
   }) {
+    this.#deviceId = getDeviceId(keyManager)
     this.#projectId = projectKeyToId(projectKey)
 
     ///////// 1. Setup database
@@ -362,6 +364,10 @@ export class MapeoProject {
     } catch {
       return /** @type {EditableProjectSettings} */ ({})
     }
+  }
+
+  async $getOwnCapabilities() {
+    return this.#capabilities.getCapabilities(this.#deviceId)
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,3 +127,11 @@ export function projectKeyToPublicId(projectKey) {
 export function projectIdToNonce(projectId) {
   return Buffer.from(projectId, 'hex').subarray(0, 24)
 }
+
+/**
+ * @param {import('@mapeo/crypto').KeyManager} keyManager
+ * @returns {string}
+ */
+export function getDeviceId(keyManager) {
+  return keyManager.getIdentityKeypair().publicKey.toString('hex')
+}


### PR DESCRIPTION
Closes #239 

Exposes capabilities in the following ways:

- adds a `$getOwnCapabilities()` method to `MapeoProject`
- adds a `capabilities` field to the return value of `project.$member.getById()` and `project.$member.getMany()`

TODO:

- [ ] Feel like some of the tests belong in e2e but not sure if that's blocked on the invites stuff
  - the e2e capabilities tests should ideally be able to use `project.$member` to retrieve the capabilities. currently relies on https://github.com/digidem/mapeo-core-next/issues/289 and updating the `MemberApi.invite()` implementation
  - the e2e manager invite tests should check that the inviter can retrieve the member's device info using the member api after the invite is accepted
- [X] still wondering what the best way to get your own capabilities for a project is. basically, should there be a `project.$getOwnCapabilities()` method?
  - [X] Update tests to account for this method