### PR TITLE
chore: run CI on PRs against any branch

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Currently CI only runs for PRs against `main`, which means it does not
run for stacked PRs. This changes the CI workflow to run on all PRs