### PR TITLE
fix!: delete() by docId not versionId(s)

### DIFF
--- a/src/datatype/index.d.ts
+++ b/src/datatype/index.d.ts
@@ -95,5 +95,5 @@ export class DataType<
     >
   >(versionId: string | string[], value: T): Promise<TDoc & { forks: string[] }>
 
-  delete(versionId: string | string[]): Promise<TDoc & { forks: string[] }>
+  delete(docId: string): Promise<TDoc & { forks: string[] }>
 }

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -208,7 +208,6 @@ export class DataType extends TypedEmitter {
   }
 
   /**
-   * Not yet implemented
    * @param {string} docId
    */
   async delete(docId) {

--- a/test-types/data-types.ts
+++ b/test-types/data-types.ts
@@ -71,6 +71,9 @@ mapeoProject.observation.on('updated-docs', (docs) => {
   Expect<Equal<Observation[], typeof docs>>
 })
 
+const deletedObservation = await mapeoProject.observation.delete('abc')
+Expect<Equal<Observation & { forks: string[] }, typeof deletedObservation>>
+
 ///// Presets
 
 const createdPreset = await mapeoProject.preset.create({} as PresetValue)

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -146,7 +146,7 @@ test('delete()', async (t) => {
   const { dataType } = await testenv({ projectKey })
   const doc = await dataType.create(obsFixture)
   t.is(doc.deleted, false, `'deleted' field is false before deletion`)
-  const deletedDoc = await dataType.delete(doc.versionId)
+  const deletedDoc = await dataType.delete(doc.docId)
   t.is(deletedDoc.deleted, true, `'deleted' field is true after deletion`)
   t.alike(
     deletedDoc.links,


### PR DESCRIPTION
Fixes "`dataType.delete()` should use `docId` not `versionId`" (#422)

The deletion document links to all forks, if forks exist.