### PR TITLE
feat: add functionality to serve offline fallback map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "husky": "^8.0.0",
         "light-my-request": "^5.10.0",
         "lint-staged": "^14.0.1",
+        "mapeo-offline-map": "^2.0.0",
         "math-random-seed": "^2.0.0",
         "nanobench": "^3.0.0",
         "npm-run-all": "^4.1.5",
@@ -5017,6 +5018,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/mapeo-offline-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mapeo-offline-map/-/mapeo-offline-map-2.0.0.tgz",
+      "integrity": "sha512-/a2BVgSwcL0EGqNxc7MWaApEJ0uLxr/scaZimd/2RvihDtvaNsLQurHIAjXJnY5lj4to5fBFBpcWXntdZoRBdg==",
+      "dev": true
     },
     "node_modules/marked": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "husky": "^8.0.0",
     "light-my-request": "^5.10.0",
     "lint-staged": "^14.0.1",
+    "mapeo-offline-map": "^2.0.0",
     "math-random-seed": "^2.0.0",
     "nanobench": "^3.0.0",
     "npm-run-all": "^4.1.5",

--- a/src/fastify-plugins/maps/offline-fallback-map.js
+++ b/src/fastify-plugins/maps/offline-fallback-map.js
@@ -1,0 +1,117 @@
+import path from 'path'
+import fs from 'fs/promises'
+import FastifyStatic from '@fastify/static'
+import fp from 'fastify-plugin'
+
+import {
+  NotFoundError,
+  createStyleJsonResponseHeaders,
+  getFastifyServerAddress,
+} from '../utils.js'
+
+export const PLUGIN_NAME = 'mapeo-static-maps'
+
+export const plugin = fp(offlineFallbackMapPlugin, {
+  fastify: '4.x',
+  name: PLUGIN_NAME,
+})
+
+/**
+ * @typedef {object} OfflineFallbackMapPluginOpts
+ * @property {string} [prefix]
+ * @property {string} styleJsonPath
+ * @property {string} sourcesDir
+ */
+
+/**
+ * @typedef {object} FallbackMapPluginDecorator
+ * @property {(serverAddress: string) => Promise<any>} getResolvedStyleJson
+ * @property {() => Promise<import('node:fs').Stats>} getStyleJsonStats
+ */
+
+/** @type {import('fastify').FastifyPluginAsync<OfflineFallbackMapPluginOpts>} */
+async function offlineFallbackMapPlugin(fastify, opts) {
+  const { styleJsonPath, sourcesDir } = opts
+
+  fastify.decorate(
+    'mapeoFallbackMap',
+    /** @type {FallbackMapPluginDecorator} */
+    ({
+      async getResolvedStyleJson(serverAddress) {
+        const rawStyleJson = await fs.readFile(styleJsonPath, 'utf-8')
+        const styleJson = JSON.parse(rawStyleJson)
+
+        const sources = styleJson.sources || {}
+
+        const sourcesDirFiles = await fs.readdir(sourcesDir, {
+          withFileTypes: true,
+        })
+
+        for (const file of sourcesDirFiles) {
+          // Only work with files
+          if (file.isDirectory()) continue
+
+          // Ignore the style.json file if it exists
+          if (file.name === 'style.json') continue
+
+          // Only work with json or geojson files
+          const extension = path.extname(file.name)
+          if (!(extension === '.json' || extension === '.geojson')) continue
+
+          const sourceName = path.basename(file.name, extension) + '-source'
+
+          sources[sourceName] = {
+            type: 'geojson',
+            data: new URL(`${opts.prefix || ''}/${file.name}`, serverAddress)
+              .href,
+          }
+        }
+
+        styleJson.sources = sources
+
+        return styleJson
+      },
+      async getStyleJsonStats() {
+        return fs.stat(styleJsonPath)
+      },
+    })
+  )
+
+  fastify.register(routes, {
+    prefix: opts.prefix,
+    styleJsonPath: opts.styleJsonPath,
+    sourcesDir: opts.sourcesDir,
+  })
+}
+
+/** @type {import('fastify').FastifyPluginAsync<OfflineFallbackMapPluginOpts, import('fastify').RawServerDefault, import('@fastify/type-provider-typebox').TypeBoxTypeProvider>} */
+async function routes(fastify, opts) {
+  const { sourcesDir } = opts
+
+  fastify.register(FastifyStatic, {
+    root: sourcesDir,
+    decorateReply: false,
+  })
+
+  fastify.get('/style.json', async (req, rep) => {
+    const serverAddress = await getFastifyServerAddress(req.server.server)
+
+    let stats, styleJson
+
+    try {
+      const results = await Promise.all([
+        fastify.mapeoFallbackMap.getStyleJsonStats(),
+        fastify.mapeoFallbackMap.getResolvedStyleJson(serverAddress),
+      ])
+
+      stats = results[0]
+      styleJson = results[1]
+    } catch (err) {
+      throw new NotFoundError(`id = fallback, style.json`)
+    }
+
+    rep.headers(createStyleJsonResponseHeaders(stats.mtime))
+
+    return styleJson
+  })
+}

