### PR TITLE
chore: update @mapeo/sqlite-indexer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "^1.0.0-alpha.10",
         "@mapeo/schema": "^3.0.0-next.11",
-        "@mapeo/sqlite-indexer": "^1.0.0-alpha.6",
+        "@mapeo/sqlite-indexer": "^1.0.0-alpha.7",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
         "base32.js": "^0.1.0",
@@ -932,8 +932,9 @@
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
-      "version": "1.0.0-alpha.6",
-      "license": "MIT",
+      "version": "1.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@mapeo/sqlite-indexer/-/sqlite-indexer-1.0.0-alpha.7.tgz",
+      "integrity": "sha512-XvFDP2V8QfbkuA9/Dsn1rNK+zoEPYTBHKPm80AQIIqqQvRe7fgLfI/O0nO94Z83WMtsepPw7Py/T7jwDdVQ2xw==",
       "dependencies": {
         "@types/better-sqlite3": "^7.6.4",
         "better-sqlite3": "^8.4.0"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "^1.0.0-alpha.10",
     "@mapeo/schema": "^3.0.0-next.11",
-    "@mapeo/sqlite-indexer": "^1.0.0-alpha.6",
+    "@mapeo/sqlite-indexer": "^1.0.0-alpha.7",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",
     "base32.js": "^0.1.0",


### PR DESCRIPTION
Upgrades @mapeo/sqlite-indexer from 1.0.0-alpha.6 to 1.0.0-alpha.7

Not sure if anyone is aware of any tests that would benefit from being updated as a result of this change.