### PR TITLE
feat: integrate LocalDiscovery & LocalPeers

### DIFF
--- a/test-types/data-types.ts
+++ b/test-types/data-types.ts
@@ -36,7 +36,7 @@ const mapeoProject = new MapeoProject({
     tables: [projectSettingsTable],
     sqlite,
   }),
-  rpc: new LocalPeers(),
+  localPeers: new LocalPeers(),
 })
 
 ///// Observations


### PR DESCRIPTION
Stacked on #356

This is a lot of plumbing to connect everything together.

- Replication with local peers now happens at the MapeoManager level, and multiple projects can sync over the same connection (this is done via `protomux.pair()` on the hypercore protocol identifier, which gets us an event with the discovery key whenever a hypercore is replicated, and we pass this discovery key to the project instance via the LocalPeers class.
- Adds a `mapeoManager.replicate()` method, for replicating directly with a stream rather that just using discovery (may move this to a symbol method - would mainly be for testing)
- Narrows types for replication methods to be clearer about what should be passed where. This is a bit confusing, mainly due to the complex actual types used by Hypercore.
- A local discovery instance is now attached to MapeoManager, and new connections are managed by LocalPeers, which sends the device name and implements the RPC methods.

I'm going to do limited testing with this - ensuring that the replicate() method works, and will add more thorough e2e tests once the `listLocalPeers()` method and e2e invites are done.