### PR TITLE
feat: add method to MapeoManager for getting stable map style json url

### DIFF
--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -40,8 +40,22 @@ export const plugin = fp(mapsPlugin, {
  * @property {string} [defaultOnlineStyleUrl]
  */
 
+/**
+ * @typedef {object} MapsPluginContext
+ * @property {() => Promise<string>} getStyleJsonUrl
+ */
+
 /** @type {import('fastify').FastifyPluginAsync<MapsPluginOpts>} */
 async function mapsPlugin(fastify, opts) {
+  fastify.decorate('mapeoMaps', {
+    async getStyleJsonUrl() {
+      const base = await getFastifyServerAddress(fastify.server, {
+        timeout: 5000,
+      })
+
+      return new URL(`${opts.prefix || ''}/style.json`, base).href
+    },
+  })
   fastify.register(routes, {
     prefix: opts.prefix,
     defaultOnlineStyleUrl: opts.defaultOnlineStyleUrl,

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -7,6 +7,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import Hypercore from 'hypercore'
 import { TypedEmitter } from 'tiny-typed-emitter'
+import pTimeout from 'p-timeout'
 
 import { IndexWriter } from './index-writer/index.js'
 import {
@@ -793,6 +794,11 @@ export class MapeoManager extends TypedEmitter {
       .run()
 
     this.#activeProjects.delete(projectPublicId)
+  }
+
+  async getMapStyleJsonUrl() {
+    await pTimeout(this.#fastify.ready(), { milliseconds: 1000 })
+    return this.#fastify.mapeoMaps.getStyleJsonUrl()
   }
 }
 

--- a/test-e2e/manager-fastify-server.js
+++ b/test-e2e/manager-fastify-server.js
@@ -14,6 +14,7 @@ import { MapeoManager } from '../src/mapeo-manager.js'
 import { FastifyController } from '../src/fastify-controller.js'
 import { plugin as StaticMapsPlugin } from '../src/fastify-plugins/maps/static-maps.js'
 import { plugin as MapServerPlugin } from '../src/fastify-plugins/maps/index.js'
+import { plugin as OfflineFallbackMapPlugin } from '../src/fastify-plugins/maps/offline-fallback-map.js'
 
 const BLOB_FIXTURES_DIR = fileURLToPath(
   new URL('../tests/fixtures/blob-api/', import.meta.url)
@@ -21,6 +22,11 @@ const BLOB_FIXTURES_DIR = fileURLToPath(
 
 const MAP_FIXTURES_PATH = new URL('../tests/fixtures/maps', import.meta.url)
   .pathname
+
+const MAPEO_FALLBACK_MAP_PATH = new URL(
+  '../../node_modules/mapeo-offline-map',
+  import.meta.url
+).pathname
 
 const projectMigrationsFolder = new URL('../drizzle/project', import.meta.url)
   .pathname
@@ -296,6 +302,12 @@ test('retrieving style.json using stable url', async (t) => {
     prefix: 'static',
     staticRootDir: MAP_FIXTURES_PATH,
   })
+  fastify.register(OfflineFallbackMapPlugin, {
+    prefix: 'fallback',
+    styleJsonPath: join(MAPEO_FALLBACK_MAP_PATH, 'style.json'),
+    sourcesDir: join(MAPEO_FALLBACK_MAP_PATH, 'dist'),
+  })
+
   fastify.register(MapServerPlugin, {
     prefix: 'maps',
   })

--- a/tests/fastify-plugins/maps.js
+++ b/tests/fastify-plugins/maps.js
@@ -79,6 +79,12 @@ test('mapeoMaps decorator context', async (t) => {
     staticRootDir: MAP_FIXTURES_PATH,
   })
 
+  server.register(OfflineFallbackMapPlugin, {
+    prefix: 'fallback',
+    styleJsonPath: path.join(MAPEO_FALLBACK_MAP_PATH, 'style.json'),
+    sourcesDir: path.join(MAPEO_FALLBACK_MAP_PATH, 'dist'),
+  })
+
   server.register(MapServerPlugin, { prefix: 'maps' })
 
   const address = await server.listen()

--- a/tests/fastify-plugins/maps.js
+++ b/tests/fastify-plugins/maps.js
@@ -71,6 +71,26 @@ test('prefix opt is handled correctly', async (t) => {
   }
 })
 
+test('mapeoMaps decorator context', async (t) => {
+  const server = setup(t)
+
+  server.register(StaticMapsPlugin, {
+    prefix: 'static',
+    staticRootDir: MAP_FIXTURES_PATH,
+  })
+
+  server.register(MapServerPlugin, { prefix: 'maps' })
+
+  const address = await server.listen()
+
+  t.ok(server.hasDecorator('mapeoMaps'), 'decorator added')
+
+  t.test('mapeoMaps.getStyleJsonUrl()', async (st) => {
+    const styleJsonUrl = await server.mapeoMaps.getStyleJsonUrl()
+    st.is(styleJsonUrl, new URL('/maps/style.json', address).href)
+  })
+})
+
 test('/style.json resolves style.json of local "default" static map when available', async (t) => {
   const server = setup(t)
 

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -1,11 +1,13 @@
 import fastify from 'fastify'
 
+import { MapsPluginContext } from '../src/fastify-plugins/maps/index.js'
 import { StaticMapsPluginDecorator } from '../src/fastify-plugins/maps/static-maps.js'
 import { FallbackMapPluginDecorator } from '../src/fastify-plugins/maps/offline-fallback-map.js'
 
 declare module 'fastify' {
   export interface FastifyInstance {
     mapeoFallbackMap: FallbackMapPluginDecorator
+    mapeoMaps: MapsPluginContext
     mapeoStaticMaps: StaticMapsPluginDecorator
   }
 }


### PR DESCRIPTION
Closes #438

Stacked on #435 

Notes:

- updates the maps fastify plugin to decorate the fastify instance with a `mapeoMaps` context, which currently implements a method for getting the style json url
- this PR does not actually implement the endpoint that handles the returned url. that will be addressed in https://github.com/digidem/mapeo-core-next/issues/439