### PR TITLE
feat: add method for deleting core data from storage

### DIFF
--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -478,6 +478,25 @@ export class CoreManager extends TypedEmitter {
     })
     return this.#corestore.replicate(stream)
   }
+
+  /**
+   * @param {Exclude<typeof NAMESPACES[number], 'auth'>} namespace
+   * @param {Object} [opts]
+   * @param {boolean} [opts.deleteOwn=false]
+   */
+  async deleteData(namespace, { deleteOwn = false } = {}) {
+    const coreRecords = this.getCores(namespace)
+    const ownWriterCore = this.getWriterCore(namespace)
+
+    const deletionPromises = []
+
+    for (const { core, key } of coreRecords) {
+      if (!deleteOwn && key === ownWriterCore.key) continue
+      deletionPromises.push(core.purge())
+    }
+
+    return Promise.all(deletionPromises)
+  }
 }
 
 /**

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -491,7 +491,7 @@ export class CoreManager extends TypedEmitter {
     const deletionPromises = []
 
     for (const { core, key } of coreRecords) {
-      if (!deleteOwn && key === ownWriterCore.key) continue
+      if (!deleteOwn && key.equals(ownWriterCore.key)) continue
       deletionPromises.push(core.purge())
     }
 

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -483,6 +483,7 @@ export class CoreManager extends TypedEmitter {
    * @param {Exclude<typeof NAMESPACES[number], 'auth'>} namespace
    * @param {Object} [opts]
    * @param {boolean} [opts.deleteOwn=false]
+   * @returns {Promise<void>}
    */
   async deleteData(namespace, { deleteOwn = false } = {}) {
     const coreRecords = this.getCores(namespace)

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -495,7 +495,7 @@ export class CoreManager extends TypedEmitter {
       deletionPromises.push(core.purge())
     }
 
-    return Promise.all(deletionPromises)
+    await Promise.all(deletionPromises)
   }
 }
 

--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'brittle'
 import { access, constants } from 'node:fs/promises'
 import NoiseSecretStream from '@hyperswarm/secret-stream'


### PR DESCRIPTION
Towards #241 . Extracted from #410 

Implements a `CoreManager.deleteData()` method for deleting data from cores for a given namespace. By default, it will not delete data that resides in its writer core but that can be changed using the `deleteOwn` opt.