### PR TITLE
chore: update github action steps

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -21,9 +21,9 @@ jobs:
           - '16.x'
           - '18.x'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
Updates to actions/checkout@v4 and actions/setup-node@v2
Removes deprecation warnings