### PR TITLE
fix: Fix sending RPC messages after connection

### DIFF
--- a/src/invite-api.js
+++ b/src/invite-api.js
@@ -109,7 +109,7 @@ export class InviteApi extends TypedEmitter {
 
     if (isAlreadyMember) {
       for (const peerId of peersToRespondTo) {
-        this.#sendAlreadyResponse({ peerId, projectId })
+        await this.#sendAlreadyResponse({ peerId, projectId })
       }
       return
     }
@@ -123,7 +123,7 @@ export class InviteApi extends TypedEmitter {
     }
 
     try {
-      this.#sendAcceptResponse({
+      await this.#sendAcceptResponse({
         peerId: pendingInvite.fromPeerId,
         projectId,
       })
@@ -162,7 +162,7 @@ export class InviteApi extends TypedEmitter {
       )
     }
     for (const peerId of this.#peersToRespondTo.get(projectId)) {
-      this.#sendRejectResponse({ peerId, projectId })
+      await this.#sendRejectResponse({ peerId, projectId })
     }
   }
 
@@ -171,9 +171,9 @@ export class InviteApi extends TypedEmitter {
    *
    * @param {{ peerId: string, projectId: string }} opts
    */
-  #sendAcceptResponse({ peerId, projectId }) {
+  async #sendAcceptResponse({ peerId, projectId }) {
     const projectKey = Buffer.from(projectId, 'hex')
-    this.rpc.inviteResponse(peerId, {
+    await this.rpc.inviteResponse(peerId, {
       projectKey,
       decision: InviteResponse_Decision.ACCEPT,
     })
@@ -184,10 +184,10 @@ export class InviteApi extends TypedEmitter {
    *
    * @param {{ peerId: string, projectId: string }} opts
    */
-  #sendAlreadyResponse({ peerId, projectId }) {
+  async #sendAlreadyResponse({ peerId, projectId }) {
     const projectKey = Buffer.from(projectId, 'hex')
     try {
-      this.rpc.inviteResponse(peerId, {
+      await this.rpc.inviteResponse(peerId, {
         projectKey,
         decision: InviteResponse_Decision.ALREADY,
       })
@@ -202,10 +202,10 @@ export class InviteApi extends TypedEmitter {
    *
    * @param {{ peerId: string, projectId: string }} opts
    */
-  #sendRejectResponse({ peerId, projectId }) {
+  async #sendRejectResponse({ peerId, projectId }) {
     const projectKey = Buffer.from(projectId, 'hex')
     try {
-      this.rpc.inviteResponse(peerId, {
+      await this.rpc.inviteResponse(peerId, {
         projectKey,
         decision: InviteResponse_Decision.REJECT,
       })

--- a/tests/helpers/rpc.js
+++ b/tests/helpers/rpc.js
@@ -1,9 +1,13 @@
 import NoiseSecretStream from '@hyperswarm/secret-stream'
 
 /**
+ * @typedef {ReturnType<import('@hyperswarm/secret-stream').keyPair>} KeyPair
+ */
+
+/**
  * @param {import('../../src/rpc/index.js').MapeoRPC} rpc1
  * @param {import('../../src/rpc/index.js').MapeoRPC} rpc2
- * @param { {kp1?: import('@hyperswarm/secret-stream'), kp2?: import('@hyperswarm/secret-stream')} } [keyPairs]
+ * @param { {kp1?: KeyPair, kp2?: KeyPair} } [keyPairs]
  * @returns {() => Promise<[void, void]>}
  */
 export function replicate(
@@ -25,9 +29,7 @@ export function replicate(
   // @ts-expect-error
   n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
 
-  // @ts-expect-error
   rpc1.connect(n1)
-  // @ts-expect-error
   rpc2.connect(n2)
 
   return async function destroy() {

--- a/tests/helpers/rpc.js
+++ b/tests/helpers/rpc.js
@@ -29,7 +29,9 @@ export function replicate(
   // @ts-expect-error
   n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
 
+  // @ts-expect-error
   rpc1.connect(n1)
+  // @ts-expect-error
   rpc2.connect(n2)
 
   return async function destroy() {

--- a/tests/invite-api.js
+++ b/tests/invite-api.js
@@ -321,7 +321,6 @@ test('invitor disconnecting results in accept throwing', async (t) => {
 
   r1.on('peers', async (peers) => {
     if (peers.length !== 1 || peers[0].status === 'disconnected') return
-
     await t.exception(() => {
       return r1.invite(peers[0].id, {
         projectKey,


### PR DESCRIPTION
Trying to send an RPC message immediately after connecting the RPC
channel would fail because the protomux channel was not yet open. This
fix ensures that sending an RPC message waits for a peer to fully
connect before trying to send. This is necessary for sending device info
(e.g. the device name) immediately after connecting to a peer.