### PR TITLE
chore: update better-sqlite3 to 8.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
         "base32.js": "^0.1.0",
-        "better-sqlite3": "^8.3.0",
+        "better-sqlite3": "^8.7.0",
         "big-sparse-array": "^1.0.3",
         "bogon": "^1.1.0",
         "bonjour-service": "^1.1.1",
@@ -1503,12 +1503,13 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "8.5.0",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
+      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.0"
+        "prebuild-install": "^7.1.1"
       }
     },
     "node_modules/big-sparse-array": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",
     "base32.js": "^0.1.0",
-    "better-sqlite3": "^8.3.0",
+    "better-sqlite3": "^8.7.0",
     "big-sparse-array": "^1.0.3",
     "bogon": "^1.1.0",
     "bonjour-service": "^1.1.1",


### PR DESCRIPTION
Upgrades `better-sqlite3` from `8.5.0` to `8.7.0`. Doing this because I'm planning to build the prebuilds for 8.7.0, so I wanted them to match initially

[v9](https://github.com/WiseLibs/better-sqlite3/releases/tag/v9.0.0) was recently released but refraining due to dropped official support for Node 16