--- a/src/fastify-plugins/maps/offline-fallback-map.js
+++ b/src/fastify-plugins/maps/offline-fallback-map.js
@@ -48,7 +48,7 @@ async function offlineFallbackMapPlugin(fastify, opts) {
         })
 
         for (const file of sourcesDirFiles) {
-          if (file.isDirectory()) continue
+          if (!file.isFile()) continue
 
           if (file.name === 'style.json') continue
 

--- a/src/fastify-plugins/maps/offline-fallback-map.js
+++ b/src/fastify-plugins/maps/offline-fallback-map.js
@@ -52,8 +52,7 @@ async function offlineFallbackMapPlugin(fastify, opts) {
 
           if (file.name === 'style.json') continue
 
-          // Only work with json or geojson files
-          const extension = path.extname(file.name)
+          const extension = path.extname(file.name).toLowerCase()
           if (!(extension === '.json' || extension === '.geojson')) continue
 
           const sourceName = path.basename(file.name, extension) + '-source'

--- a/src/fastify-plugins/maps/offline-fallback-map.js
+++ b/src/fastify-plugins/maps/offline-fallback-map.js
@@ -48,10 +48,8 @@ async function offlineFallbackMapPlugin(fastify, opts) {
         })
 
         for (const file of sourcesDirFiles) {
-          // Only work with files
           if (file.isDirectory()) continue
 
-          // Ignore the style.json file if it exists
           if (file.name === 'style.json') continue
 
           // Only work with json or geojson files

--- a/src/fastify-plugins/maps/offline-fallback-map.js
+++ b/src/fastify-plugins/maps/offline-fallback-map.js
@@ -71,7 +71,7 @@ async function offlineFallbackMapPlugin(fastify, opts) {
 
         return styleJson
       },
-      async getStyleJsonStats() {
+      getStyleJsonStats() {
         return fs.stat(styleJsonPath)
       },
     })

--- a/src/fastify-plugins/maps/static-maps.js
+++ b/src/fastify-plugins/maps/static-maps.js
@@ -7,7 +7,11 @@ import asar from '@electron/asar'
 import { Mime } from 'mime/lite'
 import standardTypes from 'mime/types/standard.js'
 
-import { NotFoundError, getFastifyServerAddress } from '../utils.js'
+import {
+  NotFoundError,
+  createStyleJsonResponseHeaders,
+  getFastifyServerAddress,
+} from '../utils.js'
 
 export const PLUGIN_NAME = 'mapeo-static-maps'
 
@@ -186,19 +190,9 @@ async function routes(fastify, opts) {
         throw new NotFoundError(`id = ${styleId}, style.json`)
       }
 
-      const styleJsonBytes = Buffer.from(styleJson)
+      rep.headers(createStyleJsonResponseHeaders(stats.mtime))
 
-      rep.headers({
-        'Content-Type': 'application/json; charset=utf-8',
-        'Cache-Control': 'max-age=' + 5 * 60, // 5 minutes
-        'Access-Control-Allow-Headers':
-          'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since',
-        'Access-Control-Allow-Origin': '*',
-        'Last-Modified': new Date(stats.mtime).toUTCString(),
-        'Content-Length': styleJsonBytes.length,
-      })
-
-      return styleJsonBytes
+      return styleJson
     }
   )
 

--- a/src/fastify-plugins/utils.js
+++ b/src/fastify-plugins/utils.js
@@ -37,3 +37,16 @@ export async function getFastifyServerAddress(server, { timeout } = {}) {
 
   return 'http://' + addr
 }
+
+/**
+ * @param {Date} lastModified
+ */
+export function createStyleJsonResponseHeaders(lastModified) {
+  return {
+    'Cache-Control': 'max-age=' + 5 * 60, // 5 minutes
+    'Access-Control-Allow-Headers':
+      'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since',
+    'Access-Control-Allow-Origin': '*',
+    'Last-Modified': new Date(lastModified).toUTCString(),
+  }
+}

