### PR TITLE
chore: prefer `net.isIPv4` over custom function

### DIFF
--- a/src/discovery/dns-sd.js
+++ b/src/discovery/dns-sd.js
@@ -1,6 +1,7 @@
 import { TypedEmitter } from 'tiny-typed-emitter'
 import { Bonjour } from 'bonjour-service'
 import pTimeout from 'p-timeout'
+import { isIPv4 } from 'node:net'
 import { randomBytes } from 'node:crypto'
 import { once } from 'node:events'
 import { Logger } from '../logger.js'
@@ -39,7 +40,7 @@ export class DnsSd extends TypedEmitter {
       this.#log(`Ignoring service up from self`)
       return
     }
-    const address = service.addresses?.filter(isIpv4)[0]
+    const address = service.addresses?.filter(isIPv4)[0]
     /* c8 ignore start */
     if (!address) {
       this.#log(`service up (${service.name}) with no ipv4 addresses`)
@@ -56,7 +57,7 @@ export class DnsSd extends TypedEmitter {
       this.#log(`Ignoring service down from self`)
       return
     }
-    const address = service.addresses?.filter(isIpv4)[0]
+    const address = service.addresses?.filter(isIPv4)[0]
     /* c8 ignore start */
     if (!address) {
       this.#log(`service down (${service.name}) with no ipv4 addresses`)
@@ -227,13 +228,4 @@ export class DnsSd extends TypedEmitter {
     )
     return this.#bonjour
   }
-}
-
-/**
- * Returns true if the given ip is an ipv4 address
- * @param {string} ip
- * @returns {boolean}
- */
-function isIpv4(ip) {
-  return ip.split('.').length === 4
 }


### PR DESCRIPTION
This replaces our custom `isIpv4` function with [`net.isIPv4`][0], which is built into Node.

`net.isIPv4` is stricter than ours (see [Node's source][1]), but it's the same basic thing.

[0]: https://nodejs.org/api/net.html#netisipv4input
[1]: https://github.com/nodejs/node/blob/f820efe0851dd3c64d673156b037ce7e8648fd81/lib/internal/net.js#L31-L36