### PR TITLE
chore: update sodium-native to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5363,8 +5363,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "license": "MIT",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -7281,6 +7282,15 @@
         "xsalsa20": "^1.0.0"
       }
     },
+    "node_modules/sodium-native": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.4.tgz",
+      "integrity": "sha512-faqOKw4WQKK7r/ybn6Lqo1F9+L5T6NlBJJYvpxbZPetpWylUVqz449mvlwIBKBqxEHbWakWuOlUt8J3Qpc4sWw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.6.0"
+      }
+    },
     "node_modules/sodium-secretstream": {
       "version": "1.1.0",
       "license": "MIT",
@@ -7302,14 +7312,6 @@
         "sodium-javascript": "~0.8.0",
         "sodium-native": "^4.0.0",
         "xsalsa20": "^1.0.0"
-      }
-    },
-    "node_modules/sodium-universal/node_modules/sodium-native": {
-      "version": "4.0.1",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
       }
     },
     "node_modules/sonic-boom": {


### PR DESCRIPTION
Similar reasoning as #337 

Updates sodium-native (used by sodium-universal) from 4.0.1 to 4.0.4