### PR TITLE
fix: fix mdns discovery (finally)

### DIFF
--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -187,8 +187,14 @@ export class MdnsDiscovery extends TypedEmitter {
         remotePublicKey
       )
       const keepExisting =
+        // These first two checks check if a peer tried to connect twice. In
+        // this case we keep the existing connection.
         (isInitiator && existing.isInitiator) ||
         (!isInitiator && !existing.isInitiator) ||
+        // If each peer tried to connect to the other at the same time, then we
+        // tie-break based on public key comparison (the initiator need to check
+        // the opposite of the non-initiator, because the keys are the other way
+        // around for them)
         (isInitiator ? keyCompare > 0 : keyCompare <= 0)
       if (keepExisting) {
         this.#log(`keeping existing, destroying new`)

--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -182,10 +182,14 @@ export class MdnsDiscovery extends TypedEmitter {
     const existing = this.#noiseConnections.get(remoteId)
 
     if (existing) {
+      const keyCompare = Buffer.compare(
+        this.#identityKeypair.publicKey,
+        remotePublicKey
+      )
       const keepExisting =
         (isInitiator && existing.isInitiator) ||
         (!isInitiator && !existing.isInitiator) ||
-        Buffer.compare(this.#identityKeypair.publicKey, remotePublicKey) > 0
+        (isInitiator ? keyCompare > 0 : keyCompare <= 0)
       if (keepExisting) {
         this.#log(`keeping existing, destroying new`)
         conn.on('error', noop)

--- a/tests/discovery/mdns.js
+++ b/tests/discovery/mdns.js
@@ -75,24 +75,12 @@ test('deduplicate incoming connections', async (t) => {
   await discovery.stop({ force: true })
 })
 
-// These tests are failing randomly due to a race condition when de-duplicating connections.
-// TODO: Fix the race condition and re-enable these tests, and try to write a test that will consistently reproduce
-test.skip(`mdns - discovery of 20 peers with random time instantiation`, async (t) => {
-  await testMultiple(t, { period: 2000, nPeers: 20 })
+test(`mdns - discovery of 30 peers with random time instantiation`, async (t) => {
+  await testMultiple(t, { period: 2000, nPeers: 30 })
 })
 
-// These tests are failing randomly due to a race condition when de-duplicating connections.
-// TODO: Fix the race condition and re-enable these tests, and try to write a test that will consistently reproduce
-test.skip(`mdns - discovery of 20 peers instantiated at the same time`, async (t) => {
-  await testMultiple(t, { period: 0, nPeers: 20 })
-})
-
-test(`mdns - discovery of 3 peers with random time instantiation`, async (t) => {
-  await testMultiple(t, { period: 2000, nPeers: 3 })
-})
-
-test(`mdns - discovery of 3 peers instantiated at the same time`, async (t) => {
-  await testMultiple(t, { period: 0, nPeers: 3 })
+test(`mdns - discovery of 30 peers instantiated at the same time`, async (t) => {
+  await testMultiple(t, { period: 0, nPeers: 30 })
 })
 
 /**


### PR DESCRIPTION
The dedupe logic was incorrect, but in most cases the check in
`handleServiceUp` was hiding that. Temporarily removing that check
revealed the bug in a reproducible way.