### PR TITLE
chore: fix release workflow configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,3 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
           build-command: |
             npm install
-            npm run build


### PR DESCRIPTION
Fixes #359 

Noticed an error about missing a `build` npm script: https://github.com/digidem/mapeo-core-next/actions/runs/6882793274/job/18722037582#step:3:164

> npm ERR! Missing script: "build"

Not entirely sure what the necessary change is, but figured at least removing the step that fails would be a good start.