### PR TITLE
chore: update @mapeo/schema to 3.0.0-next.10

### DIFF
--- a/drizzle/client/0000_foamy_madame_hydra.sql
+++ b/drizzle/client/0000_foamy_madame_hydra.sql
@@ -22,6 +22,7 @@ CREATE TABLE `projectSettings` (
 	`createdBy` text NOT NULL,
 	`updatedAt` text NOT NULL,
 	`links` text NOT NULL,
+	`deleted` integer NOT NULL,
 	`name` text,
 	`defaultPresets` text,
 	`forks` text NOT NULL

--- a/drizzle/client/meta/0000_snapshot.json
+++ b/drizzle/client/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "e6899762-16e4-4571-92f5-e0e5fdb87e86",
+  "id": "fb87fd88-8355-492e-9515-9aea8f994567",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "localDeviceInfo": {
@@ -137,6 +137,13 @@
         "links": {
           "name": "links",
           "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1695224550073,
-      "tag": "0000_fearless_green_goblin",
+      "when": 1695927276027,
+      "tag": "0000_foamy_madame_hydra",
       "breakpoints": true
     }
   ]

--- a/drizzle/project/0000_brown_living_mummy.sql
+++ b/drizzle/project/0000_brown_living_mummy.sql
@@ -10,6 +10,7 @@ CREATE TABLE `coreOwnership` (
 	`createdBy` text NOT NULL,
 	`updatedAt` text NOT NULL,
 	`links` text NOT NULL,
+	`deleted` integer NOT NULL,
 	`authCoreId` text NOT NULL,
 	`configCoreId` text NOT NULL,
 	`dataCoreId` text NOT NULL,
@@ -30,6 +31,7 @@ CREATE TABLE `deviceInfo` (
 	`createdBy` text NOT NULL,
 	`updatedAt` text NOT NULL,
 	`links` text NOT NULL,
+	`deleted` integer NOT NULL,
 	`name` text NOT NULL,
 	`forks` text NOT NULL
 );
@@ -46,6 +48,7 @@ CREATE TABLE `field` (
 	`createdBy` text NOT NULL,
 	`updatedAt` text NOT NULL,
 	`links` text NOT NULL,
+	`deleted` integer NOT NULL,
 	`tagKey` text NOT NULL,
 	`type` text NOT NULL,
 	`label` text NOT NULL,
@@ -70,6 +73,7 @@ CREATE TABLE `observation` (
 	`createdBy` text NOT NULL,
 	`updatedAt` text NOT NULL,
 	`links` text NOT NULL,
+	`deleted` integer NOT NULL,
 	`lat` real,
 	`lon` real,
 	`refs` text NOT NULL,
@@ -91,6 +95,7 @@ CREATE TABLE `preset` (
 	`createdBy` text NOT NULL,
 	`updatedAt` text NOT NULL,
 	`links` text NOT NULL,
+	`deleted` integer NOT NULL,
 	`name` text NOT NULL,
 	`geometry` text NOT NULL,
 	`tags` text NOT NULL,
@@ -114,6 +119,7 @@ CREATE TABLE `role` (
 	`createdBy` text NOT NULL,
 	`updatedAt` text NOT NULL,
 	`links` text NOT NULL,
+	`deleted` integer NOT NULL,
 	`roleId` text NOT NULL,
 	`fromIndex` real NOT NULL,
 	`forks` text NOT NULL

--- a/drizzle/project/meta/0000_snapshot.json
+++ b/drizzle/project/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "5078e2b0-6319-4f3c-aee3-b024e8fe3f9a",
+  "id": "ee8a89aa-fd1d-47d8-88db-86f467de1c18",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "coreOwnership_backlink": {
@@ -68,6 +68,13 @@
         "links": {
           "name": "links",
           "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
@@ -188,6 +195,13 @@
           "notNull": true,
           "autoincrement": false
         },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
         "name": {
           "name": "name",
           "type": "text",
@@ -272,6 +286,13 @@
         "links": {
           "name": "links",
           "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
@@ -420,6 +441,13 @@
           "notNull": true,
           "autoincrement": false
         },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
         "lat": {
           "name": "lat",
           "type": "real",
@@ -539,6 +567,13 @@
         "links": {
           "name": "links",
           "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
@@ -676,6 +711,13 @@
         "links": {
           "name": "links",
           "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false

--- a/drizzle/project/meta/_journal.json
+++ b/drizzle/project/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1695224585287,
-      "tag": "0000_huge_mikhail_rasputin",
+      "when": 1695927172554,
+      "tag": "0000_brown_living_mummy",
       "breakpoints": true
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fastify/type-provider-typebox": "^3.3.0",
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "^1.0.0-alpha.8",
-        "@mapeo/schema": "^3.0.0-next.9",
+        "@mapeo/schema": "^3.0.0-next.10",
         "@mapeo/sqlite-indexer": "^1.0.0-alpha.6",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@mapeo/schema": {
-      "version": "3.0.0-next.9",
-      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.9.tgz",
-      "integrity": "sha512-6ispOMPa5YvI5oAHxNzoqMX50jq5LPbEWyr87nAMRRlCRAtfzR1VcK/HMi5m46/S5178p8NHmPgvp6tT93vKCQ==",
+      "version": "3.0.0-next.10",
+      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.10.tgz",
+      "integrity": "sha512-5r1G9TBRCVS1RouXL+ekXgdBZA/XpzbLyHnhf/jU7b5dCtTV05AmAuTl6s3SKHYuhycgDypE/9CO6U05NEI4qg==",
       "dependencies": {
         "@json-schema-tools/dereferencer": "^1.6.1",
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@fastify/type-provider-typebox": "^3.3.0",
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "^1.0.0-alpha.8",
-    "@mapeo/schema": "^3.0.0-next.9",
+    "@mapeo/schema": "^3.0.0-next.10",
     "@mapeo/sqlite-indexer": "^1.0.0-alpha.6",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -213,6 +213,19 @@ export class CoreManager extends TypedEmitter {
   }
 
   /**
+   * Get a core by its discovery key
+   *
+   * @param {Buffer} discoveryKey
+   * @returns {Core | undefined}
+   */
+  getCoreByDiscoveryKey(discoveryKey) {
+    const coreRecord = this.#coreIndex.getByDiscoveryId(
+      discoveryKey.toString('hex')
+    )
+    return coreRecord && coreRecord.core
+  }
+
+  /**
    * Close all open cores and end any replication streams
    * TODO: gracefully close replication streams
    */

--- a/src/core-ownership.js
+++ b/src/core-ownership.js
@@ -7,6 +7,7 @@ import sodium from 'sodium-universal'
 import { kTable, kSelect, kCreateWithDocId } from './datatype/index.js'
 import { eq, or } from 'drizzle-orm'
 import mapObject from 'map-obj'
+import { discoveryKey } from 'hypercore-crypto'
 
 /**
  * @typedef {import('./types.js').CoreOwnershipWithSignatures} CoreOwnershipWithSignatures
@@ -97,8 +98,10 @@ export class CoreOwnership {
  * @param {import('@mapeo/schema').VersionIdObject} version
  * @returns {import('@mapeo/schema').CoreOwnership}
  */
-export function mapAndValidateCoreOwnership(doc, { coreKey }) {
-  if (doc.authCoreId !== coreKey.toString('hex')) {
+export function mapAndValidateCoreOwnership(doc, { coreDiscoveryKey }) {
+  if (
+    !coreDiscoveryKey.equals(discoveryKey(Buffer.from(doc.authCoreId, 'hex')))
+  ) {
     throw new Error('Invalid coreOwnership record: mismatched authCoreId')
   }
   if (!verifyCoreOwnership(doc)) {

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -122,6 +122,7 @@ export class DataType {
       createdAt: nowDateString,
       updatedAt: nowDateString,
       createdBy: discoveryId,
+      deleted: false,
       links: [],
     }
 

--- a/src/index-writer/index.js
+++ b/src/index-writer/index.js
@@ -2,6 +2,7 @@ import { decode } from '@mapeo/schema'
 import SqliteIndexer from '@mapeo/sqlite-indexer'
 import { getTableConfig } from 'drizzle-orm/sqlite-core'
 import { getBacklinkTableName } from '../schema/utils.js'
+import { discoveryKey } from 'hypercore-crypto'
 
 /**
  * @typedef {import('../datatype/index.js').MapeoDocTables} MapeoDocTables
@@ -59,7 +60,7 @@ export class IndexWriter {
     const queued = {}
     for (const { block, key, index } of entries) {
       try {
-        const version = { coreKey: key, index }
+        const version = { coreDiscoveryKey: discoveryKey(key), index }
         var doc = this.#mapDoc(decode(block, version), version)
       } catch (e) {
         // Unknown or invalid entry - silently ignore

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -5,6 +5,7 @@ import { decodeBlockPrefix } from '@mapeo/schema'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import pDefer from 'p-defer'
+import { discoveryKey } from 'hypercore-crypto'
 
 import { CoreManager, NAMESPACES } from './core-manager/index.js'
 import { DataStore } from './datastore/index.js'
@@ -410,8 +411,8 @@ function getCoreKeypairs({ projectKey, projectSecretKey, keyManager }) {
  * @param {import('@mapeo/schema').VersionIdObject} version
  * @returns {import('@mapeo/schema').DeviceInfo}
  */
-function mapAndValidateDeviceInfo(doc, { coreKey }) {
-  if (doc.docId !== coreKey.toString('hex')) {
+function mapAndValidateDeviceInfo(doc, { coreDiscoveryKey }) {
+  if (!coreDiscoveryKey.equals(discoveryKey(Buffer.from(doc.docId, 'hex')))) {
     throw new Error(
       'Invalid deviceInfo record, cannot write deviceInfo for another device'
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ type BlobIdBase<T extends BlobType> = {
   variant: BlobVariant<T>
   /** unique identifier for blob (e.g. hash of content) */
   name: string
-  /** public key as hex string of hyperdrive where blob is stored */
+  /** discovery key as hex string of hyperdrive where blob is stored */
   driveId: string
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,7 +84,7 @@ export function deNullify(obj) {
 /**
  * @template {import('@mapeo/schema').MapeoDoc & { forks: string[] }} T
  * @param {T} doc
- * @returns {Omit<T, 'docId' | 'versionId' | 'links' | 'forks' | 'createdAt' | 'updatedAt' | 'createdBy'>}
+ * @returns {Omit<T, 'docId' | 'versionId' | 'links' | 'forks' | 'createdAt' | 'updatedAt' | 'createdBy' | 'deleted'>}
  */
 export function valueOf(doc) {
   /* eslint-disable no-unused-vars */
@@ -96,6 +96,7 @@ export function valueOf(doc) {
     createdAt,
     updatedAt,
     createdBy,
+    deleted,
     ...rest
   } = doc
   /* eslint-enable no-unused-vars */

--- a/test-e2e/core-ownership.js
+++ b/test-e2e/core-ownership.js
@@ -4,6 +4,7 @@ import { MapeoManager } from '../src/mapeo-manager.js'
 import { kCoreOwnership } from '../src/mapeo-project.js'
 import { parseVersionId } from '@mapeo/schema'
 import RAM from 'random-access-memory'
+import { discoveryKey } from 'hypercore-crypto'
 
 test('CoreOwnership', async (t) => {
   const rootKey = KeyManager.generateRootKey()
@@ -35,8 +36,8 @@ test('CoreOwnership', async (t) => {
     fieldIds: [],
   })
   t.is(
-    await coreOwnership.getCoreId(deviceId, 'config'),
-    parseVersionId(preset.versionId).coreKey.toString('hex')
+    discoveryId(await coreOwnership.getCoreId(deviceId, 'config')),
+    parseVersionId(preset.versionId).coreDiscoveryKey.toString('hex')
   )
 
   const observation = await project.observation.create({
@@ -47,7 +48,12 @@ test('CoreOwnership', async (t) => {
     metadata: {},
   })
   t.is(
-    await coreOwnership.getCoreId(deviceId, 'data'),
-    parseVersionId(observation.versionId).coreKey.toString('hex')
+    discoveryId(await coreOwnership.getCoreId(deviceId, 'data')),
+    parseVersionId(observation.versionId).coreDiscoveryKey.toString('hex')
   )
 })
+
+/** @param {string} id */
+function discoveryId(id) {
+  return discoveryKey(Buffer.from(id, 'hex')).toString('hex')
+}

--- a/tests/blob-api.js
+++ b/tests/blob-api.js
@@ -9,7 +9,7 @@ import { createBlobStore } from './helpers/blob-store.js'
 import { timeoutException } from './helpers/index.js'
 
 test('get port after listening event with explicit port', async (t) => {
-  const blobStore = createBlobStore()
+  const { blobStore } = createBlobStore()
   const server = await createBlobServer({ blobStore })
 
   t.ok(await timeoutException(getPort(server.server)))
@@ -31,7 +31,7 @@ test('get port after listening event with explicit port', async (t) => {
 })
 
 test('get port after listening event with unset port', async (t) => {
-  const blobStore = createBlobStore()
+  const { blobStore } = createBlobStore()
   const server = await createBlobServer({ blobStore })
 
   t.ok(await timeoutException(getPort(server.server)))
@@ -52,11 +52,11 @@ test('get port after listening event with unset port', async (t) => {
 
 test('get url from blobId', async (t) => {
   const projectId = '1234'
-  const type = 'image'
+  const type = 'photo'
   const variant = 'original'
   const name = '1234'
 
-  const blobStore = createBlobStore()
+  const { blobStore } = createBlobStore()
   const blobServer = await createBlobServer({ blobStore })
   const blobApi = new BlobApi({ projectId: '1234', blobStore, blobServer })
 
@@ -66,7 +66,12 @@ test('get url from blobId', async (t) => {
     })
   })
 
-  const url = await blobApi.getUrl({ type, variant, name })
+  const url = await blobApi.getUrl({
+    driveId: blobStore.writerDriveId,
+    type,
+    variant,
+    name,
+  })
 
   t.is(
     url,

--- a/tests/blob-server.js
+++ b/tests/blob-server.js
@@ -201,9 +201,12 @@ test('GET photo returns 404 when trying to get non-replicated blob', async (t) =
 
   const { destroy } = replicateBlobs(cm1, cm2)
 
-  await waitForCores(cm2, [Buffer.from(blobId.driveId, 'hex')])
+  await waitForCores(cm2, [cm1.getWriterCore('blobIndex').key])
+
   /** @type {any}*/
-  const replicatedCore = cm2.getCoreByKey(Buffer.from(blobId.driveId, 'hex'))
+  const replicatedCore = cm2.getCoreByDiscoveryKey(
+    Buffer.from(blobId.driveId, 'hex')
+  )
   await replicatedCore.update({ wait: true })
   await replicatedCore.download({ end: replicatedCore.length }).done()
   await destroy()

--- a/tests/core-ownership.js
+++ b/tests/core-ownership.js
@@ -8,6 +8,7 @@ import {
 } from '../src/core-ownership.js'
 import { randomBytes } from 'node:crypto'
 import { parseVersionId, getVersionId } from '@mapeo/schema'
+import { discoveryKey } from 'hypercore-crypto'
 
 test('Valid coreOwnership record', (t) => {
   const validDoc = generateValidDoc()
@@ -91,7 +92,7 @@ test('Invalid - different coreKey', (t) => {
   const validDoc = generateValidDoc()
   const version = {
     ...parseVersionId(validDoc.versionId),
-    coreKey: randomBytes(32),
+    coreDiscoveryKey: discoveryKey(randomBytes(32)),
   }
   t.exception(() => mapAndValidateCoreOwnership(validDoc, version))
 })
@@ -152,7 +153,11 @@ function generateValidDoc() {
   /** @type {ReturnType<typeof import('@mapeo/schema').decode>} */
   const validDoc = {
     docId: km.getIdentityKeypair().publicKey.toString('hex'),
-    versionId: getVersionId({ coreKey: coreKeypairs.auth.publicKey, index: 1 }),
+    versionId: getVersionId({
+      coreDiscoveryKey: discoveryKey(coreKeypairs.auth.publicKey),
+      index: 1,
+    }),
+    createdBy: discoveryKey(coreKeypairs.auth.publicKey).toString('hex'),
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     links: ['5678/0'],

--- a/tests/core-ownership.js
+++ b/tests/core-ownership.js
@@ -160,6 +160,7 @@ function generateValidDoc() {
     createdBy: discoveryKey(coreKeypairs.auth.publicKey).toString('hex'),
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+    deleted: false,
     links: ['5678/0'],
     schemaName: 'coreOwnership',
     authCoreId: coreKeypairs.auth.publicKey.toString('hex'),

--- a/tests/datastore.js
+++ b/tests/datastore.js
@@ -5,6 +5,7 @@ import { createCoreManager } from './helpers/core-manager.js'
 import { getVersionId } from '@mapeo/schema'
 import { once } from 'events'
 import RAM from 'random-access-memory'
+import { discoveryKey } from 'hypercore-crypto'
 
 /** @type {Omit<import('@mapeo/schema').Observation, 'versionId'>} */
 const obs = {
@@ -30,14 +31,16 @@ test('read and write', async (t) => {
     namespace: 'data',
     batch: async (entries) => {
       for (const { index, key } of entries) {
-        const versionId = getVersionId({ coreKey: key, index })
+        const coreDiscoveryKey = discoveryKey(key)
+        const versionId = getVersionId({ coreDiscoveryKey, index })
         indexedVersionIds.push(versionId)
       }
     },
     storage: () => new RAM(),
   })
   const written = await dataStore.write(obs)
-  const expectedVersionId = getVersionId({ coreKey: writerCore.key, index: 0 })
+  const coreDiscoveryKey = discoveryKey(writerCore.key)
+  const expectedVersionId = getVersionId({ coreDiscoveryKey, index: 0 })
   t.is(
     written.versionId,
     expectedVersionId,

--- a/tests/datastore.js
+++ b/tests/datastore.js
@@ -19,6 +19,7 @@ const obs = {
   tags: {},
   attachments: [],
   metadata: {},
+  deleted: false,
 }
 
 test('read and write', async (t) => {


### PR DESCRIPTION
Closes #265 
Closes #272

Extracts the relevant changes from #271 

This version of `@mapeo/schema` introduced the following:

- [X] adding `deleted` field to common schema
- [X] renaming coreKey to coreDiscoveryKey
- [X] renaming driveId to driveDiscoveryId (see #294)
  - this one doesn't have many direct changes from schema, but requires us to derive the drive ids differently

