### PR TITLE
chore: add types for nanobench

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@types/b4a": "^1.6.0",
         "@types/debug": "^4.1.8",
         "@types/json-schema": "^7.0.11",
+        "@types/nanobench": "^3.0.0",
         "@types/node": "^18.16.3",
         "@types/sinonjs__fake-timers": "^8.1.2",
         "@types/streamx": "^2.9.1",
@@ -937,6 +938,12 @@
       "version": "0.7.31",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/nanobench": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nanobench/-/nanobench-3.0.0.tgz",
+      "integrity": "sha512-ZLUczwWDAdILwoIigOJYHsuecrKqxq8tY3uVCgWLUkFNYIIIYQcFhrVwCOkDLDYOoXbwhxgfCWjszmHUEBGHMA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.16.19",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/b4a": "^1.6.0",
     "@types/debug": "^4.1.8",
     "@types/json-schema": "^7.0.11",
+    "@types/nanobench": "^3.0.0",
     "@types/node": "^18.16.3",
     "@types/sinonjs__fake-timers": "^8.1.2",
     "@types/streamx": "^2.9.1",

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -4,7 +4,6 @@
 // - KeyPair
 // - DhtNode
 
-declare module 'nanobench'
 declare module 'sodium-universal'
 declare module 'sub-encoder'
 


### PR DESCRIPTION
Types for nanobench were [recently added to DefinitelyTyped][0], so we can use them.

The `benchmarks` directory is not currently type-checked, so this change has no impact, but it should make it easier to type-check in the future.

[0]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68221
