### PR TITLE
rename MapeoManager.start() and MapeoManager.stop() methods

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -641,11 +641,11 @@ export class MapeoManager extends TypedEmitter {
   /**
    * @param {import('./media-server.js').StartOpts} [opts]
    */
-  async start(opts) {
+  async startMediaServer(opts) {
     await this.#mediaServer.start(opts)
   }
 
-  async stop() {
+  async stopMediaServer() {
     await this.#mediaServer.stop()
   }
 

--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from 'brittle'
 import { randomBytes, createHash } from 'crypto'
 import { KeyManager } from '@mapeo/crypto'
@@ -287,25 +288,6 @@ test('Consistent storage folders', async (t) => {
 
   // @ts-ignore snapshot() is missing from typedefs
   t.snapshot(storageNames.sort())
-})
-
-test('manager.start() and manager.stop()', async (t) => {
-  const manager = new MapeoManager({
-    rootKey: KeyManager.generateRootKey(),
-    projectMigrationsFolder,
-    clientMigrationsFolder,
-    dbFolder: ':memory:',
-    coreStorage: () => new RAM(),
-  })
-
-  await manager.start()
-  await manager.start()
-  await manager.stop()
-
-  await manager.start()
-  await manager.stop()
-
-  t.pass('start() and stop() life cycle runs without issues')
 })
 
 /**


### PR DESCRIPTION
Closes https://github.com/digidem/mapeo-core-next/issues/391

Renames them to `startMediaServer()` and `stopMediaServer()`, respectively