### PR TITLE
feat: implement online style fetching for stable style resolving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "throttle-debounce": "^5.0.0",
         "tiny-typed-emitter": "^2.1.0",
         "type-fest": "^4.5.0",
+        "undici": "^6.7.0",
         "varint": "^6.0.0",
         "yauzl-promise": "^4.0.0"
       },
@@ -95,8 +96,7 @@
         "ts-proto": "^1.156.7",
         "typedoc": "^0.24.8",
         "typedoc-plugin-markdown": "^3.15.3",
-        "typescript": "^5.1.6",
-        "undici": "^6.7.0"
+        "typescript": "^5.1.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -243,22 +243,6 @@
         "@bufbuild/buf-win32-x64": "1.26.1"
       }
     },
-    "node_modules/@bufbuild/buf-darwin-arm64": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.26.1.tgz",
-      "integrity": "sha512-nmyWiT/59RFja0ZuXFxjNGoAMDPTApU66CZUUevkFVWbNB9nzeQDjx2vsJyACY64k5fTgZiaelSiyppwObQknw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@digidem/types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@digidem/types/-/types-2.2.0.tgz",
@@ -325,21 +309,6 @@
         "source-map-support": "^0.5.21"
       }
     },
-    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
       "version": "0.17.19",
       "dev": true,
@@ -383,21 +352,6 @@
       "dependencies": {
         "@esbuild-kit/core-utils": "^3.0.0",
         "get-tsconfig": "^4.4.0"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.17",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -510,7 +464,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
       "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -949,51 +902,6 @@
         "@node-rs/crc32-win32-x64-msvc": "1.7.2"
       }
     },
-    "node_modules/@node-rs/crc32-android-arm-eabi": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.7.2.tgz",
-      "integrity": "sha512-6IoXQTHt9U/1Ejz/MPbAk3mtcAGcS1WUvg2YfEtezLCmzbDpQO3OTA9fZpu3z2AhBuLHiKMKDVcfrWybRiWBJw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-android-arm64": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.7.2.tgz",
-      "integrity": "sha512-SMEd6cN+034LTv9kFmCGMZjBNTf39xXIcgqq05JM9A55ywUvXdoXnFOttrQ9x/iZgqANNU6Ms5uZCAJbNA2dZA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-darwin-arm64": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.7.2.tgz",
-      "integrity": "sha512-sPJisK5pyZ+iBs9KuGsvu0Z+Qshw4GvOgaHjPktQ+suz0p00Yts3zl5D6PpGaaW4EAKTo8zCUIlVEArV0vglvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@node-rs/crc32-darwin-x64": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.7.2.tgz",
@@ -1004,141 +912,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-freebsd-x64": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.7.2.tgz",
-      "integrity": "sha512-OgkxnkiGdztcBilm7m31Sb6zx89ghK4WpZz9WVVU86PIHQH0sfrZEebdomw6R7mMnQuqbnRwjTS5r1nchVMPzQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.7.2.tgz",
-      "integrity": "sha512-hTY83MQML8WrMnD3dmzjrcCn0Sqgw0w2wRc1Ji2dCaE0fDqra47W5KBQXx4hKZYFwNr5KreTqdvD3Ejf/mKzEA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-linux-arm64-gnu": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.7.2.tgz",
-      "integrity": "sha512-4p6DZ9YT+CBSi+72OclzI5hBin15brqrbLLHFePPl4AhAazg6+ReTv3C4DnyJqyL0ZHZamiA9zDtOlvHo0nk0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-linux-arm64-musl": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.7.2.tgz",
-      "integrity": "sha512-/shZkkNyDyDjaxU5rYFY4aoajLjBqdfKQYZCcA6XS27FiGzHQ3petgP0I5Zjm+Jf75G7gLT8NQXiQWIzkgo2xw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-linux-x64-gnu": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.7.2.tgz",
-      "integrity": "sha512-rzoqXqPLjx5sx8jzEg/xRAdBDkjnaM+D3Nrm9xJckHWzeeUB0FC0E4QGrdtqFo15lQ1GDVV/q6n93mLSK5vCkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-linux-x64-musl": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.7.2.tgz",
-      "integrity": "sha512-Hwim1Wc8LoNqG53qX8Dm3VY32ClbKWpdi9pkbJU4/aG5RFUfd3k/x9WSeATlBx+K36Tc1XsrWvbsf1eWwryEYA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-win32-arm64-msvc": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.7.2.tgz",
-      "integrity": "sha512-vj+HWzwy86wNBY+1vW+QPje/MrJppufGCYIisFwvghBzk6WtClNGEjbQqotieIxDNohcmHREQEeg8wY8PMCvew==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-win32-ia32-msvc": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.7.2.tgz",
-      "integrity": "sha512-YQQtPkHvqbMEJmaMzEH3diYHk0q9zWb+Tkzij9d4OZZzpt4HM6j8FuiIB37BJ0CQmgMiDZEBYsX3KOfYxxO0VA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/crc32-win32-x64-msvc": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.7.2.tgz",
-      "integrity": "sha512-DnluAFM6X8qsYVI1VaFQtI6ukigIQ2P4eVcEuNQ3d1lF5fs0RYAKY7Ajqrdk298TSGZ2joMiqfJksTHBsQoxtA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -8004,7 +7777,6 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.0.tgz",
       "integrity": "sha512-IcWssIyDN1gk6Mcae44q04oRoWTKrW8OKz0effVK1xdWwAgMPnfpxhn9RXUSL5JlwSikO18R7Ibk7Nukz6kxWA==",
-      "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,6 +243,22 @@
         "@bufbuild/buf-win32-x64": "1.26.1"
       }
     },
+    "node_modules/@bufbuild/buf-darwin-arm64": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.26.1.tgz",
+      "integrity": "sha512-nmyWiT/59RFja0ZuXFxjNGoAMDPTApU66CZUUevkFVWbNB9nzeQDjx2vsJyACY64k5fTgZiaelSiyppwObQknw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@digidem/types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@digidem/types/-/types-2.2.0.tgz",
@@ -309,6 +325,21 @@
         "source-map-support": "^0.5.21"
       }
     },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
       "version": "0.17.19",
       "dev": true,
@@ -352,6 +383,21 @@
       "dependencies": {
         "@esbuild-kit/core-utils": "^3.0.0",
         "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.17",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -902,6 +948,51 @@
         "@node-rs/crc32-win32-x64-msvc": "1.7.2"
       }
     },
+    "node_modules/@node-rs/crc32-android-arm-eabi": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.7.2.tgz",
+      "integrity": "sha512-6IoXQTHt9U/1Ejz/MPbAk3mtcAGcS1WUvg2YfEtezLCmzbDpQO3OTA9fZpu3z2AhBuLHiKMKDVcfrWybRiWBJw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm64": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.7.2.tgz",
+      "integrity": "sha512-SMEd6cN+034LTv9kFmCGMZjBNTf39xXIcgqq05JM9A55ywUvXdoXnFOttrQ9x/iZgqANNU6Ms5uZCAJbNA2dZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-arm64": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.7.2.tgz",
+      "integrity": "sha512-sPJisK5pyZ+iBs9KuGsvu0Z+Qshw4GvOgaHjPktQ+suz0p00Yts3zl5D6PpGaaW4EAKTo8zCUIlVEArV0vglvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@node-rs/crc32-darwin-x64": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.7.2.tgz",
@@ -912,6 +1003,141 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-freebsd-x64": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.7.2.tgz",
+      "integrity": "sha512-OgkxnkiGdztcBilm7m31Sb6zx89ghK4WpZz9WVVU86PIHQH0sfrZEebdomw6R7mMnQuqbnRwjTS5r1nchVMPzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.7.2.tgz",
+      "integrity": "sha512-hTY83MQML8WrMnD3dmzjrcCn0Sqgw0w2wRc1Ji2dCaE0fDqra47W5KBQXx4hKZYFwNr5KreTqdvD3Ejf/mKzEA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-gnu": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.7.2.tgz",
+      "integrity": "sha512-4p6DZ9YT+CBSi+72OclzI5hBin15brqrbLLHFePPl4AhAazg6+ReTv3C4DnyJqyL0ZHZamiA9zDtOlvHo0nk0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-musl": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.7.2.tgz",
+      "integrity": "sha512-/shZkkNyDyDjaxU5rYFY4aoajLjBqdfKQYZCcA6XS27FiGzHQ3petgP0I5Zjm+Jf75G7gLT8NQXiQWIzkgo2xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-gnu": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.7.2.tgz",
+      "integrity": "sha512-rzoqXqPLjx5sx8jzEg/xRAdBDkjnaM+D3Nrm9xJckHWzeeUB0FC0E4QGrdtqFo15lQ1GDVV/q6n93mLSK5vCkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-musl": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.7.2.tgz",
+      "integrity": "sha512-Hwim1Wc8LoNqG53qX8Dm3VY32ClbKWpdi9pkbJU4/aG5RFUfd3k/x9WSeATlBx+K36Tc1XsrWvbsf1eWwryEYA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-arm64-msvc": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.7.2.tgz",
+      "integrity": "sha512-vj+HWzwy86wNBY+1vW+QPje/MrJppufGCYIisFwvghBzk6WtClNGEjbQqotieIxDNohcmHREQEeg8wY8PMCvew==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-ia32-msvc": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.7.2.tgz",
+      "integrity": "sha512-YQQtPkHvqbMEJmaMzEH3diYHk0q9zWb+Tkzij9d4OZZzpt4HM6j8FuiIB37BJ0CQmgMiDZEBYsX3KOfYxxO0VA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-x64-msvc": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.7.2.tgz",
+      "integrity": "sha512-DnluAFM6X8qsYVI1VaFQtI6ukigIQ2P4eVcEuNQ3d1lF5fs0RYAKY7Ajqrdk298TSGZ2joMiqfJksTHBsQoxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"

--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
     "ts-proto": "^1.156.7",
     "typedoc": "^0.24.8",
     "typedoc-plugin-markdown": "^3.15.3",
