### PR TITLE
fix: fix DataType.getByDocId implementation to match type definition

### DIFF
--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -137,7 +137,8 @@ export class DataType {
    */
   async getByDocId(docId) {
     const result = this.#sql.getByDocId.get({ docId })
-    return result ? deNullify(result) : result
+    if (!result) throw new Error('Not found')
+    return deNullify(result)
   }
 
   /** @param {string} versionId */

--- a/test-types/data-types.ts
+++ b/test-types/data-types.ts
@@ -55,6 +55,9 @@ Expect<Equal<ObservationWithForks, typeof updatedObservation>>
 const manyObservations = await mapeoProject.observation.getMany()
 Expect<Equal<ObservationWithForks[], typeof manyObservations>>
 
+const observationByDocId = await mapeoProject.observation.getByDocId('abc')
+Expect<Equal<Observation & { forks: string[] }, typeof observationByDocId>>
+
 const observationByVersionId = await mapeoProject.observation.getByVersionId(
   'abc'
 )
@@ -71,6 +74,9 @@ Expect<Equal<PresetWithForks, typeof updatedPreset>>
 const manyPresets = await mapeoProject.preset.getMany()
 Expect<Equal<PresetWithForks[], typeof manyPresets>>
 
+const presetByDocId = await mapeoProject.preset.getByDocId('abc')
+Expect<Equal<Preset & { forks: string[] }, typeof presetByDocId>>
+
 const presetByVersionId = await mapeoProject.preset.getByVersionId('abc')
 Expect<Equal<Preset, typeof presetByVersionId>>
 
@@ -84,6 +90,9 @@ Expect<Equal<FieldWithForks, typeof updatedField>>
 
 const manyFields = await mapeoProject.field.getMany()
 Expect<Equal<FieldWithForks[], typeof manyFields>>
+
+const fieldByDocId = await mapeoProject.field.getByDocId('abc')
+Expect<Equal<Field & { forks: string[] }, typeof fieldByDocId>>
 
 const fieldByVersionId = await mapeoProject.field.getByVersionId('abc')
 Expect<Equal<Field, typeof fieldByVersionId>>


### PR DESCRIPTION
Closes #301

Decided to go with throwing an error if not found since 

1. all of the existing code that uses this method is written based on that type definition. 
2. it aligns more closely with the [client docs](https://github.com/digidem/mapeo-core-docs/blob/4359febd84163c28cc0ae55d6bbf08f150d592e3/client-docs/README.md#mapeodocgetbydocid) i had spec'd a while ago

Not a huge fan of it, as explained in https://github.com/digidem/mapeo-core-next/issues/301#issuecomment-1747452577, but this approach requires the smallest amount of changes and is fine for now
