### PR TITLE
fix: remove stale project reference in manager when leaving a project

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -726,6 +726,8 @@ export class MapeoManager extends TypedEmitter {
       .delete(projectSettingsTable)
       .where(eq(projectSettingsTable.docId, projectId))
       .run()
+
+    this.#activeProjects.delete(projectPublicId)
   }
 }
 

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -278,3 +278,5 @@ test('Data access after leaving project', async (t) => {
 
   await disconnectPeers(managers)
 })
+
+// TODO: Add test for leaving and rejoining a project


### PR DESCRIPTION
I _think_ this is needed in order to avoid some bugs related to using a stale project reference. Also have a todo to write an e2e test for leaving and then rejoining, since my early attempt has not been successful 🤔 (which may highlight other issues?)