### PR TITLE
chore: use looser type for Brittle's teardown function

### DIFF
--- a/types/brittle.d.ts
+++ b/types/brittle.d.ts
@@ -43,7 +43,7 @@ declare module 'brittle' {
 
   export interface TestInstance extends Assertion {
     plan(n: number): void
-    teardown(fn: () => void | Promise<void>, options?: { order?: number }): void
+    teardown(fn: () => unknown | Promise<unknown>, options?: { order?: number }): void
     timeout(ms: number): void
     comment(message: string): void
     end(): void


### PR DESCRIPTION
`t.teardown` [doesn't care about the return type of its callback][0] so I updated the types to match.

[0]: https://github.com/holepunchto/brittle/blob/8926893862dc1ecf9a213fedf2306f24fe47b8cc/index.js#L640
