### PR TITLE
chore: don't run Prettier on generated files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+/drizzle/*/meta/
+/src/generated/


### PR DESCRIPTION
This adds a [.prettierignore](https://prettier.io/docs/en/ignore.html#ignoring-files-prettierignore) to prevent formatting of generated files.

Fixes #216.