### PR TITLE
chore: gitignore .eslintcache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp
 proto/build
 /dist
 !/drizzle/**/*.sql
+.eslintcache


### PR DESCRIPTION
started appearing after husky lint on commit hook (which uses the cache)