-    "typescript": "^5.1.6",
-    "undici": "^6.7.0"
+    "typescript": "^5.1.6"
   },
   "dependencies": {
     "@digidem/types": "^2.2.0",
@@ -151,6 +150,7 @@
     "throttle-debounce": "^5.0.0",
     "tiny-typed-emitter": "^2.1.0",
     "type-fest": "^4.5.0",
+    "undici": "^6.7.0",
     "varint": "^6.0.0",
     "yauzl-promise": "^4.0.0"
   }

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -95,7 +95,7 @@ async function routes(fastify, opts) {
             return upstreamResponse.json()
           } else {
             fastify.log.error(
-              `Upstream style.json request failed: ${upstreamResponse.statusText}`
+              `Upstream style.json request failed: ${upstreamResponse.status} ${upstreamResponse.statusText}`
             )
           }
         } catch (err) {

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -110,11 +110,15 @@ async function routes(fastify, opts) {
 
           if (upstreamResponse.ok) {
             // Set up headers to forward
-            // TODO: Change this to an allow-list of headers instead of a block-list
             for (const [name, value] of upstreamResponse.headers) {
-              // We do our own content encoding
-              if (name.toLowerCase() === 'content-encoding') continue
-              rep.header(name, value)
+              // Only forward headers related to caching
+              // https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions
+              // e.g. usage from map renderer: https://github.com/maplibre/maplibre-gl-js/blob/26a7a6c2c142ef2e26db89f5fdf2338769494902/src/util/ajax.ts#L205
+              if (
+                ['age', 'cache-control', 'expires'].includes(name.toLowerCase())
+              ) {
+                rep.header(name, value)
+              }
             }
             // Some upstream providers will not set the 'application/json' content-type header despite the body being JSON e.g. Protomaps
             // TODO: Should we forward the upstream 'content-type' header?

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -99,7 +99,7 @@ async function routes(fastify, opts) {
 
         try {
           const upstreamResponse = await fetch(upstreamUrlObj.href, {
-            signal: AbortSignal.timeout(3000),
+            signal: AbortSignal.timeout(30_000),
           })
 
           if (upstreamResponse.ok) {

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -98,7 +98,9 @@ async function routes(fastify, opts) {
         }
 
         try {
-          const upstreamResponse = await fetch(upstreamUrlObj.href)
+          const upstreamResponse = await fetch(upstreamUrlObj.href, {
+            signal: AbortSignal.timeout(3000),
+          })
 
           if (upstreamResponse.ok) {
             // Set up headers to forward

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -99,7 +99,7 @@ async function routes(fastify, opts) {
             )
           }
         } catch (err) {
-          fastify.log.error(err)
+          fastify.log.warn('Upstream style.json request totally failed')
         }
       }
 
@@ -158,7 +158,7 @@ function styleUrlWithApiKey(url, key) {
       break
     }
     case 'basemapstyles-api.arcgis.com': {
-      // ArcGIS expects `token`: https://docs.maptiler.com/cloud/api/maps/
+      // ArcGIS expects `token`: https://developers.arcgis.com/documentation/mapping-apis-and-services/security/api-keys/
       paramToUpsert = 'token'
       break
     }

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -11,6 +11,8 @@ import { PLUGIN_NAME as MAPEO_STATIC_MAPS } from './static-maps.js'
 import { PLUGIN_NAME as MAPEO_OFFLINE_FALLBACK } from './offline-fallback-map.js'
 
 export const PLUGIN_NAME = 'mapeo-maps'
+export const DEFAULT_MAPBOX_STYLE_URL =
+  'https://api.mapbox.com/styles/v1/mapbox/outdoors-v12'
 
 export const plugin = fp(mapsPlugin, {
   fastify: '4.x',
@@ -22,21 +24,25 @@ export const plugin = fp(mapsPlugin, {
 /**
  * @typedef {object} MapsPluginOpts
  * @property {string} [prefix]
+ * @property {string} [defaultOnlineStyleUrl]
  */
 
 /** @type {import('fastify').FastifyPluginAsync<MapsPluginOpts>} */
 async function mapsPlugin(fastify, opts) {
   fastify.register(routes, {
     prefix: opts.prefix,
+    defaultOnlineStyleUrl: opts.defaultOnlineStyleUrl,
   })
 }
 
 const GetStyleJsonQueryStringSchema = T.Object({
-  access_token: T.Optional(T.String()),
+  api_key: T.Optional(T.String()),
 })
 
 /** @type {import('fastify').FastifyPluginAsync<MapsPluginOpts, import('fastify').RawServerDefault, import('@fastify/type-provider-typebox').TypeBoxTypeProvider>} */
-async function routes(fastify) {
+async function routes(fastify, opts) {
+  const { defaultOnlineStyleUrl = DEFAULT_MAPBOX_STYLE_URL } = opts
+
   fastify.get(
     '/style.json',
     { schema: { querystring: GetStyleJsonQueryStringSchema } },
@@ -64,9 +70,12 @@ async function routes(fastify) {
 
       // 2. Attempt to get a default style.json from online source
       {
-        const upstreamResponse = await fetch(
-          constructUpstreamStyleUrl(req.query.access_token)
-        ).catch((err) => {
+        const apiKey = req.query.api_key
+        const upstreamUrl = apiKey
+          ? styleUrlWithApiKey(defaultOnlineStyleUrl, apiKey)
+          : defaultOnlineStyleUrl
+
+        const upstreamResponse = await fetch(upstreamUrl).catch((err) => {
           fastify.log.error(err)
           return null
         })
@@ -80,6 +89,12 @@ async function routes(fastify) {
               if (key.toLowerCase() === 'content-encoding') continue
               rep.header(key, value)
             }
+            // Some upstream providers will not set the 'application/json' content-type header despite the body being JSON e.g. Protomaps
+            // TODO: Should we forward the upstream 'content-type' header?
+            // We kind of assume that a Style Spec-compatible JSON payload will always be used by a provider
+            // Tehcnically, there could be cases where a provider doesn't use the Mapbox Style Spec and has their own format,
+            // which may be delivered as some other content type
+            rep.header('content-type', 'application/json; charset=utf-8')
             return upstreamResponse.json()
           } else {
             fastify.log.error(
@@ -110,21 +125,53 @@ async function routes(fastify) {
   )
 }
 
-export const UPSTREAM_MAP_STYLE_URL =
-  'https://api.mapbox.com/styles/v1/mapbox/outdoors-v12'
-
 /**
- * @param {string} [accessToken]
+ * If `url` already contains a relevant api key query param, this function will overwrite it with `apiKey`.
+ *
+ * @param {string} url
+ * @param {string} apiKey
  * @returns {string}
  */
-function constructUpstreamStyleUrl(accessToken) {
-  const url = new URL(UPSTREAM_MAP_STYLE_URL)
+function styleUrlWithApiKey(url, apiKey) {
+  const u = new URL(url)
 
-  if (accessToken) {
-    url.search = new URLSearchParams({
-      access_token: accessToken,
-    }).toString()
+  const existingSearchParams = new URLSearchParams(u.search)
+
+  /** @type {string | null} */
+  let paramToUpsert = null
+
+  switch (u.hostname) {
+    case 'api.mapbox.com': {
+      // Mapbox expects `access_token`: https://docs.mapbox.com/api/maps/styles/
+      paramToUpsert = 'access_token'
+      break
+    }
+    case 'api.protomaps.com':
+    case 'api.maptiler.com': {
+      // Protomaps expects `key` (no docs link yet)
+      // MapTiler expects `key`: https://docs.maptiler.com/cloud/api/maps/
+      paramToUpsert = 'key'
+      break
+    }
+    case 'tiles.stadiamaps.com': {
+      // Stadia expects `api_key`: https://docs.stadiamaps.com/themes/
+      paramToUpsert = 'api_key'
+      break
+    }
+    case 'basemapstyles-api.arcgis.com': {
+      // ArcGIS expects `token`: https://docs.maptiler.com/cloud/api/maps/
+      paramToUpsert = 'token'
+      break
+    }
+    default: {
+      // TODO: Should there be a default? (e.g. self-hosted instances using something like https://openmaptiles.org/)
+    }
   }
 
-  return url.href
+  if (paramToUpsert) {
+    existingSearchParams.set(paramToUpsert, apiKey)
+    u.search = existingSearchParams.toString()
+  }
+
+  return u.href
 }

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -1,4 +1,6 @@
 import fp from 'fastify-plugin'
+import { Type as T } from '@sinclair/typebox'
+import { fetch } from 'undici'
 
 import {
   NotFoundError,
@@ -29,48 +31,100 @@ async function mapsPlugin(fastify, opts) {
   })
 }
 
+const GetStyleJsonQueryStringSchema = T.Object({
+  access_token: T.Optional(T.String()),
+})
+
 /** @type {import('fastify').FastifyPluginAsync<MapsPluginOpts, import('fastify').RawServerDefault, import('@fastify/type-provider-typebox').TypeBoxTypeProvider>} */
 async function routes(fastify) {
-  fastify.get('/style.json', async (req, rep) => {
-    const serverAddress = await getFastifyServerAddress(req.server.server)
+  fastify.get(
+    '/style.json',
+    { schema: { querystring: GetStyleJsonQueryStringSchema } },
+    async (req, rep) => {
+      const serverAddress = await getFastifyServerAddress(req.server.server)
 
-    // 1. Attempt to get "default" local static map's style.json
-    {
-      const styleId = 'default'
+      // 1. Attempt to get "default" local static map's style.json
+      {
+        const styleId = 'default'
 
-      const results = await Promise.all([
-        fastify.mapeoStaticMaps.getStyleJsonStats(styleId),
-        fastify.mapeoStaticMaps.getResolvedStyleJson(styleId, serverAddress),
-      ]).catch(() => {
-        fastify.log.warn('Cannot read default static map')
-        return null
-      })
+        const results = await Promise.all([
+          fastify.mapeoStaticMaps.getStyleJsonStats(styleId),
+          fastify.mapeoStaticMaps.getResolvedStyleJson(styleId, serverAddress),
+        ]).catch(() => {
+          fastify.log.warn('Cannot read default static map')
+          return null
+        })
 
-      if (results) {
+        if (results) {
+          const [stats, styleJson] = results
+          rep.headers(createStyleJsonResponseHeaders(stats.mtime))
+          return styleJson
+        }
+      }
+
+      // 2. Attempt to get a default style.json from online source
+      {
+        const upstreamResponse = await fetch(
+          constructUpstreamStyleUrl(req.query.access_token)
+        ).catch((err) => {
+          fastify.log.error(err)
+          return null
+        })
+
+        if (upstreamResponse) {
+          if (upstreamResponse.ok) {
+            // Set up headers to forward
+            for (const [key, value] of upstreamResponse.headers) {
+              // TODO: Typically Mapbox gzips the content but we'd need to make sure
+              // something like https://github.com/fastify/fastify-compress/ is registered
+              if (key.toLowerCase() === 'content-encoding') continue
+              rep.header(key, value)
+            }
+            return upstreamResponse.json()
+          } else {
+            fastify.log.error(
+              `Upstream style.json request failed: ${upstreamResponse.statusText}`
+            )
+          }
+        }
+      }
+
+      // 3. Provide offline fallback map's style.json
+      {
+        let results = null
+
+        try {
+          results = await Promise.all([
+            fastify.mapeoFallbackMap.getStyleJsonStats(),
+            fastify.mapeoFallbackMap.getResolvedStyleJson(serverAddress),
+          ])
+        } catch (err) {
+          throw new NotFoundError(`id = fallback, style.json`)
+        }
+
         const [stats, styleJson] = results
         rep.headers(createStyleJsonResponseHeaders(stats.mtime))
         return styleJson
       }
     }
+  )
+}
 
-    // TODO: 2. Attempt to get map's style.json from online source
+export const UPSTREAM_MAP_STYLE_URL =
+  'https://api.mapbox.com/styles/v1/mapbox/outdoors-v12'
 
-    // 3. Provide offline fallback map's style.json
-    {
-      let results = null
+/**
+ * @param {string} [accessToken]
+ * @returns {string}
+ */
+function constructUpstreamStyleUrl(accessToken) {
+  const url = new URL(UPSTREAM_MAP_STYLE_URL)
 
-      try {
-        results = await Promise.all([
-          fastify.mapeoFallbackMap.getStyleJsonStats(),
-          fastify.mapeoFallbackMap.getResolvedStyleJson(serverAddress),
-        ])
-      } catch (err) {
-        throw new NotFoundError(`id = fallback, style.json`)
-      }
+  if (accessToken) {
+    url.search = new URLSearchParams({
+      access_token: accessToken,
+    }).toString()
+  }
 
-      const [stats, styleJson] = results
-      rep.headers(createStyleJsonResponseHeaders(stats.mtime))
-      return styleJson
-    }
-  })
+  return url.href
 }

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -75,12 +75,9 @@ async function routes(fastify, opts) {
           ? styleUrlWithApiKey(defaultOnlineStyleUrl, apiKey)
           : defaultOnlineStyleUrl
 
-        const upstreamResponse = await fetch(upstreamUrl).catch((err) => {
-          fastify.log.error(err)
-          return null
-        })
+        try {
+          const upstreamResponse = await fetch(upstreamUrl)
 
-        if (upstreamResponse) {
           if (upstreamResponse.ok) {
             // Set up headers to forward
             for (const [key, value] of upstreamResponse.headers) {
@@ -101,6 +98,8 @@ async function routes(fastify, opts) {
               `Upstream style.json request failed: ${upstreamResponse.statusText}`
             )
           }
+        } catch (err) {
+          fastify.log.error(err)
         }
       }
 

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -119,11 +119,11 @@ async function routes(fastify, opts) {
             return upstreamResponse.json()
           } else {
             fastify.log.error(
-              `Upstream style.json request failed: ${upstreamResponse.status} ${upstreamResponse.statusText}`
+              `Upstream style.json request returned non-2xx status: ${upstreamResponse.status} ${upstreamResponse.statusText}`
             )
           }
         } catch (err) {
-          fastify.log.warn('Upstream style.json request totally failed', err)
+          fastify.log.warn('Failed to make upstream style.json request', err)
         }
       }
 

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -102,6 +102,7 @@ async function routes(fastify, opts) {
 
           if (upstreamResponse.ok) {
             // Set up headers to forward
+            // TODO: Change this to an allow-list of headers instead of a block-list
             for (const [name, value] of upstreamResponse.headers) {
               // We do our own content encoding
               if (name.toLowerCase() === 'content-encoding') continue

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -124,7 +124,7 @@ async function routes(fastify, opts) {
             rep.header('content-type', 'application/json; charset=utf-8')
             return upstreamResponse.json()
           } else {
-            fastify.log.error(
+            fastify.log.warn(
               `Upstream style.json request returned non-2xx status: ${upstreamResponse.status} ${upstreamResponse.statusText}`
             )
           }

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -111,7 +111,7 @@ async function routes(fastify, opts) {
             // Some upstream providers will not set the 'application/json' content-type header despite the body being JSON e.g. Protomaps
             // TODO: Should we forward the upstream 'content-type' header?
             // We kind of assume that a Style Spec-compatible JSON payload will always be used by a provider
-            // Tehcnically, there could be cases where a provider doesn't use the Mapbox Style Spec and has their own format,
+            // Technically, there could be cases where a provider doesn't use the Mapbox Style Spec and has their own format,
             // which may be delivered as some other content type
             rep.header('content-type', 'application/json; charset=utf-8')
             return upstreamResponse.json()

--- a/src/fastify-plugins/maps/index.js
+++ b/src/fastify-plugins/maps/index.js
@@ -103,8 +103,7 @@ async function routes(fastify, opts) {
           if (upstreamResponse.ok) {
             // Set up headers to forward
             for (const [name, value] of upstreamResponse.headers) {
-              // TODO: Typically Mapbox gzips the content but we'd need to make sure
-              // something like https://github.com/fastify/fastify-compress/ is registered
+              // We do our own content encoding
               if (name.toLowerCase() === 'content-encoding') continue
               rep.header(name, value)
             }
@@ -121,7 +120,7 @@ async function routes(fastify, opts) {
             )
           }
         } catch (err) {
-          fastify.log.warn('Upstream style.json request totally failed')
+          fastify.log.warn('Upstream style.json request totally failed', err)
         }
       }
 

--- a/test-e2e/manager-fastify-server.js
+++ b/test-e2e/manager-fastify-server.js
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { fileURLToPath } from 'url'
 import { KeyManager } from '@mapeo/crypto'
 import FakeTimers from '@sinonjs/fake-timers'
-import { Agent, fetch, setGlobalDispatcher } from 'undici'
+import { Agent, fetch as uFetch } from 'undici'
 import fs from 'fs/promises'
 import RAM from 'random-access-memory'
 import Fastify from 'fastify'
@@ -21,8 +21,6 @@ const projectMigrationsFolder = new URL('../drizzle/project', import.meta.url)
   .pathname
 const clientMigrationsFolder = new URL('../drizzle/client', import.meta.url)
   .pathname
-
-setupFetch()
 
 test('start/stop lifecycle', async (t) => {
   const fastify = Fastify()
@@ -283,13 +281,16 @@ test('retrieving icons using url', async (t) => {
   await exceptionPromise2
 })
 
-async function setupFetch() {
-  // Prevents tests from hanging caused by Undici's default behavior
-  // https://undici.nodejs.org/#/docs/best-practices/writing-tests
-  setGlobalDispatcher(
-    new Agent({
+/**
+ * @param {Parameters<typeof uFetch>} args
+ */
+async function fetch(...args) {
+  return uFetch(args[0], {
+    ...args[1],
+    // Prevents tests from hanging caused by Undici's default behavior
+    dispatcher: new Agent({
       keepAliveMaxTimeout: 10,
       keepAliveTimeout: 10,
-    })
-  )
+    }),
+  })
 }

--- a/tests/fastify-plugins/maps.js
+++ b/tests/fastify-plugins/maps.js
@@ -1,8 +1,12 @@
 import { test } from 'brittle'
 import path from 'node:path'
 import Fastify from 'fastify'
+import { MockAgent, setGlobalDispatcher } from 'undici'
 
-import { plugin as MapServerPlugin } from '../../src/fastify-plugins/maps/index.js'
+import {
+  UPSTREAM_MAP_STYLE_URL,
+  plugin as MapServerPlugin,
+} from '../../src/fastify-plugins/maps/index.js'
 import { plugin as StaticMapsPlugin } from '../../src/fastify-plugins/maps/static-maps.js'
 import { plugin as OfflineFallbackMapPlugin } from '../../src/fastify-plugins/maps/offline-fallback-map.js'
 
@@ -12,6 +16,8 @@ const MAPEO_FALLBACK_MAP_PATH = new URL(
   '../../node_modules/mapeo-offline-map',
   import.meta.url
 ).pathname
+
+setupFetch()
 
 test('fails to register when dependent plugins are not registered', async (t) => {
   const server = setup(t)
@@ -83,6 +89,34 @@ test('/style.json resolves style.json of local "default" static map when availab
   t.is(response.statusCode, 200)
 })
 
+test('/style.json resolves online style.json when local static is not available', async (t) => {
+  const server = setup(t)
+
+  server.register(StaticMapsPlugin, {
+    prefix: 'static',
+    // Need to choose a directory that doesn't have any map fixtures
+    staticRootDir: path.resolve(MAP_FIXTURES_PATH, '../does-not-exist'),
+  })
+  server.register(OfflineFallbackMapPlugin, {
+    prefix: 'fallback',
+    styleJsonPath: path.join(MAPEO_FALLBACK_MAP_PATH, 'style.json'),
+    sourcesDir: path.join(MAPEO_FALLBACK_MAP_PATH, 'dist'),
+  })
+  server.register(MapServerPlugin)
+
+  await server.listen()
+
+  const response = await server.inject({
+    method: 'GET',
+    url: '/style.json',
+    // Including the access_token query param here to simulate successfully getting an online style.json
+    query: `?access_token=pk.abc-123`,
+  })
+
+  t.is(response.statusCode, 200)
+  t.is(response.json().name, 'Mapbox Streets', 'gets online style.json')
+})
+
 test('/style.json resolves style.json of offline fallback map when static and online are not available', async (t) => {
   const server = setup(t)
 
@@ -103,6 +137,7 @@ test('/style.json resolves style.json of offline fallback map when static and on
   const response = await server.inject({
     method: 'GET',
     url: '/style.json',
+    // Omitting the access_token query param here to simulate not being able to get the online style.json
   })
 
   t.is(response.json().id, 'blank', 'gets fallback style.json')
@@ -122,4 +157,62 @@ function setup(t) {
   })
 
   return server
+}
+
+function setupFetch() {
+  const mockAgent = new MockAgent({
+    keepAliveMaxTimeout: 10,
+    keepAliveTimeout: 10,
+  })
+
+  mockAgent.disableNetConnect()
+
+  setGlobalDispatcher(mockAgent)
+
+  const upstreamUrlObj = new URL(UPSTREAM_MAP_STYLE_URL)
+
+  const mockPool = mockAgent.get(upstreamUrlObj.origin)
+
+  mockPool
+    .intercept({
+      method: 'GET',
+      path: (path) => {
+        return path.startsWith(upstreamUrlObj.pathname)
+      },
+    })
+    .reply(
+      // @ts-expect-error
+      (req) => {
+        const searchParams = new URL(req.path, req.origin).searchParams
+
+        // Return a very basic (valid) style spec if there's any access token param specified at all
+        return searchParams.has('access_token')
+          ? {
+              statusCode: 200,
+              data: {
+                version: 8,
+                name: 'Mapbox Streets', // Technically an optional property
+                sources: {
+                  'mapbox-streets': {
+                    type: 'vector',
+                    url: 'mapbox://mapbox.mapbox-streets-v6',
+                  },
+                },
+                layers: [
+                  {
+                    id: 'water',
+                    source: 'mapbox-streets',
+                    'source-layer': 'water',
+                    type: 'fill',
+                    paint: {
+                      'fill-color': '#00ffff',
+                    },
+                  },
+                ],
+              },
+            }
+          : { statusCode: 401, data: { message: 'Unauthorized' } }
+      }
+    )
+    .persist()
 }

--- a/tests/fastify-plugins/maps.js
+++ b/tests/fastify-plugins/maps.js
@@ -4,7 +4,7 @@ import Fastify from 'fastify'
 import { MockAgent, setGlobalDispatcher } from 'undici'
 
 import {
-  UPSTREAM_MAP_STYLE_URL,
+  DEFAULT_MAPBOX_STYLE_URL,
   plugin as MapServerPlugin,
 } from '../../src/fastify-plugins/maps/index.js'
 import { plugin as StaticMapsPlugin } from '../../src/fastify-plugins/maps/static-maps.js'
@@ -109,8 +109,8 @@ test('/style.json resolves online style.json when local static is not available'
   const response = await server.inject({
     method: 'GET',
     url: '/style.json',
-    // Including the access_token query param here to simulate successfully getting an online style.json
-    query: `?access_token=pk.abc-123`,
+    // Including the api_key query param here to simulate successfully getting an online style.json
+    query: `?api_key=pk.abc-123`,
   })
 
   t.is(response.statusCode, 200)
@@ -137,7 +137,7 @@ test('/style.json resolves style.json of offline fallback map when static and on
   const response = await server.inject({
     method: 'GET',
     url: '/style.json',
-    // Omitting the access_token query param here to simulate not being able to get the online style.json
+    // Omitting the api_key query param here to simulate not being able to get the online style.json
   })
 
   t.is(response.json().id, 'blank', 'gets fallback style.json')
@@ -169,7 +169,7 @@ function setupFetch() {
 
   setGlobalDispatcher(mockAgent)
 
-  const upstreamUrlObj = new URL(UPSTREAM_MAP_STYLE_URL)
+  const upstreamUrlObj = new URL(DEFAULT_MAPBOX_STYLE_URL)
 
   const mockPool = mockAgent.get(upstreamUrlObj.origin)
 

--- a/tests/fastify-plugins/maps.js
+++ b/tests/fastify-plugins/maps.js
@@ -115,8 +115,8 @@ test('/style.json resolves online style.json when local static is not available'
   const response = await server.inject({
     method: 'GET',
     url: '/style.json',
-    // Including the api_key query param here to simulate successfully getting an online style.json
-    query: `?api_key=pk.abc-123`,
+    // Including the `key` query param here to simulate successfully getting an online style.json
+    query: `?key=pk.abc-123`,
   })
 
   t.is(response.statusCode, 200)
@@ -152,8 +152,8 @@ test('defaultOnlineStyleUrl opt works', async (t) => {
   const response = await server.inject({
     method: 'GET',
     url: '/style.json',
-    // Including the api_key query param here to simulate successfully getting an online style.json
-    query: `?api_key=abc-123`,
+    // Including the `key` query param here to simulate successfully getting an online style.json
+    query: `?key=abc-123`,
   })
 
   t.is(response.statusCode, 200)
@@ -185,7 +185,7 @@ test('/style.json resolves style.json of offline fallback map when static and on
   const response = await server.inject({
     method: 'GET',
     url: '/style.json',
-    // Omitting the api_key query param here to simulate not being able to get the online style.json
+    // Omitting the `key` query param here to simulate not being able to get the online style.json
   })
 
   t.is(response.json().id, 'blank', 'gets fallback style.json')

--- a/tests/fixtures/map-style-definitions/mapbox-outdoors-v12.json
+++ b/tests/fixtures/map-style-definitions/mapbox-outdoors-v12.json
@@ -1,0 +1,6418 @@
+{
+  "name": "Mapbox Outdoors",
+  "sprite": "mapbox://sprites/mapbox/outdoors-v12",
+  "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+  "center": [9.1, 42.2],
+  "zoom": 7.5,
+  "fog": {
+    "range": [1, 20],
+    "color": [
+      "interpolate",
+      ["linear"],
+      ["zoom"],
+      4,
+      "hsl(200, 100%, 100%)",
+      6,
+      "hsl(200, 50%, 90%)"
+    ],
+    "high-color": [
+      "interpolate",
+      ["linear"],
+      ["zoom"],
+      4,
+      "hsl(200, 100%, 60%)",
+      6,
+      "hsl(310, 60%, 80%)"
+    ],
+    "space-color": [
+      "interpolate",
+      ["exponential", 1.2],
+      ["zoom"],
+      4,
+      "hsl(205, 10%, 10%)",
+      6,
+      "hsl(205, 60%, 50%)"
+    ],
+    "horizon-blend": [
+      "interpolate",
+      ["exponential", 1.2],
+      ["zoom"],
+      4,
+      0.01,
+      6,
+      0.1
+    ],
+    "star-intensity": [
+      "interpolate",
+      ["exponential", 1.2],
+      ["zoom"],
+      4,
+      0.1,
+      6,
+      0
+    ]
+  },
+  "projection": { "name": "globe" },
+  "visibility": "public",
+  "version": 8,
+  "layers": [
+    {
+      "id": "land",
+      "type": "background",
+      "layout": {},
+      "minzoom": 0,
+      "paint": { "background-color": "hsl(60, 20%, 85%)" },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, land"
+      }
+    },
+    {
+      "id": "landcover",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "landcover",
+      "minzoom": 0,
+      "maxzoom": 12,
+      "layout": {},
+      "paint": {
+        "fill-color": [
+          "match",
+          ["get", "class"],
+          "wood",
+          "hsla(103, 50%, 60%, 0.8)",
+          "scrub",
+          "hsla(98, 47%, 68%, 0.6)",
+          "crop",
+          "hsla(68, 55%, 70%, 0.6)",
+          "grass",
+          "hsla(98, 50%, 74%, 0.6)",
+          "snow",
+          "hsl(205, 45%, 95%)",
+          "hsl(98, 48%, 67%)"
+        ],
+        "fill-opacity": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          8,
+          0.8,
+          12,
+          0
+        ],
+        "fill-antialias": false
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, land"
+      }
+    },
+    {
+      "id": "national-park",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "landuse_overlay",
+      "minzoom": 5,
+      "filter": ["==", ["get", "class"], "national_park"],
+      "layout": {},
+      "paint": {
+        "fill-color": "hsl(98, 38%, 68%)",
+        "fill-opacity": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          5,
+          0,
+          6,
+          0.6,
+          12,
+          0.2
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, land"
+      }
+    },
+    {
+      "id": "national-park_tint-band",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "landuse_overlay",
+      "minzoom": 9,
+      "filter": ["==", ["get", "class"], "national_park"],
+      "layout": {},
+      "paint": {
+        "line-color": "hsl(98, 38%, 68%)",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          9,
+          1,
+          14,
+          8
+        ],
+        "line-blur": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          9,
+          1,
+          14,
+          8
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, land"
+      }
+    },
+    {
+      "id": "landuse",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "landuse",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [">=", ["to-number", ["get", "sizerank"]], 0],
+        [
+          "match",
+          ["get", "class"],
+          ["agriculture", "wood", "grass", "scrub", "glacier", "pitch", "sand"],
+          ["step", ["zoom"], false, 11, true],
+          "residential",
+          ["step", ["zoom"], true, 10, false],
+          ["park", "airport"],
+          [
+            "step",
+            ["zoom"],
+            false,
+            8,
+            ["case", ["==", ["get", "sizerank"], 1], true, false],
+            10,
+            true
+          ],
+          ["facility", "industrial"],
+          ["step", ["zoom"], false, 12, true],
+          "rock",
+          ["step", ["zoom"], false, 11, true],
+          "cemetery",
+          ["step", ["zoom"], false, 11, true],
+          "school",
+          ["step", ["zoom"], false, 11, true],
+          "hospital",
+          ["step", ["zoom"], false, 11, true],
+          "commercial_area",
+          ["step", ["zoom"], false, 11, true],
+          false
+        ],
+        [
+          "<=",
+          [
+            "-",
+            ["to-number", ["get", "sizerank"]],
+            ["interpolate", ["exponential", 1.5], ["zoom"], 12, 0, 18, 14]
+          ],
+          14
+        ]
+      ],
+      "layout": {},
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          15,
+          [
+            "match",
+            ["get", "class"],
+            "wood",
+            "hsla(103, 50%, 60%, 0.8)",
+            "scrub",
+            "hsla(98, 47%, 68%, 0.6)",
+            "agriculture",
+            "hsla(98, 50%, 74%, 0.6)",
+            "park",
+            [
+              "match",
+              ["get", "type"],
+              ["garden", "playground", "zoo"],
+              "hsl(98, 38%, 68%)",
+              "hsl(98, 55%, 70%)"
+            ],
+            "grass",
+            "hsla(98, 50%, 74%, 0.6)",
+            "airport",
+            "hsl(230, 40%, 82%)",
+            "cemetery",
+            "hsl(98, 45%, 75%)",
+            "glacier",
+            "hsl(205, 45%, 95%)",
+            "hospital",
+            "hsl(20, 45%, 82%)",
+            "pitch",
+            "hsl(88, 65%, 75%)",
+            "sand",
+            "hsl(69, 60%, 72%)",
+            "rock",
+            "hsl(60, 0%, 85%)",
+            "school",
+            "hsl(40, 45%, 78%)",
+            "commercial_area",
+            "hsl(55, 45%, 85%)",
+            "residential",
+            "hsl(60, 7%, 87%)",
+            ["facility", "industrial"],
+            "hsl(230, 20%, 85%)",
+            "hsl(60, 22%, 72%)"
+          ],
+          16,
+          [
+            "match",
+            ["get", "class"],
+            "wood",
+            "hsla(103, 50%, 60%, 0.8)",
+            "scrub",
+            "hsla(98, 47%, 68%, 0.6)",
+            "agriculture",
+            "hsla(98, 50%, 74%, 0.6)",
+            "park",
+            [
+              "match",
+              ["get", "type"],
+              ["garden", "playground", "zoo"],
+              "hsl(98, 38%, 68%)",
+              "hsl(98, 55%, 70%)"
+            ],
+            "grass",
+            "hsla(98, 50%, 74%, 0.6)",
+            "airport",
+            "hsl(230, 40%, 82%)",
+            "cemetery",
+            "hsl(98, 45%, 75%)",
+            "glacier",
+            "hsl(205, 45%, 95%)",
+            "hospital",
+            "hsl(20, 45%, 82%)",
+            "pitch",
+            "hsl(88, 65%, 75%)",
+            "sand",
+            "hsl(69, 60%, 72%)",
+            "rock",
+            "hsla(60, 0%, 85%, 0.5)",
+            "school",
+            "hsl(40, 45%, 78%)",
+            "commercial_area",
+            "hsla(55, 45%, 85%, 0.5)",
+            ["facility", "industrial"],
+            "hsl(230, 20%, 85%)",
+            "hsl(60, 22%, 72%)"
+          ]
+        ],
+        "fill-opacity": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          8,
+          ["match", ["get", "class"], "residential", 0.8, 0.2],
+          10,
+          ["match", ["get", "class"], "residential", 0, 1]
+        ],
+        "fill-antialias": false
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, land"
+      }
+    },
+    {
+      "id": "pitch-outline",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "landuse",
+      "minzoom": 15,
+      "filter": ["==", ["get", "class"], "pitch"],
+      "layout": {},
+      "paint": { "line-color": "hsl(88, 60%, 65%)" },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, land"
+      }
+    },
+    {
+      "id": "waterway-shadow",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "waterway",
+      "minzoom": 10,
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 11, "round"],
+        "line-join": ["step", ["zoom"], "miter", 11, "round"]
+      },
+      "paint": {
+        "line-color": "hsl(224, 79%, 69%)",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          9,
+          ["match", ["get", "class"], ["canal", "river"], 0.1, 0],
+          20,
+          ["match", ["get", "class"], ["canal", "river"], 8, 3]
+        ],
+        "line-translate": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          7,
+          ["literal", [0, 0]],
+          16,
+          ["literal", [-1, -1]]
+        ],
+        "line-translate-anchor": "viewport",
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 8, 0, 8.5, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, water"
+      }
+    },
+    {
+      "id": "water-shadow",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "water",
+      "minzoom": 10,
+      "layout": {},
+      "paint": {
+        "fill-color": "hsl(224, 79%, 69%)",
+        "fill-translate": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          7,
+          ["literal", [0, 0]],
+          16,
+          ["literal", [-1, -1]]
+        ],
+        "fill-translate-anchor": "viewport"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, water"
+      }
+    },
+    {
+      "id": "waterway",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "waterway",
+      "minzoom": 8,
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 11, "round"],
+        "line-join": ["step", ["zoom"], "miter", 11, "round"]
+      },
+      "paint": {
+        "line-color": "hsl(205, 75%, 70%)",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.3],
+          ["zoom"],
+          9,
+          ["match", ["get", "class"], ["canal", "river"], 0.1, 0],
+          20,
+          ["match", ["get", "class"], ["canal", "river"], 8, 3]
+        ],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 8, 0, 8.5, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, water"
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "water",
+      "minzoom": 0,
+      "layout": {},
+      "paint": { "fill-color": "hsl(205, 75%, 70%)" },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, water"
+      }
+    },
+    {
+      "id": "water-depth",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "depth",
+      "minzoom": 0,
+      "maxzoom": 8,
+      "layout": {},
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          6,
+          [
+            "interpolate",
+            ["linear"],
+            ["get", "min_depth"],
+            0,
+            "hsla(205, 75%, 70%, 0.35)",
+            200,
+            "hsla(205, 75%, 63%, 0.35)",
+            7000,
+            "hsla(205, 75%, 56%, 0.35)"
+          ],
+          8,
+          [
+            "interpolate",
+            ["linear"],
+            ["get", "min_depth"],
+            0,
+            "hsla(205, 75%, 70%, 0)",
+            200,
+            "hsla(205, 75%, 63%, 0)",
+            7000,
+            "hsla(205, 75%, 53%, 0)"
+          ]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, water"
+      }
+    },
+    {
+      "id": "wetland",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "landuse_overlay",
+      "minzoom": 5,
+      "filter": [
+        "match",
+        ["get", "class"],
+        ["wetland", "wetland_noveg"],
+        true,
+        false
+      ],
+      "paint": {
+        "fill-color": "hsl(194, 38%, 74%)",
+        "fill-opacity": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          0.25,
+          10.5,
+          0.15
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, water"
+      }
+    },
+    {
+      "id": "wetland-pattern",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "landuse_overlay",
+      "minzoom": 5,
+      "filter": [
+        "match",
+        ["get", "class"],
+        ["wetland", "wetland_noveg"],
+        true,
+        false
+      ],
+      "paint": {
+        "fill-color": "hsl(194, 38%, 74%)",
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 10, 0, 10.5, 1],
+        "fill-pattern": "wetland",
+        "fill-translate-anchor": "viewport"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, water"
+      }
+    },
+    {
+      "id": "hillshade",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "hillshade",
+      "filter": [
+        "all",
+        ["step", ["zoom"], ["==", ["get", "class"], "shadow"], 11, true],
+        [
+          "match",
+          ["get", "level"],
+          89,
+          true,
+          78,
+          ["step", ["zoom"], false, 5, true],
+          67,
+          ["step", ["zoom"], false, 9, true],
+          56,
+          ["step", ["zoom"], false, 6, true],
+          94,
+          ["step", ["zoom"], false, 11, true],
+          90,
+          ["step", ["zoom"], false, 12, true],
+          false
+        ]
+      ],
+      "minzoom": 0,
+      "maxzoom": 16,
+      "layout": {},
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          14,
+          [
+            "match",
+            ["get", "class"],
+            "shadow",
+            "hsla(66, 38%, 17%, 0.08)",
+            "hsla(60, 20%, 95%, 0.14)"
+          ],
+          16,
+          [
+            "match",
+            ["get", "class"],
+            "shadow",
+            "hsla(66, 38%, 17%, 0)",
+            "hsla(60, 20%, 95%, 0)"
+          ]
+        ],
+        "fill-antialias": false
+      },
+      "metadata": {
+        "mapbox:featureComponent": "terrain",
+        "mapbox:group": "Terrain, land"
+      }
+    },
+    {
+      "id": "contour-line",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "contour",
+      "minzoom": 11,
+      "filter": ["!=", ["get", "index"], -1],
+      "layout": {},
+      "paint": {
+        "line-opacity": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          11,
+          ["match", ["get", "index"], [1, 2], 0.15, 0.3],
+          13,
+          ["match", ["get", "index"], [1, 2], 0.3, 0.5]
+        ],
+        "line-color": "hsl(60, 10%, 35%)",
+        "line-width": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          13,
+          ["match", ["get", "index"], [1, 2], 0.5, 0.6],
+          16,
+          ["match", ["get", "index"], [1, 2], 0.8, 1.2]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "terrain",
+        "mapbox:group": "Terrain, land"
+      }
+    },
+    {
+      "id": "land-structure-polygon",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "structure",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "land"],
+        ["==", ["geometry-type"], "Polygon"]
+      ],
+      "layout": {},
+      "paint": { "fill-color": "hsl(60, 20%, 85%)" },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, built"
+      }
+    },
+    {
+      "id": "land-structure-line",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "structure",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "land"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "square" },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.99],
+          ["zoom"],
+          14,
+          0.75,
+          20,
+          40
+        ],
+        "line-color": "hsl(60, 20%, 85%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "land-and-water",
+        "mapbox:group": "Land & water, built"
+      }
+    },
+    {
+      "id": "aeroway-polygon",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "type"],
+          ["runway", "taxiway", "helipad"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "Polygon"]
+      ],
+      "paint": {
+        "fill-color": "hsl(230, 36%, 74%)",
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 10, 0, 11, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, built"
+      }
+    },
+    {
+      "id": "aeroway-line",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "aeroway",
+      "minzoom": 9,
+      "filter": ["==", ["geometry-type"], "LineString"],
+      "paint": {
+        "line-color": "hsl(230, 36%, 74%)",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          9,
+          ["match", ["get", "type"], "runway", 1, 0.5],
+          18,
+          ["match", ["get", "type"], "runway", 80, 20]
+        ],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 10, 0, 11, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, built"
+      }
+    },
+    {
+      "id": "building",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "building",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["!=", ["get", "type"], "building:part"],
+        ["==", ["get", "underground"], "false"]
+      ],
+      "layout": {},
+      "paint": {
+        "fill-color": "hsl(50, 15%, 75%)",
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 15, 0, 16, 1],
+        "fill-outline-color": "hsl(60, 10%, 65%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "buildings",
+        "mapbox:group": "Buildings, built"
+      }
+    },
+    {
+      "id": "building-underground",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "building",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", ["get", "underground"], "true"],
+        ["==", ["geometry-type"], "Polygon"]
+      ],
+      "layout": {},
+      "paint": {
+        "fill-color": "hsl(260, 60%, 85%)",
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 15, 0, 16, 0.5]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "buildings",
+        "mapbox:group": "Buildings, built"
+      }
+    },
+    {
+      "id": "tunnel-minor-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        [
+          "match",
+          ["get", "class"],
+          ["track"],
+          true,
+          "service",
+          ["step", ["zoom"], false, 14, true],
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 3%, 57%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          18,
+          10,
+          22,
+          100
+        ],
+        "line-dasharray": [3, 3]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels-case"
+      }
+    },
+    {
+      "id": "tunnel-street-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 3%, 57%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 14, 1],
+        "line-dasharray": [3, 3]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels-case"
+      }
+    },
+    {
+      "id": "tunnel-minor-link-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["primary_link", "secondary_link", "tertiary_link"],
+          true,
+          false
+        ],
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.4,
+          18,
+          18,
+          22,
+          180
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 11, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels-case"
+      }
+    },
+    {
+      "id": "tunnel-secondary-tertiary-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 3%, 57%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0,
+          18,
+          26,
+          22,
+          260
+        ],
+        "line-dasharray": [3, 3]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels-case"
+      }
+    },
+    {
+      "id": "tunnel-primary-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "class"], "primary"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 3%, 57%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          28,
+          22,
+          280
+        ],
+        "line-dasharray": [3, 3]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels-case"
+      }
+    },
+    {
+      "id": "tunnel-major-link-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-dasharray": [3, 3]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels-case"
+      }
+    },
+    {
+      "id": "tunnel-motorway-trunk-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 82%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ],
+        "line-dasharray": [3, 3]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels-case"
+      }
+    },
+    {
+      "id": "tunnel-path-trail",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "class"], "path"],
+        [
+          "match",
+          ["get", "type"],
+          ["hiking", "mountain_bike", "trail"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(60, 32%, 90%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [5, 0.5]],
+          15,
+          ["literal", [4, 0.5]],
+          16,
+          ["literal", [4, 0.45]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., tunnels"
+      }
+    },
+    {
+      "id": "tunnel-path-cycleway-piste",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "class"], "path"],
+        ["match", ["get", "type"], ["cycleway", "piste"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(60, 32%, 90%)",
+        "line-dasharray": [10, 0]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., tunnels"
+      }
+    },
+    {
+      "id": "tunnel-path",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "class"], "path"],
+        ["!=", ["get", "type"], "steps"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(60, 32%, 90%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.75, 1]],
+          16,
+          ["literal", [1, 0.75]],
+          17,
+          ["literal", [1, 0.5]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., tunnels"
+      }
+    },
+    {
+      "id": "tunnel-steps",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "type"], "steps"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          16,
+          1.6,
+          18,
+          6
+        ],
+        "line-color": "hsl(60, 32%, 90%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.75, 1]],
+          16,
+          ["literal", [1, 0.75]],
+          17,
+          ["literal", [0.3, 0.3]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., tunnels"
+      }
+    },
+    {
+      "id": "tunnel-pedestrian",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "class"], "pedestrian"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.5,
+          18,
+          12
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.5, 0.4]],
+          16,
+          ["literal", [1, 0.2]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., tunnels"
+      }
+    },
+    {
+      "id": "tunnel-construction",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "class"], "construction"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          2,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [0.4, 0.8]],
+          15,
+          ["literal", [0.3, 0.6]],
+          16,
+          ["literal", [0.2, 0.3]],
+          17,
+          ["literal", [0.2, 0.25]],
+          18,
+          ["literal", [0.15, 0.15]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-minor",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        [
+          "match",
+          ["get", "class"],
+          ["track"],
+          true,
+          "service",
+          ["step", ["zoom"], false, 14, true],
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          18,
+          10,
+          22,
+          100
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "street_limited",
+          "hsl(60, 22%, 80%)",
+          "hsl(0, 0%, 95%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-minor-link",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["primary_link", "secondary_link", "tertiary_link"],
+          true,
+          false
+        ],
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 13, "round"],
+        "line-join": ["step", ["zoom"], "miter", 13, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.4,
+          18,
+          18,
+          22,
+          180
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-major-link",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "motorway_link",
+          "hsl(15, 100%, 85%)",
+          "hsl(35, 78%, 85%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-street",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "street_limited",
+          "hsl(60, 22%, 80%)",
+          "hsl(0, 0%, 95%)"
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-street-low",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-secondary-tertiary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0,
+          18,
+          26,
+          22,
+          260
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-primary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "class"], "primary"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          28,
+          22,
+          280
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-motorway-trunk",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "motorway",
+          "hsl(15, 100%, 85%)",
+          "hsl(35, 78%, 85%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-oneway-arrow-blue",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        ["==", ["get", "oneway"], "true"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "class"],
+            ["primary", "secondary", "street", "street_limited", "tertiary"],
+            true,
+            false
+          ],
+          16,
+          [
+            "match",
+            ["get", "class"],
+            [
+              "primary",
+              "secondary",
+              "tertiary",
+              "street",
+              "street_limited",
+              "primary_link",
+              "secondary_link",
+              "tertiary_link",
+              "service",
+              "track"
+            ],
+            true,
+            false
+          ]
+        ]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "icon-image": ["step", ["zoom"], "oneway-small", 18, "oneway-large"],
+        "symbol-spacing": 200,
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "tunnel-oneway-arrow-white",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "tunnel"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway", "motorway_link", "trunk", "trunk_link"],
+          true,
+          false
+        ],
+        ["==", ["get", "oneway"], "true"]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "icon-image": [
+          "step",
+          ["zoom"],
+          "oneway-white-small",
+          18,
+          "oneway-white-large"
+        ],
+        "symbol-spacing": 200,
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, tunnels"
+      }
+    },
+    {
+      "id": "cliff",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "structure",
+      "minzoom": 15,
+      "filter": ["==", ["get", "class"], "cliff"],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 15, 0, 15.25, 1],
+        "line-width": 10,
+        "line-pattern": "cliff"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "terrain",
+        "mapbox:group": "Terrain, surface"
+      }
+    },
+    {
+      "id": "ferry",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 8,
+      "filter": ["==", ["get", "type"], "ferry"],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          15,
+          "hsl(214, 68%, 63%)",
+          17,
+          "hsl(239, 68%, 63%)"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.5,
+          20,
+          1
+        ],
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          13,
+          ["literal", [12, 4]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, ferries"
+      }
+    },
+    {
+      "id": "ferry-auto",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 8,
+      "filter": ["==", ["get", "type"], "ferry_auto"],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          15,
+          "hsl(214, 68%, 63%)",
+          17,
+          "hsl(239, 68%, 63%)"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.5,
+          20,
+          1
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, ferries"
+      }
+    },
+    {
+      "id": "road-pedestrian-polygon-fill",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["path", "pedestrian"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["case", ["has", "layer"], [">=", ["get", "layer"], 0], true],
+        ["==", ["geometry-type"], "Polygon"]
+      ],
+      "paint": { "fill-color": "hsl(60, 20%, 85%)" },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-pedestrian-polygon-pattern",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["path", "pedestrian"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["case", ["has", "layer"], [">=", ["get", "layer"], 0], true],
+        ["==", ["geometry-type"], "Polygon"]
+      ],
+      "paint": {
+        "fill-pattern": "pedestrian-polygon",
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 16, 0, 17, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-path-bg",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "path"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "!",
+            [
+              "match",
+              ["get", "type"],
+              ["steps", "sidewalk", "crossing"],
+              true,
+              false
+            ]
+          ],
+          16,
+          ["!=", ["get", "type"], "steps"]
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": ["step", ["zoom"], "miter", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          2,
+          18,
+          7
+        ],
+        "line-color": [
+          "match",
+          ["get", "type"],
+          "piste",
+          "hsl(215, 80%, 48%)",
+          [
+            "mountain_bike",
+            "hiking",
+            "trail",
+            "cycleway",
+            "footway",
+            "path",
+            "bridleway"
+          ],
+          "hsl(35, 80%, 48%)",
+          "hsl(60, 1%, 64%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-steps-bg",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "type"], "steps"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          2,
+          17,
+          4.6,
+          18,
+          7
+        ],
+        "line-color": "hsl(35, 80%, 48%)",
+        "line-opacity": 0.75
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-pedestrian-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "pedestrian"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["case", ["has", "layer"], [">=", ["get", "layer"], 0], true],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": ["step", ["zoom"], "miter", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          2,
+          18,
+          14.5
+        ],
+        "line-color": "hsl(60, 10%, 70%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-path-trail",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "path"],
+        [
+          "match",
+          ["get", "type"],
+          ["hiking", "mountain_bike", "trail"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": ["step", ["zoom"], "miter", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [5, 0.5]],
+          15,
+          ["literal", [4, 0.5]],
+          16,
+          ["literal", [4, 0.45]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-path-cycleway-piste",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "path"],
+        ["match", ["get", "type"], ["cycleway", "piste"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": ["step", ["zoom"], "miter", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [10, 0]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-path",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "path"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "!",
+            [
+              "match",
+              ["get", "type"],
+              ["steps", "sidewalk", "crossing"],
+              true,
+              false
+            ]
+          ],
+          16,
+          ["!=", ["get", "type"], "steps"]
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": ["step", ["zoom"], "miter", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          13,
+          0.5,
+          14,
+          1,
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [4, 0.3]],
+          15,
+          ["literal", [1.75, 0.3]],
+          16,
+          ["literal", [1, 0.3]],
+          17,
+          ["literal", [1, 0.25]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-steps",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "type"], "steps"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          16,
+          1.6,
+          18,
+          6
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.75, 1]],
+          16,
+          ["literal", [1, 0.75]],
+          17,
+          ["literal", [0.3, 0.3]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-pedestrian",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "pedestrian"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["case", ["has", "layer"], [">=", ["get", "layer"], 0], true],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": ["step", ["zoom"], "miter", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.5,
+          18,
+          12
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.5, 0.4]],
+          16,
+          ["literal", [1, 0.2]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "golf-hole-line",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": ["==", ["get", "class"], "golf"],
+      "paint": { "line-color": "hsl(98, 26%, 56%)" },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., surface"
+      }
+    },
+    {
+      "id": "road-polygon",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          [
+            "primary",
+            "secondary",
+            "tertiary",
+            "primary_link",
+            "secondary_link",
+            "tertiary_link",
+            "trunk",
+            "trunk_link",
+            "street",
+            "street_limited",
+            "track",
+            "service"
+          ],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "Polygon"]
+      ],
+      "paint": {
+        "fill-color": "hsl(0, 0%, 95%)",
+        "fill-outline-color": "hsl(60, 10%, 70%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "turning-feature-outline",
+      "type": "circle",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["turning_circle", "turning_loop"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "Point"]
+      ],
+      "paint": {
+        "circle-radius": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          4.5,
+          16,
+          8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "circle-color": "hsl(0, 0%, 95%)",
+        "circle-stroke-width": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          15,
+          0.8,
+          16,
+          1.2,
+          18,
+          2
+        ],
+        "circle-stroke-color": "hsl(60, 10%, 70%)",
+        "circle-pitch-alignment": "map"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-minor-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["track"],
+          true,
+          "service",
+          ["step", ["zoom"], false, 14, true],
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "track",
+          "hsl(35, 80%, 48%)",
+          "hsl(60, 10%, 70%)"
+        ],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          18,
+          10,
+          22,
+          100
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-street-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-minor-link-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["primary_link", "secondary_link", "tertiary_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.4,
+          18,
+          18,
+          22,
+          180
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 11, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-secondary-tertiary-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0,
+          18,
+          26,
+          22,
+          260
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-primary-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "primary"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          28,
+          22,
+          280
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-major-link-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 82%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 11, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-motorway-trunk-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "step",
+          ["zoom"],
+          ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+          5,
+          [
+            "all",
+            ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+            ["match", ["get", "structure"], ["none", "ford"], true, false]
+          ]
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 82%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 3, 0, 3.5, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "turning-feature",
+      "type": "circle",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["turning_circle", "turning_loop"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "Point"]
+      ],
+      "paint": {
+        "circle-radius": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          4.5,
+          16,
+          8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "circle-color": "hsl(0, 0%, 95%)",
+        "circle-pitch-alignment": "map"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-construction",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "construction"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          2,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [0.4, 0.8]],
+          15,
+          ["literal", [0.3, 0.6]],
+          16,
+          ["literal", [0.2, 0.3]],
+          17,
+          ["literal", [0.2, 0.25]],
+          18,
+          ["literal", [0.15, 0.15]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-minor",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["track"],
+          true,
+          "service",
+          ["step", ["zoom"], false, 14, true],
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          18,
+          10,
+          22,
+          100
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-minor-link",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["primary_link", "secondary_link", "tertiary_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 13, "round"],
+        "line-join": ["step", ["zoom"], "miter", 13, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.4,
+          18,
+          18,
+          22,
+          180
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-major-link",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 13, "round"],
+        "line-join": ["step", ["zoom"], "miter", 13, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "motorway_link",
+          "hsl(15, 100%, 75%)",
+          "hsl(35, 89%, 75%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-street",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "street_limited",
+          "hsl(60, 22%, 80%)",
+          "hsl(0, 0%, 95%)"
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-street-low",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 11,
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-secondary-tertiary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 9,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0,
+          18,
+          26,
+          22,
+          260
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-primary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "primary"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          28,
+          22,
+          280
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-motorway-trunk",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "step",
+          ["zoom"],
+          ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+          5,
+          [
+            "all",
+            ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+            ["match", ["get", "structure"], ["none", "ford"], true, false]
+          ]
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 13, "round"],
+        "line-join": ["step", ["zoom"], "miter", 13, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ],
+        "line-color": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "class"],
+            "motorway",
+            "hsl(15, 88%, 69%)",
+            "trunk",
+            "hsl(35, 81%, 59%)",
+            "hsl(60, 18%, 85%)"
+          ],
+          9,
+          [
+            "match",
+            ["get", "class"],
+            "motorway",
+            "hsl(15, 100%, 75%)",
+            "hsl(35, 89%, 75%)"
+          ]
+        ],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 3, 0, 3.5, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface"
+      }
+    },
+    {
+      "id": "road-rail",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["major_rail", "minor_rail"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false]
+      ],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          13,
+          "hsl(75, 25%, 68%)",
+          16,
+          "hsl(60, 0%, 56%)"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.5,
+          20,
+          1
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, surface"
+      }
+    },
+    {
+      "id": "road-rail-tracks",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["major_rail", "minor_rail"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false]
+      ],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          13,
+          "hsl(75, 25%, 68%)",
+          16,
+          "hsl(60, 0%, 56%)"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          4,
+          20,
+          8
+        ],
+        "line-dasharray": [0.1, 15],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 13.75, 0, 14, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, surface"
+      }
+    },
+    {
+      "id": "level-crossing",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": ["==", ["get", "class"], "level_crossing"],
+      "layout": {
+        "icon-image": "level-crossing",
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface-icons"
+      }
+    },
+    {
+      "id": "road-oneway-arrow-blue",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", ["get", "oneway"], "true"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "class"],
+            ["primary", "secondary", "tertiary", "street", "street_limited"],
+            true,
+            false
+          ],
+          16,
+          [
+            "match",
+            ["get", "class"],
+            [
+              "primary",
+              "secondary",
+              "tertiary",
+              "street",
+              "street_limited",
+              "primary_link",
+              "secondary_link",
+              "tertiary_link",
+              "service",
+              "track"
+            ],
+            true,
+            false
+          ]
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "icon-image": ["step", ["zoom"], "oneway-small", 18, "oneway-large"],
+        "symbol-spacing": 200,
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface-icons"
+      }
+    },
+    {
+      "id": "road-oneway-arrow-white",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", ["get", "oneway"], "true"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway", "trunk", "motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "icon-image": [
+          "step",
+          ["zoom"],
+          "oneway-white-small",
+          18,
+          "oneway-white-large"
+        ],
+        "symbol-spacing": 200,
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface-icons"
+      }
+    },
+    {
+      "id": "crosswalks",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "structure",
+      "minzoom": 17,
+      "filter": [
+        "all",
+        ["==", ["get", "type"], "crosswalk"],
+        ["==", ["geometry-type"], "Point"]
+      ],
+      "layout": {
+        "icon-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          16,
+          0.1,
+          18,
+          0.2,
+          19,
+          0.5,
+          22,
+          1.5
+        ],
+        "icon-image": [
+          "step",
+          ["zoom"],
+          "crosswalk-small",
+          18,
+          "crosswalk-large"
+        ],
+        "icon-rotate": ["get", "direction"],
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, surface-icons"
+      }
+    },
+    {
+      "id": "gate-fence-hedge",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "structure",
+      "minzoom": 16,
+      "filter": [
+        "match",
+        ["get", "class"],
+        ["gate", "fence", "hedge"],
+        true,
+        false
+      ],
+      "layout": {},
+      "paint": {
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "hedge",
+          "hsl(98, 32%, 56%)",
+          "hsl(60, 25%, 63%)"
+        ],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 16, 1, 20, 3],
+        "line-opacity": ["match", ["get", "class"], "gate", 0.5, 1],
+        "line-dasharray": [1, 2, 5, 2, 1, 2]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-path-bg",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "path"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "!",
+            [
+              "match",
+              ["get", "type"],
+              ["steps", "sidewalk", "crossing"],
+              true,
+              false
+            ]
+          ],
+          16,
+          ["!=", ["get", "type"], "steps"]
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          2,
+          18,
+          7
+        ],
+        "line-color": [
+          "match",
+          ["get", "type"],
+          "piste",
+          "hsl(215, 80%, 48%)",
+          [
+            "mountain_bike",
+            "hiking",
+            "trail",
+            "cycleway",
+            "footway",
+            "path",
+            "bridleway"
+          ],
+          "hsl(35, 80%, 48%)",
+          "hsl(60, 1%, 64%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-steps-bg",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "type"], "steps"],
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          2,
+          17,
+          4.6,
+          18,
+          7
+        ],
+        "line-color": "hsl(35, 80%, 48%)",
+        "line-opacity": 0.75
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-pedestrian-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "pedestrian"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          2,
+          18,
+          14.5
+        ],
+        "line-color": "hsl(60, 10%, 70%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-path-trail",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "path"],
+        [
+          "match",
+          ["get", "type"],
+          ["hiking", "mountain_bike", "trail"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [5, 0.5]],
+          15,
+          ["literal", [4, 0.5]],
+          16,
+          ["literal", [4, 0.45]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-path-cycleway-piste",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "path"],
+        ["match", ["get", "type"], ["cycleway", "piste"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [10, 0]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-path",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "path"],
+        ["!=", ["get", "type"], "steps"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          18,
+          4
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [4, 0.3]],
+          15,
+          ["literal", [1.75, 0.3]],
+          16,
+          ["literal", [1, 0.3]],
+          17,
+          ["literal", [1, 0.25]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-steps",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "type"], "steps"],
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          15,
+          1,
+          16,
+          1.6,
+          18,
+          6
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.75, 1]],
+          16,
+          ["literal", [1, 0.75]],
+          17,
+          ["literal", [0.3, 0.3]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-pedestrian",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "pedestrian"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.5,
+          18,
+          12
+        ],
+        "line-color": "hsl(0, 0%, 95%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.5, 0.4]],
+          16,
+          ["literal", [1, 0.2]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "gate-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "structure",
+      "minzoom": 16,
+      "filter": ["==", ["get", "class"], "gate"],
+      "layout": {
+        "icon-image": [
+          "match",
+          ["get", "type"],
+          "gate",
+          "gate",
+          "lift_gate",
+          "lift-gate",
+          ""
+        ]
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., barriers-bridges"
+      }
+    },
+    {
+      "id": "bridge-minor-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["track"],
+          true,
+          "service",
+          ["step", ["zoom"], false, 14, true],
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "track",
+          "hsl(35, 80%, 48%)",
+          "hsl(60, 10%, 70%)"
+        ],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          18,
+          10,
+          22,
+          100
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-street-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "track",
+          "hsl(35, 80%, 48%)",
+          "hsl(60, 10%, 70%)"
+        ],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-minor-link-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["primary_link", "secondary_link", "tertiary_link"],
+          true,
+          false
+        ],
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": ["step", ["zoom"], "miter", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.4,
+          18,
+          18,
+          22,
+          180
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 11, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-secondary-tertiary-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0,
+          18,
+          26,
+          22,
+          260
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 10, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-primary-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "primary"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          28,
+          22,
+          280
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 10, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-major-link-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["<=", ["get", "layer"], 1],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 82%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-motorway-trunk-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["<=", ["get", "layer"], 1],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 82%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-construction",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "construction"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          2,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": "hsl(60, 10%, 70%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [0.4, 0.8]],
+          15,
+          ["literal", [0.3, 0.6]],
+          16,
+          ["literal", [0.2, 0.3]],
+          17,
+          ["literal", [0.2, 0.25]],
+          18,
+          ["literal", [0.15, 0.15]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-minor",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["track"],
+          true,
+          "service",
+          ["step", ["zoom"], false, 14, true],
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          18,
+          10,
+          22,
+          100
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-minor-link",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["primary_link", "secondary_link", "tertiary_link"],
+          true,
+          false
+        ],
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.4,
+          18,
+          18,
+          22,
+          180
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-major-link",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["<=", ["get", "layer"], 1],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 13, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "motorway_link",
+          "hsl(15, 100%, 75%)",
+          "hsl(35, 89%, 75%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-street",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "street_limited",
+          "hsl(60, 22%, 80%)",
+          "hsl(0, 0%, 95%)"
+        ],
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-street-low",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["street", "street_limited"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "line-cap": ["step", ["zoom"], "butt", 14, "round"],
+        "line-join": ["step", ["zoom"], "miter", 14, "round"]
+      },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.5,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-secondary-tertiary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0,
+          18,
+          26,
+          22,
+          260
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-primary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "primary"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          28,
+          22,
+          280
+        ],
+        "line-color": "hsl(0, 0%, 95%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-motorway-trunk",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["<=", ["get", "layer"], 1],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "motorway",
+          "hsl(15, 100%, 75%)",
+          "hsl(35, 89%, 75%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-major-link-2-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [">=", ["get", "layer"], 2],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.8,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 82%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-motorway-trunk-2-case",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [">=", ["get", "layer"], 2],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          22,
+          2
+        ],
+        "line-color": "hsl(60, 10%, 82%)",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-major-link-2",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [">=", ["get", "layer"], 2],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 13, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          12,
+          0.8,
+          18,
+          20,
+          22,
+          200
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "motorway_link",
+          "hsl(15, 100%, 75%)",
+          "hsl(35, 89%, 75%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-motorway-trunk-2",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [">=", ["get", "layer"], 2],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": ["step", ["zoom"], "butt", 14, "round"] },
+      "paint": {
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          3,
+          0.8,
+          18,
+          30,
+          22,
+          300
+        ],
+        "line-color": [
+          "match",
+          ["get", "class"],
+          "motorway",
+          "hsl(15, 100%, 75%)",
+          "hsl(35, 89%, 75%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-oneway-arrow-blue",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "oneway"], "true"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "class"],
+            ["primary", "secondary", "tertiary", "street", "street_limited"],
+            true,
+            false
+          ],
+          16,
+          [
+            "match",
+            ["get", "class"],
+            [
+              "primary",
+              "secondary",
+              "tertiary",
+              "street",
+              "street_limited",
+              "primary_link",
+              "secondary_link",
+              "tertiary_link",
+              "service",
+              "track"
+            ],
+            true,
+            false
+          ]
+        ]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "icon-image": ["step", ["zoom"], "oneway-small", 18, "oneway-large"],
+        "symbol-spacing": 200,
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-oneway-arrow-white",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway", "trunk", "motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["==", ["get", "oneway"], "true"]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "icon-image": "oneway-white-small",
+        "symbol-spacing": 200,
+        "icon-rotation-alignment": "map",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true
+      },
+      "paint": {},
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, bridges"
+      }
+    },
+    {
+      "id": "bridge-rail",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["major_rail", "minor_rail"], true, false]
+      ],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          13,
+          "hsl(75, 25%, 68%)",
+          16,
+          "hsl(60, 0%, 56%)"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          0.5,
+          20,
+          1
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, bridges"
+      }
+    },
+    {
+      "id": "bridge-rail-tracks",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["major_rail", "minor_rail"], true, false]
+      ],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          13,
+          "hsl(75, 25%, 68%)",
+          16,
+          "hsl(60, 0%, 56%)"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          4,
+          20,
+          8
+        ],
+        "line-dasharray": [0.1, 15],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 13.75, 0, 14, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, bridges"
+      }
+    },
+    {
+      "id": "aerialway",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": ["==", ["get", "class"], "aerialway"],
+      "paint": {
+        "line-color": "hsl(230, 50%, 60%)",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.5],
+          ["zoom"],
+          14,
+          1,
+          20,
+          2
+        ],
+        "line-dasharray": [4, 1]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, elevated"
+      }
+    },
+    {
+      "id": "admin-1-boundary-bg",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 1],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "paint": {
+        "line-color": "hsl(350, 90%, 88%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 3, 12, 6],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 7, 0, 8, 0.5],
+        "line-dasharray": [1, 0],
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 12, 3]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "admin-boundaries",
+        "mapbox:group": "Administrative boundaries, admin"
+      }
+    },
+    {
+      "id": "admin-0-boundary-bg",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "paint": {
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 4, 12, 8],
+        "line-color": "hsl(350, 90%, 88%)",
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.5],
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 12, 2]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "admin-boundaries",
+        "mapbox:group": "Administrative boundaries, admin"
+      }
+    },
+    {
+      "id": "admin-1-boundary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 2,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 1],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": {},
+      "paint": {
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [2, 0]],
+          7,
+          ["literal", [2, 2, 6, 2]]
+        ],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.3, 12, 1.5],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 2, 0, 3, 1],
+        "line-color": "hsl(350, 30%, 55%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "admin-boundaries",
+        "mapbox:group": "Administrative boundaries, admin"
+      }
+    },
+    {
+      "id": "admin-0-boundary",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "disputed"], "false"],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": {},
+      "paint": {
+        "line-color": "hsl(350, 30%, 50%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 12, 2],
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [2, 0]],
+          7,
+          ["literal", [2, 2, 6, 2]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "admin-boundaries",
+        "mapbox:group": "Administrative boundaries, admin"
+      }
+    },
+    {
+      "id": "admin-0-boundary-disputed",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "disputed"], "true"],
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "paint": {
+        "line-color": "hsl(350, 30%, 50%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 12, 2],
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [3, 2, 5]],
+          7,
+          ["literal", [2, 1.5]]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "admin-boundaries",
+        "mapbox:group": "Administrative boundaries, admin"
+      }
+    },
+    {
+      "id": "contour-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "contour",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["==", ["get", "index"], 10],
+        ["==", ["get", "index"], 5]
+      ],
+      "layout": {
+        "text-field": ["concat", ["get", "ele"], " m"],
+        "symbol-placement": "line",
+        "text-pitch-alignment": "viewport",
+        "text-max-angle": 25,
+        "text-padding": 5,
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 15, 9.5, 20, 12]
+      },
+      "paint": {
+        "text-color": "hsl(60, 10%, 35%)",
+        "text-halo-width": 1,
+        "text-halo-color": "hsl(60, 10%, 85%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "terrain",
+        "mapbox:group": "Terrain, terrain-labels"
+      }
+    },
+    {
+      "id": "building-entrance",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "structure",
+      "minzoom": 18,
+      "filter": ["==", ["get", "class"], "entrance"],
+      "layout": {
+        "icon-image": "marker",
+        "text-field": ["get", "ref"],
+        "text-size": 10,
+        "text-offset": [0, -0.5],
+        "text-font": ["DIN Pro Italic", "Arial Unicode MS Regular"]
+      },
+      "paint": {
+        "text-color": "hsl(60, 8%, 38%)",
+        "text-halo-color": "hsl(60, 13%, 77%)",
+        "text-halo-width": 1,
+        "icon-opacity": 0.4
+      },
+      "metadata": {
+        "mapbox:featureComponent": "buildings",
+        "mapbox:group": "Buildings, building-labels"
+      }
+    },
+    {
+      "id": "building-number-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "housenum_label",
+      "minzoom": 17,
+      "layout": {
+        "text-field": ["get", "house_num"],
+        "text-font": ["DIN Pro Italic", "Arial Unicode MS Regular"],
+        "text-padding": 4,
+        "text-max-width": 7,
+        "text-size": 10
+      },
+      "paint": {
+        "text-color": "hsl(60, 8%, 38%)",
+        "text-halo-color": "hsl(60, 13%, 77%)",
+        "text-halo-width": 1
+      },
+      "metadata": {
+        "mapbox:featureComponent": "buildings",
+        "mapbox:group": "Buildings, building-labels"
+      }
+    },
+    {
+      "id": "block-number-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "settlement_subdivision"],
+        ["==", ["get", "type"], "block"]
+      ],
+      "layout": {
+        "text-field": ["get", "name"],
+        "text-font": ["DIN Pro Italic", "Arial Unicode MS Regular"],
+        "text-max-width": 7,
+        "text-size": 11
+      },
+      "paint": {
+        "text-color": "hsl(60, 18%, 44%)",
+        "text-halo-color": "hsl(60, 17%, 84%)",
+        "text-halo-width": 0.5,
+        "text-halo-blur": 0.5
+      },
+      "metadata": {
+        "mapbox:featureComponent": "buildings",
+        "mapbox:group": "Buildings, building-labels"
+      }
+    },
+    {
+      "id": "road-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        ["has", "name"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            true,
+            false
+          ],
+          12,
+          [
+            "match",
+            ["get", "class"],
+            [
+              "motorway",
+              "trunk",
+              "primary",
+              "secondary",
+              "tertiary",
+              "street",
+              "street_limited",
+              "track"
+            ],
+            true,
+            false
+          ],
+          15,
+          [
+            "match",
+            ["get", "class"],
+            ["path", "pedestrian", "golf", "ferry", "aerialway"],
+            false,
+            true
+          ]
+        ]
+      ],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            10,
+            [
+              "motorway_link",
+              "trunk_link",
+              "primary_link",
+              "secondary_link",
+              "tertiary_link",
+              "street",
+              "street_limited",
+              "track"
+            ],
+            9,
+            6.5
+          ],
+          18,
+          [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            16,
+            [
+              "motorway_link",
+              "trunk_link",
+              "primary_link",
+              "secondary_link",
+              "tertiary_link",
+              "street",
+              "street_limited",
+              "track"
+            ],
+            14,
+            13
+          ]
+        ],
+        "text-max-angle": 30,
+        "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-letter-spacing": 0.01
+      },
+      "paint": {
+        "text-color": "hsl(0,0%, 0%)",
+        "text-halo-color": [
+          "match",
+          ["get", "class"],
+          ["motorway", "trunk"],
+          "hsla(60, 25%, 100%, 0.75)",
+          "hsl(60, 25%, 100%)"
+        ],
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, road-labels"
+      }
+    },
+    {
+      "id": "road-intersection",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "intersection"],
+        ["has", "name"]
+      ],
+      "layout": {
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "icon-image": "intersection",
+        "icon-text-fit": "both",
+        "icon-text-fit-padding": [1, 2, 1, 2],
+        "text-size": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          15,
+          9,
+          18,
+          12
+        ],
+        "text-font": ["DIN Pro Bold", "Arial Unicode MS Bold"]
+      },
+      "paint": { "text-color": "hsl(230, 36%, 64%)" },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, road-labels"
+      }
+    },
+    {
+      "id": "road-number-shield",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["has", "reflen"],
+        ["<=", ["get", "reflen"], 6],
+        ["match", ["get", "class"], ["pedestrian", "service"], false, true],
+        [
+          "step",
+          ["zoom"],
+          ["==", ["geometry-type"], "Point"],
+          11,
+          [">", ["get", "len"], 5000],
+          12,
+          [">", ["get", "len"], 2500],
+          13,
+          [">", ["get", "len"], 1000],
+          14,
+          true
+        ]
+      ],
+      "layout": {
+        "text-size": 9,
+        "icon-image": [
+          "case",
+          ["has", "shield_beta"],
+          [
+            "coalesce",
+            [
+              "image",
+              [
+                "concat",
+                ["get", "shield_beta"],
+                "-",
+                ["to-string", ["get", "reflen"]]
+              ]
+            ],
+            ["image", ["concat", "default-", ["to-string", ["get", "reflen"]]]]
+          ],
+          ["concat", ["get", "shield"], "-", ["to-string", ["get", "reflen"]]]
+        ],
+        "icon-rotation-alignment": "viewport",
+        "text-max-angle": 38,
+        "symbol-spacing": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          11,
+          400,
+          14,
+          600
+        ],
+        "text-font": ["DIN Pro Bold", "Arial Unicode MS Bold"],
+        "symbol-placement": ["step", ["zoom"], "point", 11, "line"],
+        "text-rotation-alignment": "viewport",
+        "text-field": ["get", "ref"],
+        "text-letter-spacing": 0.05
+      },
+      "paint": {
+        "text-color": [
+          "case",
+          [
+            "all",
+            ["has", "shield_text_color_beta"],
+            [
+              "to-boolean",
+              [
+                "coalesce",
+                [
+                  "image",
+                  [
+                    "concat",
+                    ["get", "shield_beta"],
+                    "-",
+                    ["to-string", ["get", "reflen"]]
+                  ]
+                ],
+                ""
+              ]
+            ]
+          ],
+          [
+            "match",
+            ["get", "shield_text_color_beta"],
+            "white",
+            "hsl(0, 0%, 100%)",
+            "yellow",
+            "hsl(50, 63%, 70%)",
+            "orange",
+            "hsl(25, 63%, 75%)",
+            "blue",
+            "hsl(230, 36%, 44%)",
+            "red",
+            "hsl(0, 54%, 59%)",
+            "green",
+            "hsl(140, 46%, 37%)",
+            "hsl(230, 11%, 13%)"
+          ],
+          [
+            "match",
+            ["get", "shield_text_color"],
+            "white",
+            "hsl(0, 0%, 100%)",
+            "yellow",
+            "hsl(50, 63%, 70%)",
+            "orange",
+            "hsl(25, 63%, 75%)",
+            "blue",
+            "hsl(230, 36%, 44%)",
+            "red",
+            "hsl(0, 54%, 59%)",
+            "green",
+            "hsl(140, 46%, 37%)",
+            "hsl(230, 11%, 13%)"
+          ]
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, road-labels"
+      }
+    },
+    {
+      "id": "road-exit-shield",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "motorway_junction",
+      "minzoom": 14,
+      "filter": ["all", ["has", "reflen"], ["<=", ["get", "reflen"], 9]],
+      "layout": {
+        "text-field": ["get", "ref"],
+        "text-size": 9,
+        "icon-image": [
+          "concat",
+          "motorway-exit-",
+          ["to-string", ["get", "reflen"]]
+        ],
+        "text-font": ["DIN Pro Bold", "Arial Unicode MS Bold"]
+      },
+      "paint": { "text-color": "hsl(0, 0%, 100%)", "text-translate": [0, 0] },
+      "metadata": {
+        "mapbox:featureComponent": "road-network",
+        "mapbox:group": "Road network, road-labels"
+      }
+    },
+    {
+      "id": "path-pedestrian-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["case", ["has", "layer"], [">=", ["get", "layer"], 0], true],
+        [
+          "step",
+          ["zoom"],
+          ["match", ["get", "class"], ["pedestrian"], true, false],
+          15,
+          ["match", ["get", "class"], ["path", "pedestrian"], true, false]
+        ]
+      ],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          ["match", ["get", "class"], "pedestrian", 9, 6.5],
+          18,
+          ["match", ["get", "class"], "pedestrian", 14, 13]
+        ],
+        "text-max-angle": 30,
+        "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-letter-spacing": 0.01
+      },
+      "paint": {
+        "text-color": "hsl(0,0%, 0%)",
+        "text-halo-color": "hsl(60, 25%, 100%)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., walking-cycling-labels"
+      }
+    },
+    {
+      "id": "golf-hole-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": ["==", ["get", "class"], "golf"],
+      "layout": {
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-size": 12
+      },
+      "paint": {
+        "text-halo-color": "hsl(98, 60%, 55%)",
+        "text-halo-width": 0.5,
+        "text-halo-blur": 0.5,
+        "text-color": "hsl(100, 80%, 18%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "walking-cycling",
+        "mapbox:group": "Walking, cycling, etc., walking-cycling-labels"
+      }
+    },
+    {
+      "id": "ferry-aerialway-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "minzoom": 15,
+      "filter": [
+        "match",
+        ["get", "class"],
+        "aerialway",
+        true,
+        "ferry",
+        true,
+        false
+      ],
+      "layout": {
+        "text-size": ["interpolate", ["linear"], ["zoom"], 10, 6.5, 18, 13],
+        "text-max-angle": 30,
+        "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-letter-spacing": 0.01
+      },
+      "paint": {
+        "text-color": [
+          "match",
+          ["get", "class"],
+          "ferry",
+          "hsl(205, 43%, 100%)",
+          "hsl(230, 50%, 60%)"
+        ],
+        "text-halo-color": [
+          "match",
+          ["get", "class"],
+          "ferry",
+          "hsl(205, 75%, 70%)",
+          "hsl(60, 20%, 100%)"
+        ],
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, ferry-aerialway-labels"
+      }
+    },
+    {
+      "id": "waterway-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "natural_label",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          [
+            "canal",
+            "river",
+            "stream",
+            "disputed_canal",
+            "disputed_river",
+            "disputed_stream"
+          ],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "text-font": ["DIN Pro Italic", "Arial Unicode MS Regular"],
+        "text-max-angle": 30,
+        "symbol-spacing": [
+          "interpolate",
+          ["linear", 1],
+          ["zoom"],
+          15,
+          250,
+          17,
+          400
+        ],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 18, 18],
+        "symbol-placement": "line",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]]
+      },
+      "paint": {
+        "text-color": "hsl(205, 43%, 90%)",
+        "text-halo-color": "hsla(60, 17%, 84%, 0.5)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "natural-features",
+        "mapbox:group": "Natural features, natural-labels"
+      }
+    },
+    {
+      "id": "natural-line-label",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:featureComponent": "natural-features",
+        "mapbox:group": "Natural features, natural-labels"
+      },
+      "source": "composite",
+      "source-layer": "natural_label",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["glacier", "landform", "disputed_glacier", "disputed_landform"],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        ["<=", ["get", "filterrank"], 4],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "text-size": [
+          "step",
+          ["zoom"],
+          ["step", ["get", "sizerank"], 18, 5, 12],
+          17,
+          ["step", ["get", "sizerank"], 18, 13, 12]
+        ],
+        "text-max-angle": 30,
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "symbol-placement": "line-center",
+        "text-pitch-alignment": "viewport"
+      },
+      "paint": {
+        "text-halo-width": 0.5,
+        "text-halo-color": "hsl(60, 17%, 84%)",
+        "text-halo-blur": 0.5,
+        "text-color": "hsl(340, 10%, 38%)"
+      }
+    },
+    {
+      "id": "natural-point-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "natural_label",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          [
+            "dock",
+            "glacier",
+            "landform",
+            "water_feature",
+            "wetland",
+            "disputed_dock",
+            "disputed_glacier",
+            "disputed_landform",
+            "disputed_water_feature",
+            "disputed_wetland"
+          ],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        ["<=", ["get", "filterrank"], 4],
+        ["==", ["geometry-type"], "Point"]
+      ],
+      "layout": {
+        "text-size": [
+          "step",
+          ["zoom"],
+          ["step", ["get", "sizerank"], 18, 5, 12],
+          17,
+          ["step", ["get", "sizerank"], 18, 13, 12]
+        ],
+        "icon-image": ["get", "maki"],
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-offset": [
+          "step",
+          ["zoom"],
+          [
+            "step",
+            ["get", "sizerank"],
+            ["literal", [0, 0]],
+            5,
+            ["literal", [0, 0.8]]
+          ],
+          17,
+          [
+            "step",
+            ["get", "sizerank"],
+            ["literal", [0, 0]],
+            13,
+            ["literal", [0, 0.8]]
+          ]
+        ],
+        "text-anchor": [
+          "step",
+          ["zoom"],
+          ["step", ["get", "sizerank"], "center", 5, "top"],
+          17,
+          ["step", ["get", "sizerank"], "center", 13, "top"]
+        ],
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]]
+      },
+      "paint": {
+        "icon-opacity": [
+          "step",
+          ["zoom"],
+          ["step", ["get", "sizerank"], 0, 5, 1],
+          17,
+          ["step", ["get", "sizerank"], 0, 13, 1]
+        ],
+        "text-halo-color": "hsl(60, 20%, 100%)",
+        "text-halo-width": 0.5,
+        "text-halo-blur": 0.5,
+        "text-color": "hsl(340, 10%, 38%)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "natural-features",
+        "mapbox:group": "Natural features, natural-labels"
+      }
+    },
+    {
+      "id": "water-line-label",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:featureComponent": "natural-features",
+        "mapbox:group": "Natural features, natural-labels"
+      },
+      "source": "composite",
+      "source-layer": "natural_label",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          [
+            "bay",
+            "ocean",
+            "reservoir",
+            "sea",
+            "water",
+            "disputed_bay",
+            "disputed_ocean",
+            "disputed_reservoir",
+            "disputed_sea",
+            "disputed_water"
+          ],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          ["*", ["-", 16, ["sqrt", ["get", "sizerank"]]], 1],
+          22,
+          ["*", ["-", 22, ["sqrt", ["get", "sizerank"]]], 1]
+        ],
+        "text-max-angle": 30,
+        "text-letter-spacing": [
+          "match",
+          ["get", "class"],
+          "ocean",
+          0.25,
+          ["sea", "bay"],
+          0.15,
+          0
+        ],
+        "text-font": ["DIN Pro Italic", "Arial Unicode MS Regular"],
+        "symbol-placement": "line-center",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]]
+      },
+      "paint": {
+        "text-color": [
+          "match",
+          ["get", "class"],
+          ["bay", "ocean", "sea"],
+          "hsl(205, 71%, 90%)",
+          "hsl(205, 43%, 90%)"
+        ],
+        "text-halo-color": "hsla(60, 17%, 84%, 0.5)"
+      }
+    },
+    {
+      "id": "water-point-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "natural_label",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          [
+            "bay",
+            "ocean",
+            "reservoir",
+            "sea",
+            "water",
+            "disputed_bay",
+            "disputed_ocean",
+            "disputed_reservoir",
+            "disputed_sea",
+            "disputed_water"
+          ],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        ["==", ["geometry-type"], "Point"]
+      ],
+      "layout": {
+        "text-line-height": 1.3,
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          ["*", ["-", 16, ["sqrt", ["get", "sizerank"]]], 1],
+          22,
+          ["*", ["-", 22, ["sqrt", ["get", "sizerank"]]], 1]
+        ],
+        "text-font": ["DIN Pro Italic", "Arial Unicode MS Regular"],
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-letter-spacing": [
+          "match",
+          ["get", "class"],
+          "ocean",
+          0.25,
+          ["bay", "sea"],
+          0.15,
+          0.01
+        ],
+        "text-max-width": [
+          "match",
+          ["get", "class"],
+          "ocean",
+          4,
+          "sea",
+          5,
+          ["bay", "water"],
+          7,
+          10
+        ]
+      },
+      "paint": {
+        "text-color": [
+          "match",
+          ["get", "class"],
+          ["bay", "ocean", "sea"],
+          "hsl(205, 71%, 90%)",
+          "hsl(205, 43%, 90%)"
+        ],
+        "text-halo-color": "hsla(60, 17%, 84%, 0.5)"
+      },
+      "metadata": {
+        "mapbox:featureComponent": "natural-features",
+        "mapbox:group": "Natural features, natural-labels"
+      }
+    },
+    {
+      "id": "poi-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "poi_label",
+      "minzoom": 6,
+      "filter": [
+        "<=",
+        ["get", "filterrank"],
+        [
+          "+",
+          ["step", ["zoom"], 0, 16, 1, 17, 2],
+          [
+            "match",
+            ["get", "class"],
+            "food_and_drink_stores",
+            3,
+            "historic",
+            3,
+            "landmark",
+            3,
+            "medical",
+            3,
+            "motorist",
+            3,
+            "park_like",
+            4,
+            "sport_and_leisure",
+            4,
+            "visitor_amenities",
+            4,
+            2
+          ]
+        ]
+      ],
+      "layout": {
+        "text-size": [
+          "step",
+          ["zoom"],
+          ["step", ["get", "sizerank"], 18, 5, 12],
+          17,
+          ["step", ["get", "sizerank"], 18, 13, 12]
+        ],
+        "icon-image": [
+          "case",
+          ["has", "maki_beta"],
+          [
+            "coalesce",
+            ["image", ["get", "maki_beta"]],
+            ["image", ["get", "maki"]]
+          ],
+          ["image", ["get", "maki"]]
+        ],
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-offset": [
+          "step",
+          ["zoom"],
+          [
+            "step",
+            ["get", "sizerank"],
+            ["literal", [0, 0]],
+            5,
+            ["literal", [0, 0.8]]
+          ],
+          17,
+          [
+            "step",
+            ["get", "sizerank"],
+            ["literal", [0, 0]],
+            13,
+            ["literal", [0, 0.8]]
+          ]
+        ],
+        "text-anchor": [
+          "step",
+          ["zoom"],
+          ["step", ["get", "sizerank"], "center", 5, "top"],
+          17,
+          ["step", ["get", "sizerank"], "center", 13, "top"]
+        ],
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]]
+      },
+      "paint": {
+        "icon-opacity": [
+          "step",
+          ["zoom"],
+          ["step", ["get", "sizerank"], 0, 5, 1],
+          17,
+          ["step", ["get", "sizerank"], 0, 13, 1]
+        ],
+        "text-halo-color": "hsl(60, 20%, 100%)",
+        "text-halo-width": 0.5,
+        "text-halo-blur": 0.5,
+        "text-color": [
+          "match",
+          ["get", "class"],
+          "food_and_drink",
+          "hsl(35, 80%, 38%)",
+          "park_like",
+          "hsl(100, 80%, 18%)",
+          "education",
+          "hsl(30, 60%, 28%)",
+          "medical",
+          "hsl(10, 60%, 43%)",
+          "sport_and_leisure",
+          "hsl(210, 60%, 38%)",
+          "hsl(340, 10%, 38%)"
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "point-of-interest-labels",
+        "mapbox:group": "Point of interest labels, poi-labels"
+      }
+    },
+    {
+      "id": "transit-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "transit_stop_label",
+      "minzoom": 12,
+      "filter": [
+        "step",
+        ["zoom"],
+        [
+          "all",
+          ["<=", ["get", "filterrank"], 4],
+          ["match", ["get", "mode"], "rail", true, "metro_rail", true, false],
+          ["!=", ["get", "stop_type"], "entrance"]
+        ],
+        14,
+        [
+          "all",
+          ["match", ["get", "mode"], "rail", true, "metro_rail", true, false],
+          ["!=", ["get", "stop_type"], "entrance"]
+        ],
+        15,
+        [
+          "all",
+          [
+            "match",
+            ["get", "mode"],
+            "rail",
+            true,
+            "metro_rail",
+            true,
+            "ferry",
+            true,
+            "light_rail",
+            true,
+            false
+          ],
+          ["!=", ["get", "stop_type"], "entrance"]
+        ],
+        16,
+        [
+          "all",
+          ["match", ["get", "mode"], "bus", false, true],
+          ["!=", ["get", "stop_type"], "entrance"]
+        ],
+        17,
+        ["!=", ["get", "stop_type"], "entrance"],
+        19,
+        true
+      ],
+      "layout": {
+        "text-size": 12,
+        "icon-image": ["get", "network"],
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-justify": [
+          "match",
+          ["get", "stop_type"],
+          "entrance",
+          "left",
+          "center"
+        ],
+        "text-offset": [
+          "match",
+          ["get", "stop_type"],
+          "entrance",
+          ["literal", [1, 0]],
+          ["literal", [0, 0.8]]
+        ],
+        "text-anchor": [
+          "match",
+          ["get", "stop_type"],
+          "entrance",
+          "left",
+          "top"
+        ],
+        "text-field": [
+          "step",
+          ["zoom"],
+          "",
+          13,
+          [
+            "match",
+            ["get", "mode"],
+            ["rail", "metro_rail"],
+            ["coalesce", ["get", "name_en"], ["get", "name"]],
+            ""
+          ],
+          14,
+          [
+            "match",
+            ["get", "mode"],
+            ["bus", "bicycle"],
+            "",
+            ["coalesce", ["get", "name_en"], ["get", "name"]]
+          ],
+          18,
+          ["coalesce", ["get", "name_en"], ["get", "name"]]
+        ],
+        "text-letter-spacing": 0.01,
+        "text-max-width": ["match", ["get", "stop_type"], "entrance", 15, 9]
+      },
+      "paint": {
+        "text-halo-color": "hsl(60, 20%, 100%)",
+        "text-color": [
+          "match",
+          ["get", "network"],
+          "tokyo-metro",
+          "hsl(180, 30%, 30%)",
+          "mexico-city-metro",
+          "hsl(25, 63%, 63%)",
+          [
+            "barcelona-metro",
+            "delhi-metro",
+            "hong-kong-mtr",
+            "milan-metro",
+            "osaka-subway"
+          ],
+          "hsl(0, 57%, 47%)",
+          ["boston-t", "washington-metro"],
+          "hsl(230, 11%, 20%)",
+          [
+            "chongqing-rail-transit",
+            "kiev-metro",
+            "singapore-mrt",
+            "taipei-metro"
+          ],
+          "hsl(140, 56%, 25%)",
+          "hsl(230, 50%, 60%)"
+        ],
+        "text-halo-blur": 0.5,
+        "text-halo-width": 0.5
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, transit-labels"
+      }
+    },
+    {
+      "id": "airport-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "airport_label",
+      "minzoom": 8,
+      "filter": [
+        "match",
+        ["get", "class"],
+        ["military", "civil", "disputed_military", "disputed_civil"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false],
+        false
+      ],
+      "layout": {
+        "text-line-height": 1.1,
+        "text-size": ["step", ["get", "sizerank"], 18, 9, 12],
+        "icon-image": ["get", "maki"],
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-offset": [0, 0.8],
+        "text-rotation-alignment": "viewport",
+        "text-anchor": "top",
+        "text-field": [
+          "step",
+          ["get", "sizerank"],
+          [
+            "case",
+            ["has", "ref"],
+            [
+              "concat",
+              ["get", "ref"],
+              " -\n",
+              ["coalesce", ["get", "name_en"], ["get", "name"]]
+            ],
+            ["coalesce", ["get", "name_en"], ["get", "name"]]
+          ],
+          15,
+          ["get", "ref"]
+        ],
+        "text-letter-spacing": 0.01,
+        "text-max-width": 9
+      },
+      "paint": {
+        "text-color": "hsl(230, 40%, 55%)",
+        "text-halo-color": "hsl(60, 20%, 100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {
+        "mapbox:featureComponent": "transit",
+        "mapbox:group": "Transit, transit-labels"
+      }
+    },
+    {
+      "id": "settlement-subdivision-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 10,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["settlement_subdivision", "disputed_settlement_subdivision"],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        ["<=", ["get", "filterrank"], 3]
+      ],
+      "layout": {
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-transform": "uppercase",
+        "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
+        "text-letter-spacing": ["match", ["get", "type"], "suburb", 0.15, 0.05],
+        "text-max-width": 7,
+        "text-padding": 3,
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.5, 0, 1, 1],
+          ["zoom"],
+          11,
+          ["match", ["get", "type"], "suburb", 11, 10.5],
+          15,
+          ["match", ["get", "type"], "suburb", 15, 14]
+        ]
+      },
+      "paint": {
+        "text-halo-color": "hsla(60, 25%, 100%, 0.75)",
+        "text-halo-width": 1,
+        "text-color": "hsl(230, 29%, 36%)",
+        "text-halo-blur": 0.5
+      },
+      "metadata": {
+        "mapbox:featureComponent": "place-labels",
+        "mapbox:group": "Place labels, place-labels"
+      }
+    },
+    {
+      "id": "settlement-minor-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 2,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        ["<=", ["get", "filterrank"], 3],
+        [
+          "match",
+          ["get", "class"],
+          ["settlement", "disputed_settlement"],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        [
+          "step",
+          ["zoom"],
+          [">", ["get", "symbolrank"], 6],
+          4,
+          [">=", ["get", "symbolrank"], 7],
+          6,
+          [">=", ["get", "symbolrank"], 8],
+          7,
+          [">=", ["get", "symbolrank"], 10],
+          10,
+          [">=", ["get", "symbolrank"], 11],
+          11,
+          [">=", ["get", "symbolrank"], 13],
+          12,
+          [">=", ["get", "symbolrank"], 15]
+        ]
+      ],
+      "layout": {
+        "symbol-sort-key": ["get", "symbolrank"],
+        "icon-image": [
+          "step",
+          ["zoom"],
+          [
+            "case",
+            ["==", ["get", "capital"], 2],
+            "border-dot-13",
+            ["step", ["get", "symbolrank"], "dot-11", 9, "dot-10", 11, "dot-9"]
+          ],
+          8,
+          ""
+        ],
+        "text-font": ["DIN Pro Regular", "Arial Unicode MS Regular"],
+        "text-radial-offset": [
+          "step",
+          ["zoom"],
+          ["match", ["get", "capital"], 2, 0.6, 0.55],
+          8,
+          0
+        ],
+        "text-anchor": ["step", ["zoom"], ["get", "text_anchor"], 8, "center"],
+        "text-justify": "auto",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-max-width": 7,
+        "text-line-height": 1.1,
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.2, 0, 0.9, 1],
+          ["zoom"],
+          3,
+          ["step", ["get", "symbolrank"], 11, 9, 10],
+          6,
+          ["step", ["get", "symbolrank"], 14, 9, 12, 12, 10],
+          8,
+          ["step", ["get", "symbolrank"], 16, 9, 14, 12, 12, 15, 10],
+          13,
+          ["step", ["get", "symbolrank"], 22, 9, 20, 12, 16, 15, 14]
+        ]
+      },
+      "paint": {
+        "text-color": "hsl(230, 29%, 0%)",
+        "text-halo-color": "hsl(60, 25%, 100%)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      },
+      "metadata": {
+        "mapbox:featureComponent": "place-labels",
+        "mapbox:group": "Place labels, place-labels"
+      }
+    },
+    {
+      "id": "settlement-major-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 2,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        ["<=", ["get", "filterrank"], 3],
+        [
+          "match",
+          ["get", "class"],
+          ["settlement", "disputed_settlement"],
+          ["match", ["get", "worldview"], ["all", "US"], true, false],
+          false
+        ],
+        [
+          "step",
+          ["zoom"],
+          false,
+          2,
+          ["<=", ["get", "symbolrank"], 6],
+          4,
+          ["<", ["get", "symbolrank"], 7],
+          6,
+          ["<", ["get", "symbolrank"], 8],
+          7,
+          ["<", ["get", "symbolrank"], 10],
+          10,
+          ["<", ["get", "symbolrank"], 11],
+          11,
+          ["<", ["get", "symbolrank"], 13],
+          12,
+          ["<", ["get", "symbolrank"], 15],
+          13,
+          [">=", ["get", "symbolrank"], 11],
+          14,
+          [">=", ["get", "symbolrank"], 15]
+        ]
+      ],
+      "layout": {
+        "symbol-sort-key": ["get", "symbolrank"],
+        "icon-image": [
+          "step",
+          ["zoom"],
+          [
+            "case",
+            ["==", ["get", "capital"], 2],
+            "border-dot-13",
+            ["step", ["get", "symbolrank"], "dot-11", 9, "dot-10", 11, "dot-9"]
+          ],
+          8,
+          ""
+        ],
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-radial-offset": [
+          "step",
+          ["zoom"],
+          ["match", ["get", "capital"], 2, 0.6, 0.55],
+          8,
+          0
+        ],
+        "text-anchor": ["step", ["zoom"], ["get", "text_anchor"], 8, "center"],
+        "text-justify": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            ["left", "bottom-left", "top-left"],
+            "left",
+            ["right", "bottom-right", "top-right"],
+            "right",
+            "center"
+          ],
+          8,
+          "center"
+        ],
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-max-width": 7,
+        "text-line-height": 1.1,
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.2, 0, 0.9, 1],
+          ["zoom"],
+          3,
+          ["step", ["get", "symbolrank"], 13, 6, 11],
+          6,
+          ["step", ["get", "symbolrank"], 18, 6, 16, 7, 14],
+          8,
+          ["step", ["get", "symbolrank"], 20, 9, 16, 10, 14],
+          15,
+          ["step", ["get", "symbolrank"], 24, 9, 20, 12, 16, 15, 14]
+        ]
+      },
+      "paint": {
+        "text-color": "hsl(230, 29%, 0%)",
+        "text-halo-color": "hsl(60, 25%, 100%)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      },
+      "metadata": {
+        "mapbox:featureComponent": "place-labels",
+        "mapbox:group": "Place labels, place-labels"
+      }
+    },
+    {
+      "id": "state-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 3,
+      "maxzoom": 9,
+      "filter": [
+        "match",
+        ["get", "class"],
+        ["state", "disputed_state"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false],
+        false
+      ],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.85, 0.7, 0.65, 1],
+          ["zoom"],
+          4,
+          ["step", ["get", "symbolrank"], 9, 6, 8, 7, 7],
+          9,
+          ["step", ["get", "symbolrank"], 21, 6, 16, 7, 14]
+        ],
+        "text-transform": "uppercase",
+        "text-font": ["DIN Pro Bold", "Arial Unicode MS Bold"],
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-letter-spacing": 0.15,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-color": "hsl(230, 29%, 0%)",
+        "text-halo-color": "hsl(60, 25%, 100%)",
+        "text-halo-width": 1,
+        "text-opacity": 0.5
+      },
+      "metadata": {
+        "mapbox:featureComponent": "place-labels",
+        "mapbox:group": "Place labels, place-labels"
+      }
+    },
+    {
+      "id": "country-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 1,
+      "maxzoom": 10,
+      "filter": [
+        "match",
+        ["get", "class"],
+        ["country", "disputed_country"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false],
+        false
+      ],
+      "layout": {
+        "icon-image": "",
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-line-height": 1.1,
+        "text-max-width": 6,
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-radial-offset": ["step", ["zoom"], 0.6, 8, 0],
+        "text-justify": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            ["left", "bottom-left", "top-left"],
+            "left",
+            ["right", "bottom-right", "top-right"],
+            "right",
+            "center"
+          ],
+          7,
+          "auto"
+        ],
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.2, 0, 0.7, 1],
+          ["zoom"],
+          1,
+          ["step", ["get", "symbolrank"], 11, 4, 9, 5, 8],
+          9,
+          ["step", ["get", "symbolrank"], 22, 4, 19, 5, 17]
+        ]
+      },
+      "paint": {
+        "icon-opacity": [
+          "step",
+          ["zoom"],
+          ["case", ["has", "text_anchor"], 1, 0],
+          7,
+          0
+        ],
+        "text-color": "hsl(230, 29%, 0%)",
+        "text-halo-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          2,
+          "hsla(60, 25%, 100%, 0.75)",
+          3,
+          "hsl(60, 25%, 100%)"
+        ],
+        "text-halo-width": 1.25
+      },
+      "metadata": {
+        "mapbox:featureComponent": "place-labels",
+        "mapbox:group": "Place labels, place-labels"
+      }
+    },
+    {
+      "id": "continent-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "natural_label",
+      "minzoom": 0.75,
+      "maxzoom": 3,
+      "filter": ["==", ["get", "class"], "continent"],
+      "layout": {
+        "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
+        "text-line-height": 1.1,
+        "text-max-width": 6,
+        "text-font": ["DIN Pro Medium", "Arial Unicode MS Regular"],
+        "text-size": [
+          "interpolate",
+          ["exponential", 0.5],
+          ["zoom"],
+          0,
+          10,
+          2.5,
+          15
+        ],
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.05
+      },
+      "paint": {
+        "text-color": "hsl(230, 29%, 0%)",
+        "text-halo-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          "hsla(60, 25%, 100%, 0.75)",
+          3,
+          "hsl(60, 25%, 100%)"
+        ],
+        "text-halo-width": 1.5,
+        "text-opacity": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          0.8,
+          1.5,
+          0.5,
+          2.5,
+          0
+        ]
+      },
+      "metadata": {
+        "mapbox:featureComponent": "place-labels",
+        "mapbox:group": "Place labels, place-labels"
+      }
+    }
+  ],
+  "sources": {
+    "composite": {
+      "url": "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2,mapbox.mapbox-bathymetry-v2",
+      "type": "vector"
+    }
+  },
+  "created": "1970-01-01T00:00:00.000Z",
+  "modified": "1970-01-01T00:00:00.000Z",
+  "owner": "mapbox",
+  "id": "outdoors-v12",
+  "draft": false
+}

