### PR TITLE
test: assert on result, not promise itself

### DIFF
--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -190,7 +190,7 @@ test('Member can leave project if creator exists', async (t) => {
   )
 
   t.ok(
-    memberProject.$member.getById(creator.deviceId),
+    await memberProject.$member.getById(creator.deviceId),
     'creator successfully added from member perspective'
   )
 


### PR DESCRIPTION
`t.ok(myPromise)` should probably be `t.ok(await myPromise)`.

I noticed a spot where we weren't doing this so I thought I'd fix it.

In the long term, we may wish to add an ESLint rule to avoid floating promises...but I think this is useful in the short term.