### PR TITLE
chore: fix param type for Capabilities.assignRole()

### DIFF
--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -251,7 +251,7 @@ export class Capabilities {
    * capability for the given roleId
    *
    * @param {string} deviceId
-   * @param {keyof DEFAULT_CAPABILITIES} roleId
+   * @param {keyof typeof DEFAULT_CAPABILITIES} roleId
    */
   async assignRole(deviceId, roleId) {
     let fromIndex = 0


### PR DESCRIPTION
Not sure how TS was still able to infer the roleId param type correctly prior to this with the incorrect declaration, but not worth musing over 😄 