--- a/tests/fixtures/map-style-definitions/protomaps-dark-v2.json
+++ b/tests/fixtures/map-style-definitions/protomaps-dark-v2.json
@@ -1,0 +1,1942 @@
+{
+  "version": 8,
+  "name": "style@2.0.0-alpha.4 theme@dark",
+  "glyphs": "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
+  "sources": {
+    "protomaps": {
+      "type": "vector",
+      "tiles": [
+        "https://api.protomaps.com/tiles/v3/{z}/{x}/{y}.mvt?key=8a605e96b40ea8c9"
+      ]
+    }
+  },
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": { "background-color": "#34373d" }
+    },
+    {
+      "id": "earth",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "earth",
+      "paint": { "fill-color": "#1f1f1f" }
+    },
+    {
+      "id": "landuse_park",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": [
+        "any",
+        [
+          "in",
+          "pmap:kind",
+          "national_park",
+          "park",
+          "cemetery",
+          "protected_area",
+          "nature_reserve",
+          "forest",
+          "golf_course"
+        ]
+      ],
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          "#232325",
+          12,
+          "#232325"
+        ]
+      }
+    },
+    {
+      "id": "landuse_hospital",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["==", "pmap:kind", "hospital"]],
+      "paint": { "fill-color": "#252424" }
+    },
+    {
+      "id": "landuse_industrial",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["==", "pmap:kind", "industrial"]],
+      "paint": { "fill-color": "#222222" }
+    },
+    {
+      "id": "landuse_school",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["in", "pmap:kind", "school", "university", "college"]],
+      "paint": { "fill-color": "#262323" }
+    },
+    {
+      "id": "landuse_beach",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["in", "pmap:kind", "beach"]],
+      "paint": { "fill-color": "#28282a" }
+    },
+    {
+      "id": "landuse_zoo",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["in", "pmap:kind", "zoo"]],
+      "paint": { "fill-color": "#222323" }
+    },
+    {
+      "id": "landuse_military",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": [
+        "any",
+        ["in", "pmap:kind", "military", "naval_base", "airfield"]
+      ],
+      "paint": { "fill-color": "#222323" }
+    },
+    {
+      "id": "natural_wood",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "natural",
+      "filter": [
+        "any",
+        ["in", "pmap:kind", "wood", "nature_reserve", "forest"]
+      ],
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          "#202121",
+          12,
+          "#202121"
+        ]
+      }
+    },
+    {
+      "id": "natural_scrub",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "natural",
+      "filter": ["in", "pmap:kind", "scrub", "grassland", "grass"],
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          "#222323",
+          12,
+          "#222323"
+        ]
+      }
+    },
+    {
+      "id": "natural_glacier",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "natural",
+      "filter": ["==", "pmap:kind", "glacier"],
+      "paint": { "fill-color": "#1c1c1c" }
+    },
+    {
+      "id": "natural_sand",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "natural",
+      "filter": ["==", "pmap:kind", "sand"],
+      "paint": { "fill-color": "#212123" }
+    },
+    {
+      "id": "landuse_aerodrome",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["in", "pmap:kind", "aerodrome"]],
+      "paint": { "fill-color": "#1e1e1e" }
+    },
+    {
+      "id": "transit_runway",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "transit",
+      "filter": ["any", ["in", "pmap:kind_detail", "runway"]],
+      "paint": {
+        "line-color": "#333333",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          10,
+          0,
+          12,
+          4,
+          18,
+          30
+        ]
+      }
+    },
+    {
+      "id": "transit_taxiway",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "transit",
+      "minzoom": 13,
+      "filter": ["any", ["in", "pmap:kind_detail", "taxiway"]],
+      "paint": {
+        "line-color": "#333333",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1,
+          15,
+          6
+        ]
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "water",
+      "paint": { "fill-color": "#34373d" }
+    },
+    {
+      "id": "physical_line_stream",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "physical_line",
+      "minzoom": 14,
+      "filter": ["all", ["in", "pmap:kind", "stream"]],
+      "paint": { "line-color": "#34373d", "line-width": 0.5 }
+    },
+    {
+      "id": "physical_line_river",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "physical_line",
+      "minzoom": 9,
+      "filter": ["all", ["in", "pmap:kind", "river"]],
+      "paint": {
+        "line-color": "#34373d",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          9,
+          0,
+          9.5,
+          1,
+          18,
+          12
+        ]
+      }
+    },
+    {
+      "id": "landuse_pedestrian",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["==", "pmap:kind", "pedestrian"]],
+      "paint": { "fill-color": "#1e1e1e" }
+    },
+    {
+      "id": "landuse_pier",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "landuse",
+      "filter": ["any", ["==", "pmap:kind", "pier"]],
+      "paint": { "fill-color": "#222222" }
+    },
+    {
+      "id": "roads_tunnels_other_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["in", "pmap:kind", "other", "path"]
+      ],
+      "paint": {
+        "line-color": "#141414",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          14,
+          0,
+          20,
+          7
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_minor_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"]
+      ],
+      "paint": {
+        "line-color": "#141414",
+        "line-dasharray": [3, 2],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          11,
+          0,
+          12.5,
+          0.5,
+          15,
+          2,
+          18,
+          11
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          12,
+          0,
+          12.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_link_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": ["all", ["<", "pmap:level", 0], ["==", "pmap:link", 1]],
+      "paint": {
+        "line-color": "#141414",
+        "line-dasharray": [3, 2],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1,
+          18,
+          11
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          12,
+          0,
+          12.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_medium_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "medium_road"]
+      ],
+      "paint": {
+        "line-color": "#141414",
+        "line-dasharray": [3, 2],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          0.5,
+          18,
+          13
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          10,
+          0,
+          10.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_major_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "major_road"]
+      ],
+      "paint": {
+        "line-color": "#141414",
+        "line-dasharray": [3, 2],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          0.5,
+          18,
+          13
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          9,
+          0,
+          9.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_highway_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "highway"],
+        ["!=", "pmap:link", 1]
+      ],
+      "paint": {
+        "line-color": "#141414",
+        "line-dasharray": [6, 0.5],
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          3.5,
+          0.5,
+          18,
+          15
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          1,
+          20,
+          15
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_other",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["in", "pmap:kind", "other", "path"]
+      ],
+      "paint": {
+        "line-color": "#292929",
+        "line-dasharray": [4.5, 0.5],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          14,
+          0,
+          20,
+          7
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_minor",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"]
+      ],
+      "paint": {
+        "line-color": "#292929",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          11,
+          0,
+          12.5,
+          0.5,
+          15,
+          2,
+          18,
+          11
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_link",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": ["all", ["<", "pmap:level", 0], ["==", "pmap:link", 1]],
+      "paint": {
+        "line-color": "#292929",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1,
+          18,
+          11
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_medium",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "medium_road"]
+      ],
+      "paint": {
+        "line-color": "#292929",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          12,
+          1.2,
+          15,
+          3,
+          18,
+          13
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_major",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "major_road"]
+      ],
+      "paint": {
+        "line-color": "#292929",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          6,
+          0,
+          12,
+          1.6,
+          15,
+          3,
+          18,
+          13
+        ]
+      }
+    },
+    {
+      "id": "roads_tunnels_highway",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["<", "pmap:level", 0],
+        ["==", "pmap:kind", "highway"],
+        ["!=", "pmap:link", 1]
+      ],
+      "paint": {
+        "line-color": "#292929",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          6,
+          1.1,
+          12,
+          1.6,
+          15,
+          5,
+          18,
+          15
+        ]
+      }
+    },
+    {
+      "id": "buildings",
+      "type": "fill",
+      "source": "protomaps",
+      "source-layer": "buildings",
+      "paint": { "fill-color": "#111111", "fill-opacity": 0.5 }
+    },
+    {
+      "id": "transit_pier",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "transit",
+      "filter": ["any", ["==", "pmap:kind", "pier"]],
+      "paint": {
+        "line-color": "#333333",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          12,
+          0,
+          12.5,
+          0.5,
+          20,
+          16
+        ]
+      }
+    },
+    {
+      "id": "roads_minor_service_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"],
+        ["==", "pmap:kind_detail", "service"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          18,
+          8
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          0.8
+        ]
+      }
+    },
+    {
+      "id": "roads_minor_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"],
+        ["!=", "pmap:kind_detail", "service"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          11,
+          0,
+          12.5,
+          0.5,
+          15,
+          2,
+          18,
+          11
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          12,
+          0,
+          12.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_link_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 13,
+      "filter": ["all", ["==", "pmap:link", 1]],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1,
+          18,
+          11
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1.5
+        ]
+      }
+    },
+    {
+      "id": "roads_medium_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "medium_road"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          12,
+          1.2,
+          15,
+          3,
+          18,
+          13
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          10,
+          0,
+          10.5,
+          1.5
+        ]
+      }
+    },
+    {
+      "id": "roads_major_casing_late",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "major_road"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          6,
+          0,
+          12,
+          1.6,
+          15,
+          3,
+          18,
+          13
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          9,
+          0,
+          9.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_highway_casing_late",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "highway"],
+        ["!=", "pmap:link", 1]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          3.5,
+          0.5,
+          18,
+          15
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          1,
+          20,
+          15
+        ]
+      }
+    },
+    {
+      "id": "roads_other",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["in", "pmap:kind", "other", "path"]
+      ],
+      "paint": {
+        "line-color": "#333333",
+        "line-dasharray": [3, 1],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          14,
+          0,
+          20,
+          7
+        ]
+      }
+    },
+    {
+      "id": "roads_link",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": ["all", ["==", "pmap:link", 1]],
+      "paint": {
+        "line-color": "#3d3d3d",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1,
+          18,
+          11
+        ]
+      }
+    },
+    {
+      "id": "roads_minor_service",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"],
+        ["==", "pmap:kind_detail", "service"]
+      ],
+      "paint": {
+        "line-color": "#333333",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          18,
+          8
+        ]
+      }
+    },
+    {
+      "id": "roads_minor",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"],
+        ["!=", "pmap:kind_detail", "service"]
+      ],
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          11,
+          "#3d3d3d",
+          16,
+          "#333333"
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          11,
+          0,
+          12.5,
+          0.5,
+          15,
+          2,
+          18,
+          11
+        ]
+      }
+    },
+    {
+      "id": "roads_medium",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "medium_road"]
+      ],
+      "paint": {
+        "line-color": "#3d3d3d",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          12,
+          1.2,
+          15,
+          3,
+          18,
+          13
+        ]
+      }
+    },
+    {
+      "id": "roads_major_casing_early",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "maxzoom": 12,
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "major_road"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          0.5,
+          18,
+          13
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          9,
+          0,
+          9.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_major",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "major_road"]
+      ],
+      "paint": {
+        "line-color": "#3d3d3d",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          6,
+          0,
+          12,
+          1.6,
+          15,
+          3,
+          18,
+          13
+        ]
+      }
+    },
+    {
+      "id": "roads_highway_casing_early",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "maxzoom": 12,
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "highway"],
+        ["!=", "pmap:link", 1]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          3.5,
+          0.5,
+          18,
+          15
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          1
+        ]
+      }
+    },
+    {
+      "id": "roads_highway",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        ["==", "pmap:level", 0],
+        ["==", "pmap:kind", "highway"],
+        ["!=", "pmap:link", 1]
+      ],
+      "paint": {
+        "line-color": "#474747",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          6,
+          1.1,
+          12,
+          1.6,
+          15,
+          5,
+          18,
+          15
+        ]
+      }
+    },
+    {
+      "id": "transit_railway",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "transit",
+      "filter": ["all", ["==", "pmap:kind", "rail"]],
+      "paint": {
+        "line-dasharray": [0.3, 0.75],
+        "line-opacity": 0.5,
+        "line-color": "#000000",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          6,
+          0.15,
+          18,
+          9
+        ]
+      }
+    },
+    {
+      "id": "boundaries_country",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "boundaries",
+      "filter": ["<=", "pmap:min_admin_level", 2],
+      "paint": {
+        "line-color": "#5b6374",
+        "line-width": 1,
+        "line-dasharray": [3, 2]
+      }
+    },
+    {
+      "id": "boundaries",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "boundaries",
+      "filter": [">", "pmap:min_admin_level", 2],
+      "paint": {
+        "line-color": "#5b6374",
+        "line-width": 0.5,
+        "line-dasharray": [3, 2]
+      }
+    },
+    {
+      "id": "roads_bridges_other_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["in", "pmap:kind", "other", "path"]
+      ],
+      "paint": {
+        "line-color": "#2b2b2b",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          14,
+          0,
+          20,
+          7
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_link_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": ["all", [">", "pmap:level", 0], ["==", "pmap:link", 1]],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1,
+          18,
+          11
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          12,
+          0,
+          12.5,
+          1.5
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_minor_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          11,
+          0,
+          12.5,
+          0.5,
+          15,
+          2,
+          18,
+          11
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          0.8
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_medium_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "medium_road"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          12,
+          1.2,
+          15,
+          3,
+          18,
+          13
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          10,
+          0,
+          10.5,
+          1.5
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_major_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "major_road"]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          0.5,
+          18,
+          10
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          9,
+          0,
+          9.5,
+          1.5
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_other",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["in", "pmap:kind", "other", "path"]
+      ],
+      "paint": {
+        "line-color": "#333333",
+        "line-dasharray": [2, 1],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          14,
+          0,
+          20,
+          7
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_minor",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "minor_road"]
+      ],
+      "paint": {
+        "line-color": "#333333",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          11,
+          0,
+          12.5,
+          0.5,
+          15,
+          2,
+          18,
+          11
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_link",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": ["all", [">", "pmap:level", 0], ["==", "pmap:link", 1]],
+      "paint": {
+        "line-color": "#333333",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          13,
+          0,
+          13.5,
+          1,
+          18,
+          11
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_medium",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "medium_road"]
+      ],
+      "paint": {
+        "line-color": "#3d3d3d",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          12,
+          1.2,
+          15,
+          3,
+          18,
+          13
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_major",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "major_road"]
+      ],
+      "paint": {
+        "line-color": "#3d3d3d",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          6,
+          0,
+          12,
+          1.6,
+          15,
+          3,
+          18,
+          13
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_highway_casing",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "highway"],
+        ["!=", "pmap:link", 1]
+      ],
+      "paint": {
+        "line-color": "#1f1f1f",
+        "line-gap-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          3.5,
+          0.5,
+          18,
+          15
+        ],
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          7,
+          0,
+          7.5,
+          1,
+          20,
+          15
+        ]
+      }
+    },
+    {
+      "id": "roads_bridges_highway",
+      "type": "line",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        [">", "pmap:level", 0],
+        ["==", "pmap:kind", "highway"],
+        ["!=", "pmap:link", 1]
+      ],
+      "paint": {
+        "line-color": "#474747",
+        "line-width": [
+          "interpolate",
+          ["exponential", 1.6],
+          ["zoom"],
+          3,
+          0,
+          6,
+          1.1,
+          12,
+          1.6,
+          15,
+          5,
+          18,
+          15
+        ]
+      }
+    },
+    {
+      "id": "physical_line_waterway_label",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "physical_line",
+      "minzoom": 13,
+      "filter": ["all", ["in", "pmap:kind", "river", "stream"]],
+      "layout": {
+        "symbol-placement": "line",
+        "text-font": ["Noto Sans Regular"],
+        "text-field": ["get", "name"],
+        "text-size": 12,
+        "text-letter-spacing": 0.3
+      },
+      "paint": { "text-color": "#717784" }
+    },
+    {
+      "id": "physical_point_peak",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "physical_point",
+      "filter": ["any", ["==", "pmap:kind", "peak"]],
+      "layout": {
+        "text-font": ["Noto Sans Italic"],
+        "text-field": ["get", "name"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 10, 8, 16, 12],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9
+      },
+      "paint": { "text-color": "#898080", "text-halo-width": 1.5 }
+    },
+    {
+      "id": "roads_labels_minor",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 15,
+      "filter": ["any", ["in", "pmap:kind", "minor_road", "other", "path"]],
+      "layout": {
+        "symbol-sort-key": ["get", "pmap:min_zoom"],
+        "symbol-placement": "line",
+        "text-font": ["Noto Sans Regular"],
+        "text-field": ["get", "name"],
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#525252",
+        "text-halo-color": "#1f1f1f",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "physical_point_ocean",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "physical_point",
+      "filter": [
+        "any",
+        [
+          "in",
+          "pmap:kind",
+          "sea",
+          "ocean",
+          "lake",
+          "water",
+          "bay",
+          "strait",
+          "fjord"
+        ]
+      ],
+      "layout": {
+        "text-font": ["Noto Sans Medium"],
+        "text-field": ["get", "name"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 3, 10, 10, 12],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9,
+        "text-transform": "uppercase"
+      },
+      "paint": { "text-color": "#717784" }
+    },
+    {
+      "id": "physical_point_lakes",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "physical_point",
+      "filter": ["any", ["in", "pmap:kind", "lake", "water"]],
+      "layout": {
+        "text-font": ["Noto Sans Medium"],
+        "text-field": ["get", "name"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 3, 0, 6, 12, 10, 12],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9
+      },
+      "paint": { "text-color": "#717784" }
+    },
+    {
+      "id": "roads_labels_major",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "roads",
+      "minzoom": 11,
+      "filter": [
+        "any",
+        ["in", "pmap:kind", "highway", "major_road", "medium_road"]
+      ],
+      "layout": {
+        "symbol-sort-key": ["get", "pmap:min_zoom"],
+        "symbol-placement": "line",
+        "text-font": ["Noto Sans Regular"],
+        "text-field": ["get", "name"],
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#666666",
+        "text-halo-color": "#1f1f1f",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "places_subplace",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "places",
+      "filter": ["==", "pmap:kind", "neighbourhood"],
+      "layout": {
+        "symbol-sort-key": ["get", "pmap:min_zoom"],
+        "text-field": "{name}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 7,
+        "text-letter-spacing": 0.1,
+        "text-padding": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          5,
+          2,
+          8,
+          4,
+          12,
+          18,
+          15,
+          20
+        ],
+        "text-size": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          11,
+          8,
+          14,
+          14,
+          18,
+          24
+        ],
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#525252",
+        "text-halo-color": "#1f1f1f",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "pois_important",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "pois",
+      "filter": ["any", ["<", ["get", "pmap:min_zoom"], 13]],
+      "layout": {
+        "symbol-sort-key": ["get", "pmap:min_zoom"],
+        "text-font": ["Noto Sans Regular"],
+        "text-field": ["get", "name"],
+        "text-size": 11,
+        "text-max-width": 9,
+        "icon-padding": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          2,
+          14,
+          2,
+          16,
+          20,
+          17,
+          2,
+          22,
+          2
+        ]
+      },
+      "paint": {
+        "text-color": "#525252",
+        "text-halo-color": "#1f1f1f",
+        "text-halo-width": 1.5
+      }
+    },
+    {
+      "id": "places_locality_circle",
+      "type": "circle",
+      "source": "protomaps",
+      "source-layer": "places",
+      "filter": ["==", "pmap:kind", "locality"],
+      "paint": {
+        "circle-radius": 2,
+        "circle-stroke-width": 1.5,
+        "circle-stroke-color": "#7a7a7a",
+        "circle-color": "#000000",
+        "circle-translate": [-6, 0]
+      },
+      "maxzoom": 8
+    },
+    {
+      "id": "places_locality",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "places",
+      "filter": ["==", "pmap:kind", "locality"],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "case",
+          ["<=", ["get", "pmap:min_zoom"], 5],
+          ["literal", ["Noto Sans Medium"]],
+          ["literal", ["Noto Sans Regular"]]
+        ],
+        "text-padding": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          5,
+          3,
+          8,
+          7,
+          12,
+          11
+        ],
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          2,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 13],
+            8,
+            [">=", ["get", "pmap:population_rank"], 13],
+            13,
+            0
+          ],
+          4,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 13],
+            10,
+            [">=", ["get", "pmap:population_rank"], 13],
+            15,
+            0
+          ],
+          6,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 12],
+            11,
+            [">=", ["get", "pmap:population_rank"], 12],
+            17,
+            0
+          ],
+          8,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 11],
+            11,
+            [">=", ["get", "pmap:population_rank"], 11],
+            18,
+            0
+          ],
+          10,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 9],
+            12,
+            [">=", ["get", "pmap:population_rank"], 9],
+            20,
+            0
+          ],
+          15,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 8],
+            12,
+            [">=", ["get", "pmap:population_rank"], 8],
+            22,
+            0
+          ]
+        ],
+        "icon-padding": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          2,
+          8,
+          4,
+          10,
+          8,
+          12,
+          6,
+          22,
+          2
+        ],
+        "text-anchor": ["step", ["zoom"], "left", 8, "center"],
+        "text-radial-offset": 0.2
+      },
+      "paint": {
+        "text-color": "#7a7a7a",
+        "text-halo-color": "#212121",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "places_region",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "places",
+      "filter": ["==", "pmap:kind", "region"],
+      "layout": {
+        "symbol-sort-key": ["get", "pmap:min_zoom"],
+        "text-field": [
+          "step",
+          ["zoom"],
+          ["get", "name:short"],
+          5,
+          ["get", "name"]
+        ],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 3, 11, 7, 24],
+        "text-radial-offset": 0.2,
+        "text-anchor": "center",
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#3d3d3d",
+        "text-halo-color": "#1f1f1f",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "places_country",
+      "type": "symbol",
+      "source": "protomaps",
+      "source-layer": "places",
+      "filter": ["==", "pmap:kind", "country"],
+      "layout": {
+        "symbol-sort-key": ["get", "pmap:min_zoom"],
+        "text-field": "{name}",
+        "text-font": ["Noto Sans Medium"],
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          2,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 10],
+            8,
+            [">=", ["get", "pmap:population_rank"], 10],
+            12,
+            0
+          ],
+          6,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 8],
+            10,
+            [">=", ["get", "pmap:population_rank"], 8],
+            18,
+            0
+          ],
+          8,
+          [
+            "case",
+            ["<", ["get", "pmap:population_rank"], 7],
+            11,
+            [">=", ["get", "pmap:population_rank"], 7],
+            20,
+            0
+          ]
+        ],
+        "icon-padding": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          0,
+          2,
+          14,
+          2,
+          16,
+          20,
+          17,
+          2,
+          22,
+          2
+        ],
+        "text-transform": "uppercase"
+      },
+      "paint": { "text-color": "#5c5c5c" }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #439 
Closes #448

Stacked on #450 

Notes:

- implements the online proxying component of determining which style.json to return handling the stable style url endpoint. Currently assumes that the client will provide an `key` query param when requesting the stable style json endpoint (as opposed to us using some hardcoded token)
- e2e test(s) will be implemented once #457 is merged

TODO:

- [X] ~Potentially use a proper fixture and/or making an actual request to the upstream provider? Right now I mock the response using Undici's mocking mechanisms~ Added fixtures for style.json's from both Mapbox and Protomaps 
- ~Do we want to incorporate a compression plugin? (e.g. https://github.com/fastify/fastify-compress/). Most of the time, these upstream providers are compressing the responses but since we don't have anything set up, our forwarded response is not compressed right now~ EDIT: seems like we don't need to right now based on feedback