### PR TITLE
chore: update type-fest and move to normal deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "sub-encoder": "^2.1.1",
         "throttle-debounce": "^5.0.0",
         "tiny-typed-emitter": "^2.1.0",
+        "type-fest": "^4.5.0",
         "varint": "^6.0.0",
         "z32": "^1.0.1"
       },
@@ -83,7 +84,6 @@
         "streamx": "^2.15.1",
         "tempy": "^3.1.0",
         "ts-proto": "^1.156.7",
-        "type-fest": "^3.10.0",
         "typedoc": "^0.24.8",
         "typedoc-plugin-markdown": "^3.15.3",
         "typescript": "^5.1.6"
@@ -919,16 +919,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@mapeo/schema/node_modules/type-fest": {
-      "version": "4.2.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
@@ -2300,6 +2290,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5059,6 +5061,18 @@
       },
       "engines": {
         "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7875,17 +7889,14 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "3.10.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.5.0.tgz",
+      "integrity": "sha512-diLQivFzddJl4ylL3jxSkEc39Tpw7o1QeEHIPxVwryDK2lpB7Nqhzhuo6v5/Ls08Z0yPSAhsyAWlv1/H0ciNmw==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.7.0"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "streamx": "^2.15.1",
     "tempy": "^3.1.0",
     "ts-proto": "^1.156.7",
-    "type-fest": "^3.10.0",
     "typedoc": "^0.24.8",
     "typedoc-plugin-markdown": "^3.15.3",
     "typescript": "^5.1.6"
@@ -145,6 +144,7 @@
     "sub-encoder": "^2.1.1",
     "throttle-debounce": "^5.0.0",
     "tiny-typed-emitter": "^2.1.0",
+    "type-fest": "^4.5.0",
     "varint": "^6.0.0",
     "z32": "^1.0.1"
   }


### PR DESCRIPTION
Updates `type-fest` from 3.10.0 to 4.5.0 and moves it to a normal dependency. The latter is necessary for type definitions to work as expected when `@mapeo/core` is used as a dependency in other projects.