### PR TITLE
feat!: rename "Capability" to "Role", attach ID

### DIFF
--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -32,9 +32,9 @@ import {
 import {
   BLOCKED_ROLE_ID,
   COORDINATOR_ROLE_ID,
-  Capabilities,
+  Roles,
   LEFT_ROLE_ID,
-} from './capabilities.js'
+} from './roles.js'
 import {
   getDeviceId,
   projectKeyToId,
@@ -71,7 +71,7 @@ export class MapeoProject extends TypedEmitter {
   #dataTypes
   #blobStore
   #coreOwnership
-  #capabilities
+  #roles
   /** @ts-ignore */
   #ownershipWriteDone
   #sqlite
@@ -246,7 +246,7 @@ export class MapeoProject extends TypedEmitter {
       coreKeypairs,
       identityKeypair,
     })
-    this.#capabilities = new Capabilities({
+    this.#roles = new Roles({
       dataType: this.#dataTypes.role,
       coreOwnership: this.#coreOwnership,
       coreManager: this.#coreManager,
@@ -256,7 +256,7 @@ export class MapeoProject extends TypedEmitter {
 
     this.#memberApi = new MemberApi({
       deviceId: this.#deviceId,
-      capabilities: this.#capabilities,
+      roles: this.#roles,
       coreOwnership: this.#coreOwnership,
       encryptionKeys,
       projectKey,
@@ -298,7 +298,7 @@ export class MapeoProject extends TypedEmitter {
 
     this.#syncApi = new SyncApi({
       coreManager: this.#coreManager,
-      capabilities: this.#capabilities,
+      roles: this.#roles,
       logger: this.#l,
     })
 
@@ -325,7 +325,7 @@ export class MapeoProject extends TypedEmitter {
     }
 
     // When a new peer is found, try to replicate (if it is not a member of the
-    // project it will fail the capability check and be ignored)
+    // project it will fail the role check and be ignored)
     localPeers.on('peer-add', onPeerAdd)
 
     // This happens whenever a peer replicates a core to the stream. SyncApi
@@ -494,8 +494,8 @@ export class MapeoProject extends TypedEmitter {
     }
   }
 
