### PR TITLE
feat: throw an Error when creating with an existing docId

### DIFF
--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -123,21 +123,24 @@ export class DataType extends TypedEmitter {
   async create(value) {
     const docId = generateId()
     // @ts-expect-error - can't figure this one out, types in index.d.ts override this
-    return this[kCreateWithDocId](docId, value)
+    return this[kCreateWithDocId](docId, value, { checkExisting: false })
   }
 
   /**
    * @param {string} docId
    * @param {TValue | import('../types.js').CoreOwnershipWithSignaturesValue} value
+   * @param {{ checkExisting?: boolean }} [opts] - only used internally to skip the checkExisting check when creating a document with a random ID (collisions should be too small probability to be worth checking for)
    */
-  async [kCreateWithDocId](docId, value) {
+  async [kCreateWithDocId](docId, value, { checkExisting = true } = {}) {
     if (!validate(this.#schemaName, value)) {
       // TODO: pass through errors from validate functions
       throw new Error('Invalid value ' + value)
     }
-    const existing = await this.getByDocId(docId).catch(noop)
-    if (existing) {
-      throw new Error('Doc with docId ' + docId + ' already exists')
+    if (checkExisting) {
+      const existing = await this.getByDocId(docId).catch(noop)
+      if (existing) {
+        throw new Error('Doc with docId ' + docId + ' already exists')
+      }
     }
     const nowDateString = generateDate()
     const discoveryId =

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -135,10 +135,14 @@ export class DataType extends TypedEmitter {
       // TODO: pass through errors from validate functions
       throw new Error('Invalid value ' + value)
     }
+    const existing = await this.getByDocId(docId).catch(noop)
+    if (existing) {
+      throw new Error('Doc with docId ' + docId + ' already exists')
+    }
     const nowDateString = generateDate()
-    const discoveryId = crypto
-      .discoveryKey(this.#dataStore.writerCore.key)
-      .toString('hex')
+    const discoveryId =
+      this.#dataStore.writerCore.discoveryKey?.toString('hex') ||
+      crypto.discoveryKey(this.#dataStore.writerCore.key).toString('hex')
 
     /** @type {OmitUnion<MapeoDoc, 'versionId'>} */
     const doc = {
@@ -274,3 +278,5 @@ export class DataType extends TypedEmitter {
     this.emit('updated-docs', updatedDocs)
   }
 }
+
+function noop() {}

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -58,6 +58,39 @@ test('private createWithDocId() method', async (t) => {
   t.is(read.docId, customId)
 })
 
+test('private createWithDocId() method throws when doc exists', async (t) => {
+  const sqlite = new Database(':memory:')
+  const db = drizzle(sqlite)
+  migrate(db, {
+    migrationsFolder: new URL('../drizzle/project', import.meta.url).pathname,
+  })
+
+  const coreManager = createCoreManager()
+  const indexWriter = new IndexWriter({
+    tables: [observationTable],
+    sqlite,
+  })
+  const dataStore = new DataStore({
+    coreManager,
+    namespace: 'data',
+    batch: async (entries) => {
+      return indexWriter.batch(entries)
+    },
+    storage: () => new RAM(),
+  })
+  const dataType = new DataType({
+    dataStore,
+    table: observationTable,
+    db,
+  })
+  const customId = randomBytes(8).toString('hex')
+  await dataType[kCreateWithDocId](customId, obsFixture)
+  await t.exception(
+    () => dataType[kCreateWithDocId](customId, obsFixture),
+    'Throws with error creating a doc with an id that already exists'
+  )
+})
+
 test('test validity of `createdBy` field', async (t) => {
   const projectKey = randomBytes(32)
   const { dataType: dt1, dataStore: ds1 } = await testenv({ projectKey })


### PR DESCRIPTION
The internal `dataType[kCreateWithDocId]()` method should not allow you to create two documents with the same `docId`. This creates a "fork", which can lead to unexpected behaviour. The existing doc should be updated instead with `dataType.update()`.

This PR checks if there is an existing document with the given docId and throws if it exists.