### PR TITLE
feat: dataType.on('updated-docs') when docs update

### DIFF
--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -3,10 +3,8 @@ import { encode, decode, getVersionId, parseVersionId } from '@mapeo/schema'
 import MultiCoreIndexer from 'multi-core-indexer'
 import pDefer from 'p-defer'
 import { discoveryKey } from 'hypercore-crypto'
+import { createMap } from '../utils.js'
 
-/**
- * @typedef {import('multi-core-indexer').IndexEvents} IndexEvents
- */
 /**
  * @typedef {import('@mapeo/schema').MapeoDoc} MapeoDoc
  */
@@ -14,9 +12,14 @@ import { discoveryKey } from 'hypercore-crypto'
  * @typedef {import('../datatype/index.js').MapeoDocTablesMap} MapeoDocTablesMap
  */
 /**
- * @typedef {object} DefaultEmitterEvents
- * @property {(eventName: keyof IndexEvents, listener: (...args: any[]) => any) => void} newListener
- * @property {(eventName: keyof IndexEvents, listener: (...args: any[]) => any) => void} removeListener
+ * For each schemaName in this dataStore, emits an array of docIds that have
+ * been indexed whenever indexing finishes (becomes idle). `projectSettings`
+ * currently not supported.
+ *
+ * @template {MapeoDoc['schemaName']} TSchemaName
+ * @typedef {{
+ *   [S in Exclude<TSchemaName, 'projectSettings'>]: (docIds: Set<string>) => void
+ * }} DataStoreEvents
  */
 /**
  * @template T
@@ -37,7 +40,7 @@ const NAMESPACE_SCHEMAS = /** @type {const} */ ({
 /**
  * @template {keyof NamespaceSchemas} [TNamespace=keyof NamespaceSchemas]
  * @template {NamespaceSchemas[TNamespace][number]} [TSchemaName=NamespaceSchemas[TNamespace][number]]
- * @extends {TypedEmitter<IndexEvents & DefaultEmitterEvents>}
+ * @extends {TypedEmitter<DataStoreEvents<TSchemaName>>}
  */
 export class DataStore extends TypedEmitter {
   #coreManager
@@ -49,12 +52,14 @@ export class DataStore extends TypedEmitter {
   #pendingIndex = new Map()
   /** @type {Set<import('p-defer').DeferredPromise<void>['promise']>} */
   #pendingAppends = new Set()
+  /** @type {Record<MapeoDoc['schemaName'], Set<string>>} */
+  #pendingEmits
 
   /**
    * @param {object} opts
    * @param {import('../core-manager/index.js').CoreManager} opts.coreManager
    * @param {TNamespace} opts.namespace
-   * @param {(entries: MultiCoreIndexer.Entry<'binary'>[]) => Promise<void>} opts.batch
+   * @param {(entries: MultiCoreIndexer.Entry<'binary'>[]) => Promise<import('../index-writer/index.js').IndexedDocIds>} opts.batch
    * @param {MultiCoreIndexer.StorageParam} opts.storage
    */
   constructor({ coreManager, namespace, batch, storage }) {
@@ -62,6 +67,10 @@ export class DataStore extends TypedEmitter {
     this.#coreManager = coreManager
     this.#namespace = namespace
     this.#batch = batch
+    this.#pendingEmits = createMap(
+      NAMESPACE_SCHEMAS[namespace],
+      () => new Set()
+    )
     this.#writerCore = coreManager.getWriterCore(namespace).core
     const cores = coreManager.getCores(namespace).map((cr) => cr.core)
     this.#coreIndexer = new MultiCoreIndexer(cores, {
@@ -72,16 +81,7 @@ export class DataStore extends TypedEmitter {
       if (coreRecord.namespace !== namespace) return
       this.#coreIndexer.addCore(coreRecord.core)
     })
-
-    // Forward events from coreIndexer
-    this.on('newListener', (eventName, listener) => {
-      if (['newListener', 'removeListener'].includes(eventName)) return
-      this.#coreIndexer.on(eventName, listener)
-    })
-    this.on('removeListener', (eventName, listener) => {
-      if (['newListener', 'removeListener'].includes(eventName)) return
-      this.#coreIndexer.off(eventName, listener)
-    })
+    this.#coreIndexer.on('idle', this.#handleIndexerIdle)
   }
 
   get indexer() {
@@ -110,7 +110,7 @@ export class DataStore extends TypedEmitter {
    * @param {MultiCoreIndexer.Entry<'binary'>[]} entries
    */
   async #handleEntries(entries) {
-    await this.#batch(entries)
+    const indexed = await this.#batch(entries)
     await Promise.all(this.#pendingAppends)
     // Writes to the writerCore need to wait until the entry is indexed before
     // returning, so we check if any incoming entry has a pending promise
@@ -123,6 +123,18 @@ export class DataStore extends TypedEmitter {
       const pending = this.#pendingIndex.get(versionId)
       if (!pending) continue
       pending.resolve()
+    }
+    for (const schemaName of this.schemas) {
+      // Unsupported initially
+      if (schemaName === 'projectSettings') continue
+      const docIds = indexed[schemaName]
+      if (!docIds) continue
+      for (const docId of docIds) {
+        // We'll only emit these once the indexer is idle - a particular docId
+        // could have many updates, and we only emit it once after indexing
+        // @ts-ignore
+        this.#pendingEmits[schemaName].add(docId)
+      }
     }
   }
 
@@ -206,5 +218,15 @@ export class DataStore extends TypedEmitter {
     const block = await coreRecord.core.get(index, { wait: false })
     if (!block) throw new Error('Not Found')
     return block
+  }
+
+  #handleIndexerIdle = () => {
+    for (const eventName of this.eventNames()) {
+      const docIds = this.#pendingEmits[eventName]
+      if (!docIds.size) continue
+      // @ts-ignore - I'm pretty sure TS is just not smart enough here, it's not me!
+      this.emit(eventName, docIds)
+      docIds.clear()
+    }
   }
 }

--- a/src/datatype/index.d.ts
+++ b/src/datatype/index.d.ts
@@ -12,6 +12,7 @@ import { type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import { SQLiteSelectBuilder } from 'drizzle-orm/sqlite-core'
 import { RunResult } from 'better-sqlite3'
 import type Hypercore from 'hypercore'
+import { TypedEmitter } from 'tiny-typed-emitter'
 
 type MapeoDocTableName = `${MapeoDoc['schemaName']}Table`
 type GetMapeoDocTables<T> = T[keyof T & MapeoDocTableName]
@@ -24,6 +25,9 @@ type MapeoDocTablesMap = {
     MapeoDocTables,
     { _: { name: K } }
   >
+}
+export interface DataTypeEvents<TDoc extends MapeoDoc> {
+  'updated-docs': (docs: TDoc[]) => void
 }
 
 export const kCreateWithDocId: unique symbol
@@ -45,7 +49,7 @@ export class DataType<
   TSchemaName extends TTable['_']['name'],
   TDoc extends MapeoDocMap[TSchemaName],
   TValue extends MapeoValueMap[TSchemaName]
-> {
+> extends TypedEmitter<DataTypeEvents<TDoc>> {
   constructor({
     dataStore,
     table,

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { validate } from '@mapeo/schema'
 import { getTableConfig } from 'drizzle-orm/sqlite-core'
-import { eq, placeholder } from 'drizzle-orm'
+import { eq, inArray, placeholder } from 'drizzle-orm'
 import { randomBytes } from 'node:crypto'
 import { deNullify } from '../utils.js'
 import crypto from 'hypercore-crypto'
+import { TypedEmitter } from 'tiny-typed-emitter'
 
 /**
  * @typedef {import('@mapeo/schema').MapeoDoc} MapeoDoc
@@ -37,6 +38,11 @@ import crypto from 'hypercore-crypto'
  * @template {keyof any} K
  * @typedef {T extends any ? Omit<T, K> : never} OmitUnion
  */
+/**
+ * @template {MapeoDoc} TDoc
+ * @typedef {object} DataTypeEvents
+ * @property {(docs: TDoc[]) => void} updated-docs
+ */
 
 function generateId() {
   return randomBytes(32).toString('hex')
@@ -54,8 +60,9 @@ export const kTable = Symbol('table')
  * @template {MapeoDocTablesMap[TSchemaName]} TTable
  * @template {Exclude<MapeoDocMap[TSchemaName], { schemaName: 'coreOwnership' }>} TDoc
  * @template {Exclude<MapeoValueMap[TSchemaName], { schemaName: 'coreOwnership' }>} TValue
+ * @extends {TypedEmitter<DataTypeEvents<TDoc> & import('../types.js').DefaultEmitterEvents<DataTypeEvents<TDoc>>>}
  */
-export class DataType {
+export class DataType extends TypedEmitter {
   #dataStore
   #table
   #getPermissions
@@ -72,6 +79,7 @@ export class DataType {
    * @param {() => any} [opts.getPermissions]
    */
   constructor({ dataStore, table, getPermissions, db }) {
+    super()
     this.#dataStore = dataStore
     this.#table = table
     this.#schemaName = /** @type {TSchemaName} */ (getTableConfig(table).name)
@@ -85,6 +93,19 @@ export class DataType {
         .prepare(),
       getMany: db.select().from(table).prepare(),
     }
+    this.on('newListener', (eventName) => {
+      if (eventName !== 'updated-docs') return
+      if (this.listenerCount('updated-docs') > 1) return
+      if (this.#schemaName === 'projectSettings') return
+      // Avoid adding a listener to the dataStore unless we need to (e.g. this has a listener attached), for performance reasons.
+      this.#dataStore.on(this.#schemaName, this.#handleDataStoreUpdate)
+    })
+    this.on('removeListener', (eventName) => {
+      if (eventName !== 'updated-docs') return
+      if (this.listenerCount('updated-docs') > 0) return
+      if (this.#schemaName === 'projectSettings') return
+      this.#dataStore.off(this.#schemaName, this.#handleDataStoreUpdate)
+    })
   }
 
   get [kTable]() {
@@ -235,5 +256,21 @@ export class DataType {
       throw new Error('Updated docs must have the same docId and schemaName')
     }
     return { docId, createdAt, createdBy }
+  }
+
+  /**
+   * @param {Set<string>} docIds
+   */
+  #handleDataStoreUpdate = (docIds) => {
+    if (this.listenerCount('updated-docs') === 0) return
+    const updatedDocs = /** @type {TDoc[]} */ (
+      this.#db
+        .select()
+        .from(this.#table)
+        .where(inArray(this.#table.docId, [...docIds]))
+        .all()
+        .map((doc) => deNullify(doc))
+    )
+    this.emit('updated-docs', updatedDocs)
   }
 }

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -365,11 +365,14 @@ export class MapeoProject {
         // Ignore errors thrown by values that can't be decoded for now
       }
     }
-
-    await Promise.all([
+    // TODO: Note that docs indexed to the shared index writer (project
+    // settings) are not currently returned here, so it is not possible to
+    // subscribe to updates for projectSettings
+    const [indexed] = await Promise.all([
       projectIndexWriter.batch(otherEntries),
       sharedIndexWriter.batch(projectSettingsEntries),
     ])
+    return indexed
   }
 
   get observation() {

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -1,6 +1,7 @@
 import mapObject from 'map-obj'
 import { NAMESPACES } from '../core-manager/index.js'
 import { Logger } from '../logger.js'
+import { createMap } from '../utils.js'
 
 /**
  * @typedef {import('../core-manager/index.js').Namespace} Namespace
@@ -304,11 +305,7 @@ function getSyncStatus(peerId, state) {
 /**
  * @template T
  * @param {T} value
- * @returns {Record<Namespace, T>} */
+ **/
 function createNamespaceMap(value) {
-  const map = /** @type {Record<Namespace, T>} */ ({})
-  for (const ns of NAMESPACES) {
-    map[ns] = value
-  }
-  return map
+  return createMap(NAMESPACES, value)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ import MultiCoreIndexer from 'multi-core-indexer'
 import Corestore from 'corestore'
 import Hypercore from 'hypercore'
 import RandomAccessStorage from 'random-access-storage'
+import { DefaultListener, ListenerSignature } from 'tiny-typed-emitter'
 
 type SupportedBlobVariants = typeof SUPPORTED_BLOB_VARIANTS
 export type BlobType = keyof SupportedBlobVariants
@@ -184,3 +185,10 @@ export type Entries<T> = {
 }[keyof T][]
 
 export type CoreStorage = (name: string) => RandomAccessStorage
+
+export type DefaultEmitterEvents<
+  L extends ListenerSignature<L> = DefaultListener
+> = {
+  newListener: (event: keyof L, listener: L[keyof L]) => void
+  removeListener: (event: keyof L, listener: L[keyof L]) => void
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,3 +139,19 @@ export function projectIdToNonce(projectId) {
 export function getDeviceId(keyManager) {
   return keyManager.getIdentityKeypair().publicKey.toString('hex')
 }
+
+/**
+ * Small helper to create a typed map
+ *
+ * @template {string} K
+ * @template {any} V
+ * @param {ReadonlyArray<K>} keys
+ * @param {V} value
+ * @returns {Record<K, V extends () => infer T ? T : V>} */
+export function createMap(keys, value) {
+  const map = /** @type {Record<K, V extends () => infer T ? T : V>} */ ({})
+  for (const key of keys) {
+    map[key] = typeof value === 'function' ? value() : value
+  }
+  return map
+}

--- a/test-types/data-types.ts
+++ b/test-types/data-types.ts
@@ -67,6 +67,10 @@ const observationByVersionId = await mapeoProject.observation.getByVersionId(
 )
 Expect<Equal<Observation, typeof observationByVersionId>>
 
+mapeoProject.observation.on('updated-docs', (docs) => {
+  Expect<Equal<Observation[], typeof docs>>
+})
+
 ///// Presets
 
 const createdPreset = await mapeoProject.preset.create({} as PresetValue)
@@ -84,6 +88,10 @@ Expect<Equal<Preset & { forks: string[] }, typeof presetByDocId>>
 const presetByVersionId = await mapeoProject.preset.getByVersionId('abc')
 Expect<Equal<Preset, typeof presetByVersionId>>
 
+mapeoProject.preset.on('updated-docs', (docs) => {
+  Expect<Equal<Preset[], typeof docs>>
+})
+
 ///// Fields
 
 const createdField = await mapeoProject.field.create({} as FieldValue)
@@ -100,3 +108,7 @@ Expect<Equal<Field & { forks: string[] }, typeof fieldByDocId>>
 
 const fieldByVersionId = await mapeoProject.field.getByVersionId('abc')
 Expect<Equal<Field, typeof fieldByVersionId>>
+
+mapeoProject.field.on('updated-docs', (docs) => {
+  Expect<Equal<Field[], typeof docs>>
+})


### PR DESCRIPTION
Emits an array of updated docs for the data type whenever the docs
update (rather than emitting one doc at a time, it waits for indexing to
complete, then emits all the docs that have been updated. If there are
several updates to a particular docId, then only the resolved `head`
version is returned).

Attaching this listener to a data type that has many values / is
frequently updated will have a performance impact, because large amounts
of data could be read from the database and there is no limit, e.g. if
this was attached to the `observation` dataType and a new device synced
with a project with 10,000 observations, an attached listener would be
called with 10,000 observations.

The main reason for this feature is for internal use for capabilities,
listening for changes and modifying permissions accordingly, initially in order to implement #268, which requires adding cores as device capabilities are updated.

