### PR TITLE
chore: don't delete own data when leaving a project

### DIFF
--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -477,18 +477,16 @@ export class CoreManager extends TypedEmitter {
 
   /**
    * @param {Exclude<typeof NAMESPACES[number], 'auth'>} namespace
-   * @param {Object} [opts]
-   * @param {boolean} [opts.deleteOwn=false]
    * @returns {Promise<void>}
    */
-  async deleteData(namespace, { deleteOwn = false } = {}) {
+  async deleteOthersData(namespace) {
     const coreRecords = this.getCores(namespace)
     const ownWriterCore = this.getWriterCore(namespace)
 
     const deletionPromises = []
 
     for (const { core, key } of coreRecords) {
-      if (!deleteOwn && key.equals(ownWriterCore.key)) continue
+      if (key.equals(ownWriterCore.key)) continue
       deletionPromises.push(core.purge())
     }
 

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -619,9 +619,10 @@ export class MapeoProject extends TypedEmitter {
       ])
 
     await Promise.all(
-      namespacesWithoutAuth.map((namespace) =>
-        this.#coreManager.deleteData(namespace, { deleteOwn: true })
-      )
+      namespacesWithoutAuth.flatMap((namespace) => [
+        this.#coreManager.getWriterCore(namespace).core.close(),
+        this.#coreManager.deleteOthersData(namespace),
+      ])
     )
 
     // TODO: 3. Clear data from indexes


### PR DESCRIPTION
When you leave a project, we no longer delete your own data (but still
close your writer Hypercore).

Because this was the last occurrence of `deleteOwn: false`, I removed
the option entirely.

Fixes #449.