### PR TITLE
chore: use upstream types for sub-encoder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@types/node": "^18.16.3",
         "@types/sinonjs__fake-timers": "^8.1.2",
         "@types/streamx": "^2.9.1",
+        "@types/sub-encoder": "^2.1.0",
         "@types/throttle-debounce": "^5.0.0",
         "@types/varint": "^6.0.1",
         "bitfield": "^4.1.0",
@@ -962,6 +963,15 @@
     "node_modules/@types/streamx": {
       "version": "2.9.1",
       "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sub-encoder": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/sub-encoder/-/sub-encoder-2.1.0.tgz",
+      "integrity": "sha512-50CGa2jmJetNAic8Xf4KXZjcdDnfL3QPi2hOQqtICV6Gw82inD7tLCfmF0NqpqL/mH55WLUgqX2IBteEEVl+TA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/node": "^18.16.3",
     "@types/sinonjs__fake-timers": "^8.1.2",
     "@types/streamx": "^2.9.1",
+    "@types/sub-encoder": "^2.1.0",
     "@types/throttle-debounce": "^5.0.0",
     "@types/varint": "^6.0.1",
     "bitfield": "^4.1.0",

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -5,7 +5,6 @@
 // - DhtNode
 
 declare module 'sodium-universal'
-declare module 'sub-encoder'
 
 declare module 'kademlia-routing-table' {
   import { TypedEmitter } from 'tiny-typed-emitter'


### PR DESCRIPTION
[@types/sub-encoder was recently created][0] so we can use that instead of defining our own type.

[0]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68390
