### PR TITLE
Chore: expose icon data type

### DIFF
--- a/src/icon-api.js
+++ b/src/icon-api.js
@@ -127,6 +127,10 @@ export class IconApi {
       })
     )
   }
+
+  get dataType() {
+    return this.#dataType
+  }
 }
 
 /**


### PR DESCRIPTION
this PR exposes `dataType`  on the `iconApi` , mostly so we can `getById` and `delete` icons (i.e. when importing a new config we delete every field, preset and icon to avoid duplicate stuff).
We could only expose `.getByVersionId` and `delete` instead of exposing all of `dataType`