--- a/src/fastify-plugins/utils.js
+++ b/src/fastify-plugins/utils.js
@@ -39,7 +39,7 @@ export async function getFastifyServerAddress(server, { timeout } = {}) {
 }
 
 /**
- * @param {Date} lastModified
+ * @param {Readonly<Date>} lastModified
  */
 export function createStyleJsonResponseHeaders(lastModified) {
   return {
@@ -47,6 +47,6 @@ export function createStyleJsonResponseHeaders(lastModified) {
     'Access-Control-Allow-Headers':
       'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since',
     'Access-Control-Allow-Origin': '*',
-    'Last-Modified': new Date(lastModified).toUTCString(),
+    'Last-Modified': lastModified.toUTCString(),
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 export { plugin as MapeoStaticMapsFastifyPlugin } from './fastify-plugins/maps/static-maps.js'
+export { plugin as MapeoOfflineFallbackMapFastifyPlugin } from './fastify-plugins/maps/offline-fallback-map.js'
+export { plugin as MapeoMapsFastifyPlugin } from './fastify-plugins/maps/index.js'
 export { FastifyController } from './fastify-controller.js'
 export { MapeoManager } from './mapeo-manager.js'

--- a/tests/fastify-plugins/offline-fallback-map.js
+++ b/tests/fastify-plugins/offline-fallback-map.js
@@ -1,0 +1,84 @@
+import path from 'node:path'
+import { test } from 'brittle'
+import Fastify from 'fastify'
+
+import { plugin as OfflineFallbackMapPlugin } from '../../src/fastify-plugins/maps/offline-fallback-map.js'
+
+const MAPEO_FALLBACK_MAP_PATH = new URL(
+  '../../node_modules/mapeo-offline-map',
+  import.meta.url
+).pathname
+
+test('decorator', async (t) => {
+  const server = setup(t)
+  await server.ready()
+  t.ok(server.hasDecorator('mapeoFallbackMap'), 'decorator is set up')
+})
+
+test('/style.json', async (t) => {
+  const server = setup(t)
+  const address = await server.listen()
+
+  const response = await server.inject({
+    method: 'GET',
+    url: '/style.json',
+  })
+
+  t.is(response.statusCode, 200)
+
+  const styleJson = response.json()
+
+  t.alike(
+    styleJson.sources,
+    {
+      'boundaries-source': {
+        type: 'geojson',
+        data: `${address}/boundaries.json`,
+      },
+      'graticule-source': {
+        type: 'geojson',
+        data: `${address}/graticule.json`,
+      },
+      'lakes-source': {
+        type: 'geojson',
+        data: `${address}/lakes.json`,
+      },
+      'land-source': {
+        type: 'geojson',
+        data: `${address}/land.json`,
+      },
+      'rivers-source': {
+        type: 'geojson',
+        data: `${address}/rivers.json`,
+      },
+    },
+    'expected `sources` field in response body'
+  )
+
+  for (const [sourceName, { data }] of Object.entries(styleJson.sources)) {
+    const response = await server.inject({
+      method: 'GET',
+      url: data,
+    })
+
+    t.is(response.statusCode, 200, `can reach ${sourceName}`)
+  }
+})
+
+/**
+ * @param {import('brittle').TestInstance} t
+ */
+function setup(t) {
+  const server = Fastify({ logger: false, forceCloseConnections: true })
+
+  server.register(OfflineFallbackMapPlugin, {
+    styleJsonPath: path.join(MAPEO_FALLBACK_MAP_PATH, 'style.json'),
+    sourcesDir: path.join(MAPEO_FALLBACK_MAP_PATH, 'dist'),
+  })
+
+  t.teardown(async () => {
+    await server.close()
+  })
+
+  return server
+}

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -1,9 +1,11 @@
 import fastify from 'fastify'
 
 import { StaticMapsPluginDecorator } from '../src/fastify-plugins/maps/static-maps.js'
+import { FallbackMapPluginDecorator } from '../src/fastify-plugins/maps/offline-fallback-map.js'
 
 declare module 'fastify' {
   export interface FastifyInstance {
+    mapeoFallbackMap: FallbackMapPluginDecorator
     mapeoStaticMaps: StaticMapsPluginDecorator
   }
 }


### PR DESCRIPTION
Towards #439 

Stacked on #435 

Implements a fastify plugin for serving a fallback map in the case of not having an available local "default" static map or being offline. The plugin accepts required options for specifying where the style definition lives and the directory containing the geojson sources (this provides flexibility for consumers that may not necessarily be using something like `mapeo-offline-map`, or happen to change the filesystem structure).


TODO:

- [ ] add documentation about the expected structure of the fallback map style definition and source files