### PR TITLE
chore: pin more hyper deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "drizzle-orm": "0.28.2",
         "fastify": ">= 4",
         "fastify-plugin": "^4.5.0",
+        "hyperblobs": "2.3.0",
         "hypercore": "10.17.0",
         "hypercore-crypto": "3.4.0",
         "hyperdrive": "11.5.3",
@@ -3402,7 +3403,8 @@
     },
     "node_modules/hyperblobs": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.3.0.tgz",
+      "integrity": "sha512-iBCLVEo6FK+Xd7cpLM3DQ6cTfuMmKPfDZNj5/JqKEgziBEuI0ZGGyMM5dqaVvtRX4s71y8BhrgsDi2p0pWdSmg==",
       "dependencies": {
         "b4a": "^1.6.1",
         "mutexify": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "fastify-plugin": "^4.5.0",
         "hypercore": "10.17.0",
         "hypercore-crypto": "^3.3.1",
-        "hyperdrive": "^11.5.3",
+        "hyperdrive": "11.5.3",
         "hyperswarm": "^4.4.1",
         "magic-bytes.js": "^1.0.14",
         "map-obj": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "fastify": ">= 4",
         "fastify-plugin": "^4.5.0",
         "hypercore": "10.17.0",
-        "hypercore-crypto": "^3.3.1",
+        "hypercore-crypto": "3.4.0",
         "hyperdrive": "11.5.3",
         "hyperswarm": "4.4.1",
         "magic-bytes.js": "^1.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "hypercore": "10.17.0",
         "hypercore-crypto": "^3.3.1",
         "hyperdrive": "11.5.3",
-        "hyperswarm": "^4.4.1",
+        "hyperswarm": "4.4.1",
         "magic-bytes.js": "^1.0.14",
         "map-obj": "^5.0.2",
         "multi-core-indexer": "1.0.0-alpha.7",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "hypercore": "10.17.0",
     "hypercore-crypto": "^3.3.1",
     "hyperdrive": "11.5.3",
-    "hyperswarm": "^4.4.1",
+    "hyperswarm": "4.4.1",
     "magic-bytes.js": "^1.0.14",
     "map-obj": "^5.0.2",
     "multi-core-indexer": "1.0.0-alpha.7",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "drizzle-orm": "0.28.2",
     "fastify": ">= 4",
     "fastify-plugin": "^4.5.0",
+    "hyperblobs": "2.3.0",
     "hypercore": "10.17.0",
     "hypercore-crypto": "3.4.0",
     "hyperdrive": "11.5.3",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "fastify": ">= 4",
     "fastify-plugin": "^4.5.0",
     "hypercore": "10.17.0",
-    "hypercore-crypto": "^3.3.1",
+    "hypercore-crypto": "3.4.0",
     "hyperdrive": "11.5.3",
     "hyperswarm": "4.4.1",
     "magic-bytes.js": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "fastify-plugin": "^4.5.0",
     "hypercore": "10.17.0",
     "hypercore-crypto": "^3.3.1",
-    "hyperdrive": "^11.5.3",
+    "hyperdrive": "11.5.3",
     "hyperswarm": "^4.4.1",
     "magic-bytes.js": "^1.0.14",
     "map-obj": "^5.0.2",


### PR DESCRIPTION
Tomas was dealing with issues because of a mangled lockfile, which updated a transitive dep (hyperblobs) and caused issues in our tests.

This change won't fix that scenario, but just to avoid other potential headaches in the future, pinning any hyper deps that haven't been pinned yet.