-  async $getOwnCapabilities() {
-    return this.#capabilities.getCapabilities(this.#deviceId)
+  async $getOwnRole() {
+    return this.#roles.getRole(this.#deviceId)
   }
 
   /**
@@ -567,7 +567,7 @@ export class MapeoProject extends TypedEmitter {
       throw new Error('Cannot leave a project as a blocked device')
     }
 
-    const knownDevices = Object.keys(await this.#capabilities.getAll())
+    const knownDevices = Object.keys(await this.#roles.getAll())
     const projectCreatorDeviceId = await this.#coreOwnership.getOwner(
       this.#projectId
     )
@@ -629,7 +629,7 @@ export class MapeoProject extends TypedEmitter {
     // 3.2 Clear indexed data
 
     // 4. Assign LEFT role for device
-    await this.#capabilities.assignRole(this.#deviceId, LEFT_ROLE_ID)
+    await this.#roles.assignRole(this.#deviceId, LEFT_ROLE_ID)
   }
 }
 

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -1,15 +1,15 @@
 import { TypedEmitter } from 'tiny-typed-emitter'
 import { InviteResponse_Decision } from './generated/rpc.js'
 import { projectKeyToId } from './utils.js'
-import { DEFAULT_CAPABILITIES } from './capabilities.js'
+import { ROLES } from './roles.js'
 
 /** @typedef {import('./datatype/index.js').DataType<import('./datastore/index.js').DataStore<'config'>, typeof import('./schema/project.js').deviceInfoTable, "deviceInfo", import('@mapeo/schema').DeviceInfo, import('@mapeo/schema').DeviceInfoValue>} DeviceInfoDataType */
 /** @typedef {import('./datatype/index.js').DataType<import('./datastore/index.js').DataStore<'config'>, typeof import('./schema/client.js').projectSettingsTable, "projectSettings", import('@mapeo/schema').ProjectSettings, import('@mapeo/schema').ProjectSettingsValue>} ProjectDataType */
-/** @typedef {{ deviceId: string, name?: import('@mapeo/schema').DeviceInfo['name'], capabilities: import('./capabilities.js').Capability }} MemberInfo */
+/** @typedef {{ deviceId: string, name?: import('@mapeo/schema').DeviceInfo['name'], role: import('./roles.js').Role }} MemberInfo */
 
 export class MemberApi extends TypedEmitter {
   #ownDeviceId
-  #capabilities
+  #roles
   #coreOwnership
   #encryptionKeys
   #projectKey
@@ -19,7 +19,7 @@ export class MemberApi extends TypedEmitter {
   /**
    * @param {Object} opts
    * @param {string} opts.deviceId public key of this device as hex string
-   * @param {import('./capabilities.js').Capabilities} opts.capabilities
+   * @param {import('./roles.js').Roles} opts.roles
    * @param {import('./core-ownership.js').CoreOwnership} opts.coreOwnership
    * @param {import('./generated/keys.js').EncryptionKeys} opts.encryptionKeys
    * @param {Buffer} opts.projectKey
@@ -30,7 +30,7 @@ export class MemberApi extends TypedEmitter {
    */
   constructor({
     deviceId,
-    capabilities,
+    roles,
     coreOwnership,
     encryptionKeys,
     projectKey,
@@ -39,7 +39,7 @@ export class MemberApi extends TypedEmitter {
   }) {
     super()
     this.#ownDeviceId = deviceId
-    this.#capabilities = capabilities
+    this.#roles = roles
     this.#coreOwnership = coreOwnership
     this.#encryptionKeys = encryptionKeys
     this.#projectKey = projectKey
@@ -51,7 +51,7 @@ export class MemberApi extends TypedEmitter {
    * @param {string} deviceId
    *
    * @param {Object} opts
-   * @param {import('./capabilities.js').RoleId} opts.roleId
+   * @param {import('./roles.js').RoleIdAssignableToOthers} opts.roleId
    * @param {string} [opts.roleName]
    * @param {string} [opts.roleDescription]
    * @param {number} [opts.timeout]
@@ -59,7 +59,7 @@ export class MemberApi extends TypedEmitter {
    * @returns {Promise<import('./generated/rpc.js').InviteResponse_Decision>}
    */
   async invite(deviceId, { roleId, roleName, roleDescription, timeout }) {
-    if (!DEFAULT_CAPABILITIES[roleId]) {
+    if (!ROLES[roleId]) {
       throw new Error('Invalid role id')
     }
 
@@ -82,14 +82,14 @@ export class MemberApi extends TypedEmitter {
       projectKey: this.#projectKey,
       encryptionKeys: this.#encryptionKeys,
       projectInfo: { name: project.name },
-      roleName: roleName || DEFAULT_CAPABILITIES[roleId].name,
+      roleName: roleName || ROLES[roleId].name,
       roleDescription,
       invitorName: deviceName,
       timeout,
     })
 
     if (response === InviteResponse_Decision.ACCEPT) {
-      await this.#capabilities.assignRole(deviceId, roleId)
+      await this.#roles.assignRole(deviceId, roleId)
     }
 
     return response
@@ -100,10 +100,10 @@ export class MemberApi extends TypedEmitter {
    * @returns {Promise<MemberInfo>}
    */
   async getById(deviceId) {
-    const capabilities = await this.#capabilities.getCapabilities(deviceId)
+    const role = await this.#roles.getRole(deviceId)
 
     /** @type {MemberInfo} */
-    const result = { deviceId, capabilities }
+    const result = { deviceId, role }
 
     try {
       const configCoreId = await this.#coreOwnership.getCoreId(
@@ -129,15 +129,15 @@ export class MemberApi extends TypedEmitter {
    * @returns {Promise<Array<MemberInfo>>}
    */
   async getMany() {
-    const [allCapabilities, allDeviceInfo] = await Promise.all([
-      this.#capabilities.getAll(),
+    const [allRoles, allDeviceInfo] = await Promise.all([
+      this.#roles.getAll(),
       this.#dataTypes.deviceInfo.getMany(),
     ])
 
     return Promise.all(
-      Object.entries(allCapabilities).map(async ([deviceId, capabilities]) => {
+      Object.entries(allRoles).map(async ([deviceId, role]) => {
         /** @type {MemberInfo} */
-        const memberInfo = { deviceId, capabilities }
+        const memberInfo = { deviceId, role }
 
         try {
           const configCoreId = await this.#coreOwnership.getCoreId(
@@ -163,10 +163,10 @@ export class MemberApi extends TypedEmitter {
 
   /**
    * @param {string} deviceId
-   * @param {import('./capabilities.js').RoleId} roleId
+   * @param {import('./roles.js').RoleIdAssignableToOthers} roleId
    * @returns {Promise<void>}
    */
   async assignRole(deviceId, roleId) {
-    return this.#capabilities.assignRole(deviceId, roleId)
+    return this.#roles.assignRole(deviceId, roleId)
   }
 }

--- a/src/roles.js
+++ b/src/roles.js
@@ -3,10 +3,12 @@ import mapObject from 'map-obj'
 import { kCreateWithDocId } from './datatype/index.js'
 
 // Randomly generated 8-byte encoded as hex
+export const CREATOR_ROLE_ID = 'a12a6702b93bd7ff'
 export const COORDINATOR_ROLE_ID = 'f7c150f5a3a9a855'
 export const MEMBER_ROLE_ID = '012fd2d431c0bf60'
 export const BLOCKED_ROLE_ID = '9e6d29263cba36c9'
 export const LEFT_ROLE_ID = '8ced989b1904606b'
+export const NO_ROLE_ID = '08e4251e36f6e7ed'
 
 /**
  * @typedef {object} DocCapability
@@ -17,25 +19,51 @@ export const LEFT_ROLE_ID = '8ced989b1904606b'
  */
 
 /**
- * @typedef {object} Capability
+ * @typedef {object} Role
+ * @property {RoleId} roleId
  * @property {string} name
  * @property {Record<import('@mapeo/schema').MapeoDoc['schemaName'], DocCapability>} docs
- * @property {RoleId[]} roleAssignment
+ * @property {RoleIdAssignableToOthers[]} roleAssignment
  * @property {Record<import('./core-manager/core-index.js').Namespace, 'allowed' | 'blocked'>} sync
  */
 
 /**
- * @typedef {typeof COORDINATOR_ROLE_ID | typeof MEMBER_ROLE_ID | typeof BLOCKED_ROLE_ID | typeof LEFT_ROLE_ID} RoleId
+ * @typedef {(
+ *   typeof CREATOR_ROLE_ID |
+ *   typeof COORDINATOR_ROLE_ID |
+ *   typeof MEMBER_ROLE_ID |
+ *   typeof BLOCKED_ROLE_ID |
+ *   typeof LEFT_ROLE_ID |
+ *   typeof NO_ROLE_ID
+ * )} RoleId
  */
 
 /**
- * This is currently the same as 'Coordinator' capabilities, but defined
- * separately because the creator should always have ALL capabilities, but we
- * could edit 'Coordinator' capabilities in the future
- *
- * @type {Capability}
+ * @typedef {Extract<RoleId,
+ *   typeof COORDINATOR_ROLE_ID |
+ *   typeof MEMBER_ROLE_ID |
+ *   typeof BLOCKED_ROLE_ID
+ * >} RoleIdAssignableToOthers
  */
-export const CREATOR_CAPABILITIES = {
+
+/**
+ * @typedef {Extract<RoleId,
+ *   typeof COORDINATOR_ROLE_ID |
+ *   typeof MEMBER_ROLE_ID |
+ *   typeof BLOCKED_ROLE_ID |
+ *   typeof LEFT_ROLE_ID
+ * >} RoleIdAssignableToAnyone
+ */
+
+/**
+ * This is currently the same as 'Coordinator' role, but defined separately
+ * because the creator should always have ALL powers, but we could edit the
+ * 'Coordinator' powers in the future.
+ *
+ * @type {Role}
+ */
+export const CREATOR_ROLE = {
+  roleId: CREATOR_ROLE_ID,
   name: 'Project Creator',
   docs: mapObject(currentSchemaVersions, (key) => {
     return [
@@ -54,16 +82,17 @@ export const CREATOR_CAPABILITIES = {
 }
 
 /**
- * These are the capabilities assumed for a device when no capability record can
- * be found. This can happen when an invited device did not manage to sync with
- * the device that invited them, and they then try to sync with someone else. We
- * want them to be able to sync the auth and config store, because that way they
- * may be able to receive their role record, and they can get the project config
- * so that they can start collecting data.
+ * This is the role assumed for a device when no role record can be found. This
+ * can happen when an invited device did not manage to sync with the device that
+ * invited them, and they then try to sync with someone else. We want them to be
+ * able to sync the auth and config store, because that way they may be able to
+ * receive their role record, and they can get the project config so that they
+ * can start collecting data.
  *
- * @type {Capability}
+ * @type {Role}
  */
-export const NO_ROLE_CAPABILITIES = {
+export const NO_ROLE = {
+  roleId: NO_ROLE_ID,
   name: 'No Role',
   docs: mapObject(currentSchemaVersions, (key) => {
     return [
@@ -81,9 +110,11 @@ export const NO_ROLE_CAPABILITIES = {
   },
 }
 
-/** @type {Record<RoleId, Capability>} */
-export const DEFAULT_CAPABILITIES = {
+/** @type {Record<RoleId, Role>} */
+export const ROLES = {
+  [CREATOR_ROLE_ID]: CREATOR_ROLE,
   [MEMBER_ROLE_ID]: {
+    roleId: MEMBER_ROLE_ID,
     name: 'Member',
     docs: mapObject(currentSchemaVersions, (key) => {
       return [
@@ -101,6 +132,7 @@ export const DEFAULT_CAPABILITIES = {
     },
   },
   [COORDINATOR_ROLE_ID]: {
+    roleId: COORDINATOR_ROLE_ID,
     name: 'Coordinator',
     docs: mapObject(currentSchemaVersions, (key) => {
       return [
@@ -118,6 +150,7 @@ export const DEFAULT_CAPABILITIES = {
     },
   },
   [BLOCKED_ROLE_ID]: {
+    roleId: BLOCKED_ROLE_ID,
     name: 'Blocked',
     docs: mapObject(currentSchemaVersions, (key) => {
       return [
@@ -140,6 +173,7 @@ export const DEFAULT_CAPABILITIES = {
     },
   },
   [LEFT_ROLE_ID]: {
+    roleId: LEFT_ROLE_ID,
     name: 'Left',
     docs: mapObject(currentSchemaVersions, (key) => {
       return [
@@ -161,16 +195,17 @@ export const DEFAULT_CAPABILITIES = {
       blob: 'blocked',
     },
   },
+  [NO_ROLE_ID]: NO_ROLE,
 }
 
-export class Capabilities {
+export class Roles {
   #dataType
   #coreOwnership
   #coreManager
   #projectCreatorAuthCoreId
   #ownDeviceId
 
-  static NO_ROLE_CAPABILITIES = NO_ROLE_CAPABILITIES
+  static NO_ROLE = NO_ROLE
 
   /**
    *
@@ -196,54 +231,53 @@ export class Capabilities {
   }
 
   /**
-   * Get the capabilities for device `deviceId`.
+   * Get the role for device `deviceId`.
    *
    * @param {string} deviceId
-   * @returns {Promise<Capability>}
+   * @returns {Promise<Role>}
    */
-  async getCapabilities(deviceId) {
+  async getRole(deviceId) {
     let roleId
     try {
       const roleAssignment = await this.#dataType.getByDocId(deviceId)
       roleId = roleAssignment.roleId
     } catch (e) {
-      // The project creator will have all capabilities
+      // The project creator will have the creator role
       const authCoreId = await this.#coreOwnership.getCoreId(deviceId, 'auth')
       if (authCoreId === this.#projectCreatorAuthCoreId) {
-        return CREATOR_CAPABILITIES
+        return CREATOR_ROLE
       } else {
         // When no role assignment exists, e.g. a newly added device which has
         // not yet synced role records.
-        return NO_ROLE_CAPABILITIES
+        return NO_ROLE
       }
     }
     if (!isKnownRoleId(roleId)) {
-      return DEFAULT_CAPABILITIES[BLOCKED_ROLE_ID]
+      return ROLES[BLOCKED_ROLE_ID]
     }
-    const capabilities = DEFAULT_CAPABILITIES[roleId]
-    return capabilities
+    return ROLES[roleId]
   }
 
   /**
-   * Get capabilities of all devices in the project. For your own device, if you
-   * have not yet synced your own role record, the "no role" capabilties is
-   * returned. The project creator will have `CREATOR_CAPABILITIES` unless a
-   * different role has been assigned.
+   * Get roles of all devices in the project. For your own device, if you have
+   * not yet synced your own role record, the "no role" capabilties is
+   * returned. The project creator will have the creator role unless a
+   * different one has been assigned.
    *
-   * @returns {Promise<Record<string, Capability>>} Map of deviceId to Capability
+   * @returns {Promise<Record<string, Role>>} Map of deviceId to Role
    */
   async getAll() {
     const roles = await this.#dataType.getMany()
-    /** @type {Record<string, Capability>} */
-    const capabilities = {}
+    /** @type {Record<string, Role>} */
+    const result = {}
     let projectCreatorDeviceId
     try {
       projectCreatorDeviceId = await this.#coreOwnership.getOwner(
         this.#projectCreatorAuthCoreId
       )
-      // Default to creator capabilities, but can be overwritten if a different
-      // role is set below
-      capabilities[projectCreatorDeviceId] = CREATOR_CAPABILITIES
+      // Default to creator role, but can be overwritten if a different role is
+      // set below
+      result[projectCreatorDeviceId] = CREATOR_ROLE
     } catch (e) {
       // Not found, we don't know who the project creator is so we can't include
       // them in the returned map
@@ -252,29 +286,28 @@ export class Capabilities {
     for (const role of roles) {
       const deviceId = role.docId
       if (!isKnownRoleId(role.roleId)) continue
-      capabilities[deviceId] = DEFAULT_CAPABILITIES[role.roleId]
+      result[deviceId] = ROLES[role.roleId]
     }
-    const includesSelf = Boolean(capabilities[this.#ownDeviceId])
+    const includesSelf = Boolean(result[this.#ownDeviceId])
     if (!includesSelf) {
       const isProjectCreator = this.#ownDeviceId === projectCreatorDeviceId
       if (isProjectCreator) {
-        capabilities[this.#ownDeviceId] = CREATOR_CAPABILITIES
+        result[this.#ownDeviceId] = CREATOR_ROLE
       } else {
-        capabilities[this.#ownDeviceId] = NO_ROLE_CAPABILITIES
+        result[this.#ownDeviceId] = NO_ROLE
       }
     }
-    return capabilities
+    return result
   }
 
   /**
    * Assign a role to the specified `deviceId`. Devices without an assigned role
-   * are unable to sync, except the project creator that defaults to having all
-   * capabilities. Only the project creator can assign their own role. Will
-   * throw if the device trying to assign the role lacks the `roleAssignment`
-   * capability for the given roleId
+   * are unable to sync, except the project creator who can do anything. Only
+   * the project creator can assign their own role. Will throw if the device's
+   * role cannot assign the role by consulting `roleAssignment`.
    *
    * @param {string} deviceId
-   * @param {keyof typeof DEFAULT_CAPABILITIES} roleId
+   * @param {RoleIdAssignableToAnyone} roleId
    */
   async assignRole(deviceId, roleId) {
     let fromIndex = 0
@@ -299,15 +332,15 @@ export class Capabilities {
         "Only the project creator can assign the project creator's role"
       )
     }
-    const ownCapabilities = await this.getCapabilities(this.#ownDeviceId)
+    const ownRole = await this.getRole(this.#ownDeviceId)
 
     if (roleId === LEFT_ROLE_ID) {
       if (deviceId !== this.#ownDeviceId) {
         throw new Error('Cannot assign LEFT role to another device')
       }
     } else {
-      if (!ownCapabilities.roleAssignment.includes(roleId)) {
-        throw new Error('No capability to assign role ' + roleId)
+      if (!ownRole.roleAssignment.includes(roleId)) {
+        throw new Error('Lacks permission to assign role ' + roleId)
       }
     }
 
@@ -344,8 +377,8 @@ export class Capabilities {
 /**
  *
  * @param {string} roleId
- * @returns {roleId is keyof DEFAULT_CAPABILITIES}
+ * @returns {roleId is keyof ROLES}
  */
 function isKnownRoleId(roleId) {
-  return roleId in DEFAULT_CAPABILITIES
+  return roleId in ROLES
 }

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -7,7 +7,7 @@ import { createMap } from '../utils.js'
  * @typedef {import('../core-manager/index.js').Namespace} Namespace
  */
 /**
- * @typedef {import('../capabilities.js').Capability['sync'][Namespace] | 'unknown'} SyncCapability
+ * @typedef {import('../roles.js').Role['sync'][Namespace] | 'unknown'} SyncCapability
  */
 
 /** @type {Namespace[]} */
@@ -22,7 +22,7 @@ export class PeerSyncController {
   #enabledNamespaces = new Set()
   #coreManager
   #protomux
-  #capabilities
+  #roles
   /** @type {Record<Namespace, SyncCapability>} */
   #syncCapability = createNamespaceMap('unknown')
   #isDataSyncEnabled = false
@@ -41,10 +41,10 @@ export class PeerSyncController {
    * @param {import("protomux")<import('../utils.js').OpenedNoiseStream>} opts.protomux
    * @param {import("../core-manager/index.js").CoreManager} opts.coreManager
    * @param {import("./sync-state.js").SyncState} opts.syncState
-   * @param {import("../capabilities.js").Capabilities} opts.capabilities
+   * @param {import('../roles.js').Roles} opts.roles
    * @param {Logger} [opts.logger]
    */
-  constructor({ protomux, coreManager, syncState, capabilities, logger }) {
+  constructor({ protomux, coreManager, syncState, roles, logger }) {
     // @ts-ignore
     this.#log = (formatter, ...args) => {
       const log = Logger.create('peer', logger).log
@@ -56,7 +56,7 @@ export class PeerSyncController {
     }
     this.#coreManager = coreManager
     this.#protomux = protomux
-    this.#capabilities = capabilities
+    this.#roles = roles
 
     // Always need to replicate the project creator core
     this.#replicateCore(coreManager.creatorCore)
@@ -170,10 +170,10 @@ export class PeerSyncController {
 
     if (didUpdate.auth) {
       try {
-        const cap = await this.#capabilities.getCapabilities(this.peerId)
+        const cap = await this.#roles.getRole(this.peerId)
         this.#syncCapability = cap.sync
       } catch (e) {
-        this.#log('Error reading capability', e)
+        this.#log('Error reading role', e)
         // Any error, consider sync unknown
         this.#syncCapability = createNamespaceMap('unknown')
       }

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -43,7 +43,7 @@ export const kSyncState = Symbol('sync state')
  */
 export class SyncApi extends TypedEmitter {
   #coreManager
-  #capabilities
+  #roles
   /** @type {Map<import('protomux'), PeerSyncController>} */
   #peerSyncControllers = new Map()
   /** @type {Set<string>} */
@@ -58,15 +58,15 @@ export class SyncApi extends TypedEmitter {
    *
    * @param {object} opts
    * @param {import('../core-manager/index.js').CoreManager} opts.coreManager
-   * @param {import("../capabilities.js").Capabilities} opts.capabilities
+   * @param {import('../roles.js').Roles} opts.roles
    * @param {number} [opts.throttleMs]
    * @param {Logger} [opts.logger]
    */
-  constructor({ coreManager, throttleMs = 200, capabilities, logger }) {
+  constructor({ coreManager, throttleMs = 200, roles, logger }) {
     super()
     this.#l = Logger.create('syncApi', logger)
     this.#coreManager = coreManager
-    this.#capabilities = capabilities
+    this.#roles = roles
     this[kSyncState] = new SyncState({ coreManager, throttleMs })
     this[kSyncState].setMaxListeners(0)
     this[kSyncState].on('state', (namespaceSyncState) => {
@@ -181,7 +181,7 @@ export class SyncApi extends TypedEmitter {
       protomux,
       coreManager: this.#coreManager,
       syncState: this[kSyncState],
-      capabilities: this.#capabilities,
+      roles: this.#roles,
       logger: this.#l,
     })
     this.#peerSyncControllers.set(protomux, peerSyncController)

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,11 +104,6 @@ export type KeyPair = {
   publicKey: PublicKey
   secretKey: SecretKey
 }
-export type RoleDetails = {
-  name: string
-  capabilities: string[]
-}
-export type AvailableRoles = RoleDetails[]
 
 export type Statement = {
   id: string

--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -289,7 +289,7 @@ test('Consistent storage folders', async (t) => {
     )
     const project = await manager.getProject(projectId)
     // awaiting this ensures that indexing is done, which means that indexer storage is created
-    await project.$getOwnCapabilities()
+    await project.$getOwnRole()
   }
 
   // @ts-ignore snapshot() is missing from typedefs

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -7,7 +7,7 @@ import {
   disconnectPeers,
   waitForPeers,
 } from './utils.js'
-import { COORDINATOR_ROLE_ID, MEMBER_ROLE_ID } from '../src/capabilities.js'
+import { COORDINATOR_ROLE_ID, MEMBER_ROLE_ID } from '../src/roles.js'
 
 test('member invite accepted', async (t) => {
   const [creator, joiner] = await createManagers(2, t)
@@ -112,7 +112,7 @@ test('chain of invites', async (t) => {
   await disconnectPeers(managers)
 })
 
-// TODO: Needs fix to inviteApi to check capabilities before sending invite
+// TODO: Needs fix to inviteApi to check role before sending invite
 skip("member can't invite", async (t) => {
   const managers = await createManagers(3, t)
   const [creator, member, joiner] = managers

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -3,10 +3,10 @@ import { test } from 'brittle'
 import {
   BLOCKED_ROLE_ID,
   COORDINATOR_ROLE_ID,
-  DEFAULT_CAPABILITIES,
+  ROLES,
   LEFT_ROLE_ID,
   MEMBER_ROLE_ID,
-} from '../src/capabilities.js'
+} from '../src/roles.js'
 import { MapeoProject } from '../src/mapeo-project.js'
 import {
   connectPeers,
@@ -89,8 +89,8 @@ test('Blocked member cannot leave project', async (t) => {
   const [creatorProject, memberProject] = projects
 
   t.alike(
-    await memberProject.$getOwnCapabilities(),
-    DEFAULT_CAPABILITIES[MEMBER_ROLE_ID],
+    await memberProject.$getOwnRole(),
+    ROLES[MEMBER_ROLE_ID],
     'Member is initially a member'
   )
 
@@ -99,8 +99,8 @@ test('Blocked member cannot leave project', async (t) => {
   await waitForSync(projects, 'initial')
 
   t.alike(
-    await memberProject.$getOwnCapabilities(),
-    DEFAULT_CAPABILITIES[BLOCKED_ROLE_ID],
+    await memberProject.$getOwnRole(),
+    ROLES[BLOCKED_ROLE_ID],
     'Member is now blocked'
   )
 
@@ -146,16 +146,16 @@ test('Creator can leave project if another coordinator exists', async (t) => {
   await creator.leaveProject(projectId)
 
   t.alike(
-    await creatorProject.$getOwnCapabilities(),
-    DEFAULT_CAPABILITIES[LEFT_ROLE_ID],
-    'creator now has LEFT role id and capabilities'
+    await creatorProject.$getOwnRole(),
+    ROLES[LEFT_ROLE_ID],
+    'creator now has LEFT role'
   )
 
   await waitForSync(projects, 'initial')
 
   t.is(
-    (await coordinatorProject.$member.getById(creator.deviceId)).capabilities,
-    DEFAULT_CAPABILITIES[LEFT_ROLE_ID],
+    (await coordinatorProject.$member.getById(creator.deviceId)).role,
+    ROLES[LEFT_ROLE_ID],
     'coordinator can still retrieve info about creator who left'
   )
 
@@ -197,16 +197,16 @@ test('Member can leave project if creator exists', async (t) => {
   await member.leaveProject(projectId)
 
   t.alike(
-    await memberProject.$getOwnCapabilities(),
-    DEFAULT_CAPABILITIES[LEFT_ROLE_ID],
-    'member now has LEFT role id and capabilities'
+    await memberProject.$getOwnRole(),
+    ROLES[LEFT_ROLE_ID],
+    'member now has LEFT role'
   )
 
   await waitForSync(projects, 'initial')
 
   t.is(
-    (await creatorProject.$member.getById(member.deviceId)).capabilities,
-    DEFAULT_CAPABILITIES[LEFT_ROLE_ID],
+    (await creatorProject.$member.getById(member.deviceId)).role,
+    ROLES[LEFT_ROLE_ID],
     'creator can still retrieve info about member who left'
   )
 

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -14,7 +14,7 @@ import { PRESYNC_NAMESPACES } from '../src/sync/peer-sync-controller.js'
 import { generate } from '@mapeo/mock-data'
 import { valueOf } from '../src/utils.js'
 import pTimeout from 'p-timeout'
-import { BLOCKED_ROLE_ID, COORDINATOR_ROLE_ID } from '../src/capabilities.js'
+import { BLOCKED_ROLE_ID, COORDINATOR_ROLE_ID } from '../src/roles.js'
 import { kSyncState } from '../src/sync/sync-api.js'
 
 const SCHEMAS_INITIAL_SYNC = ['preset', 'field']

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -11,7 +11,7 @@ import { valueOf } from '../src/utils.js'
 import { randomInt } from 'node:crypto'
 import { temporaryDirectory } from 'tempy'
 import fsPromises from 'node:fs/promises'
-import { MEMBER_ROLE_ID } from '../src/capabilities.js'
+import { MEMBER_ROLE_ID } from '../src/roles.js'
 import { kSyncState } from '../src/sync/sync-api.js'
 
 const FAST_TESTS = !!process.env.FAST_TESTS
@@ -78,7 +78,7 @@ export function connectPeers(managers, { discovery = true } = {}) {
  *   invitor: MapeoManager,
  *   projectId: string,
  *   invitees: MapeoManager[],
- *   roleId?: import('../src/capabilities.js').RoleId,
+ *   roleId?: import('../src/roles.js').RoleIdAssignableToOthers,
  *   roleName?: string
  *   reject?: boolean
  * }} opts

--- a/tests/invite-api.js
+++ b/tests/invite-api.js
@@ -7,7 +7,7 @@ import { projectKeyToPublicId } from '../src/utils.js'
 import { replicate } from './helpers/local-peers.js'
 import NoiseSecretStream from '@hyperswarm/secret-stream'
 import pDefer from 'p-defer'
-import { DEFAULT_CAPABILITIES, MEMBER_ROLE_ID } from '../src/capabilities.js'
+import { ROLES, MEMBER_ROLE_ID } from '../src/roles.js'
 
 test('invite-received event has expected payload', async (t) => {
   t.plan(7)
@@ -43,7 +43,7 @@ test('invite-received event has expected payload', async (t) => {
       projectKey,
       encryptionKeys,
       projectInfo: { name: 'Mapeo' },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     }
     r1.invite(peers[0].deviceId, invite)
@@ -55,7 +55,7 @@ test('invite-received event has expected payload', async (t) => {
       t.is(peerId, expectedInvitorPeerId)
       t.is(projectName, 'Mapeo')
       t.is(projectId, projectKeyToPublicId(projectKey))
-      t.is(roleName, DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name)
+      t.is(roleName, ROLES[MEMBER_ROLE_ID].name)
       t.is(invitorName, 'device0')
     }
   )
@@ -92,7 +92,7 @@ test('Accept invite', async (t) => {
       projectKey,
       encryptionKeys,
       projectInfo: { name: 'Mapeo' },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     }
     const response = await r1.invite(peers[0].deviceId, invite)
@@ -140,7 +140,7 @@ test('Reject invite', async (t) => {
       projectKey,
       encryptionKeys,
       projectInfo: { name: 'Mapeo' },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     }
     const response = await r1.invite(peers[0].deviceId, invite)
@@ -186,7 +186,7 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
         projectKey,
         encryptionKeys,
         projectInfo: { name: 'Mapeo' },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       }
       const response = await r1.invite(peers[0].deviceId, invite)
@@ -233,7 +233,7 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
           projectKey,
           encryptionKeys,
           projectInfo: { name: 'Mapeo' },
-          roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+          roleName: ROLES[MEMBER_ROLE_ID].name,
           invitorName: 'device0',
         }
 
@@ -282,7 +282,7 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
         projectKey,
         encryptionKeys,
         projectInfo: { name: 'Mapeo' },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       }
       const response1 = await r1.invite(peers[0].deviceId, invite)
@@ -348,7 +348,7 @@ test('invitor disconnecting results in accept throwing', async (t) => {
         projectKey,
         encryptionKeys,
         projectInfo: { name: 'Mapeo' },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       }
       return r1.invite(peers[0].deviceId, invite)
@@ -389,7 +389,7 @@ test('invitor disconnecting results in invite reject response not throwing', asy
         projectKey,
         encryptionKeys,
         projectInfo: { name: 'Mapeo' },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       }
       return r1.invite(peers[0].deviceId, invite)
@@ -433,7 +433,7 @@ test('invitor disconnecting results in invite already response not throwing', as
         projectKey,
         encryptionKeys,
         projectInfo: { name: 'Mapeo' },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       }
       return r1.invite(peers[0].deviceId, invite)
@@ -473,7 +473,7 @@ test('addProject throwing results in invite accept throwing', async (t) => {
       projectKey,
       encryptionKeys,
       projectInfo: { name: 'Mapeo' },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     }
     r1.invite(peers[0].deviceId, invite)
@@ -538,7 +538,7 @@ test('Invite from multiple peers', async (t) => {
         projectKey,
         encryptionKeys,
         projectInfo: { name: 'Mapeo' },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       }
       const response = await invitor.invite(peers[0].deviceId, invite)
@@ -615,7 +615,7 @@ test.skip('Invite from multiple peers, first disconnects before accepted, receiv
           projectKey,
           encryptionKeys,
           projectInfo: { name: 'Mapeo' },
-          roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+          roleName: ROLES[MEMBER_ROLE_ID].name,
           invitorName: 'device0',
         }
         const response = await invitor.invite(peers[0].deviceId, invite)

--- a/tests/local-peers.js
+++ b/tests/local-peers.js
@@ -14,7 +14,7 @@ import { randomBytes } from 'node:crypto'
 import NoiseSecretStream from '@hyperswarm/secret-stream'
 import Protomux from 'protomux'
 import { setTimeout as delay } from 'timers/promises'
-import { DEFAULT_CAPABILITIES, MEMBER_ROLE_ID } from '../src/capabilities.js'
+import { ROLES, MEMBER_ROLE_ID } from '../src/roles.js'
 
 test('Send invite and accept', async (t) => {
   t.plan(3)
@@ -28,7 +28,7 @@ test('Send invite and accept', async (t) => {
     const response = await r1.invite(peers[0].deviceId, {
       projectKey,
       encryptionKeys: { auth: randomBytes(32) },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     })
     t.is(response, LocalPeers.InviteResponse.ACCEPT)
@@ -59,7 +59,7 @@ test('Send invite immediately', async (t) => {
   const responsePromise = r1.invite(kp2.publicKey.toString('hex'), {
     projectKey,
     encryptionKeys: { auth: randomBytes(32) },
-    roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+    roleName: ROLES[MEMBER_ROLE_ID].name,
     invitorName: 'device0',
   })
 
@@ -82,7 +82,7 @@ test('Send invite, duplicate connections', async (t) => {
   const invite = {
     projectKey: Buffer.allocUnsafe(32).fill(0),
     encryptionKeys: { auth: randomBytes(32) },
-    roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+    roleName: ROLES[MEMBER_ROLE_ID].name,
     invitorName: 'device0',
   }
 
@@ -149,7 +149,7 @@ test('Duplicate connections with immediate disconnect', async (t) => {
   const invite = {
     projectKey: Buffer.allocUnsafe(32).fill(0),
     encryptionKeys: { auth: randomBytes(32) },
-    roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+    roleName: ROLES[MEMBER_ROLE_ID].name,
     invitorName: 'device0',
   }
 
@@ -184,7 +184,7 @@ test('Send invite and reject', async (t) => {
     const response = await r1.invite(peers[0].deviceId, {
       projectKey,
       encryptionKeys: { auth: randomBytes(32) },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     })
     t.is(response, LocalPeers.InviteResponse.REJECT)
@@ -214,7 +214,7 @@ test('Invite to unknown peer', async (t) => {
     r1.invite(unknownPeerId, {
       projectKey,
       encryptionKeys: { auth: randomBytes(32) },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     }),
     UnknownPeerError
@@ -241,7 +241,7 @@ test('Send invite and already on project', async (t) => {
     const response = await r1.invite(peers[0].deviceId, {
       projectKey,
       encryptionKeys: { auth: randomBytes(32) },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     })
     t.is(response, LocalPeers.InviteResponse.ALREADY)
@@ -274,7 +274,7 @@ test('Send invite with encryption key', async (t) => {
     const response = await r1.invite(peers[0].deviceId, {
       projectKey,
       encryptionKeys,
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     })
     t.is(response, LocalPeers.InviteResponse.ACCEPT)
@@ -310,7 +310,7 @@ test('Send invite with project info', async (t) => {
       projectKey,
       projectInfo,
       encryptionKeys: { auth: randomBytes(32) },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     })
     t.is(response, LocalPeers.InviteResponse.ACCEPT)
@@ -371,7 +371,7 @@ test('Disconnect results in rejected invite', async (t) => {
       const invite = r1.invite(peers[0].deviceId, {
         projectKey,
         encryptionKeys: { auth: randomBytes(32) },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       })
       await t.exception(
@@ -408,7 +408,7 @@ test('Invite to multiple peers', async (t) => {
         r1.invite(peer.deviceId, {
           projectKey,
           encryptionKeys: { auth: randomBytes(32) },
-          roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+          roleName: ROLES[MEMBER_ROLE_ID].name,
           invitorName: 'device0',
         })
       )
@@ -447,7 +447,7 @@ test('Multiple invites to a peer, only one response', async (t) => {
 
   const projectKey = Buffer.allocUnsafe(32).fill(0)
   const inviteFields = {
-    roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+    roleName: ROLES[MEMBER_ROLE_ID].name,
     invitorName: 'device0',
   }
   r1.on('peers', async (peers) => {
@@ -499,7 +499,7 @@ test('Default: invites do not timeout', async (t) => {
     r1.invite(peers[0].deviceId, {
       projectKey,
       encryptionKeys: { auth: randomBytes(32) },
-      roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+      roleName: ROLES[MEMBER_ROLE_ID].name,
       invitorName: 'device0',
     }).then(
       () => t.fail('invite promise should not resolve'),
@@ -529,7 +529,7 @@ test('Invite timeout', async (t) => {
           projectKey,
           timeout: 5000,
           encryptionKeys: { auth: randomBytes(32) },
-          roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+          roleName: ROLES[MEMBER_ROLE_ID].name,
           invitorName: 'device0',
         }),
       TimeoutError
@@ -551,7 +551,7 @@ test('Send invite to non-existent peer', async (t) => {
         projectKey,
         timeout: 1000,
         encryptionKeys: { auth: randomBytes(32) },
-        roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+        roleName: ROLES[MEMBER_ROLE_ID].name,
         invitorName: 'device0',
       }),
     UnknownPeerError
@@ -586,7 +586,7 @@ test('Reconnect peer and send invite', async (t) => {
   const response = await r1.invite(peers[0].deviceId, {
     projectKey,
     encryptionKeys: { auth: randomBytes(32) },
-    roleName: DEFAULT_CAPABILITIES[MEMBER_ROLE_ID].name,
+    roleName: ROLES[MEMBER_ROLE_ID].name,
     invitorName: 'device0',
   })
   t.is(response, LocalPeers.InviteResponse.ACCEPT)


### PR DESCRIPTION
This change makes several improvements to the concept formerly known as "capabilities":

- `Capability` is now called `Role` across the project, resulting in many simple renames.

- `Role`s have an attached `roleId` property, which they didn't before.

- The creator role and "no role" role now have role IDs.[^1]

- The `RoleId` type now includes all possible role types, now including the creator role and the "no role" role. I created narrower types such as `RoleIdAssignableToOthers` and `RoleIdAssignableToAnyone`, which don't include those.

This should help the front-end know what role someone is (for example, <https://github.com/digidem/CoMapeo-mobile/pull/79#discussion_r1470494854>).

[^1]: I generated these with `crypto.randomBytes(8).toString('hex')`.
