### PR TITLE
chore!: remove "already part of project" invite response

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -18,7 +18,6 @@ message InviteResponse {
   enum Decision {
     REJECT = 0;
     ACCEPT = 1;
-    ALREADY = 2;
   }
   bytes projectKey = 1;
   Decision decision = 2;

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -20,7 +20,6 @@ export interface InviteResponse {
 export declare const InviteResponse_Decision: {
     readonly REJECT: "REJECT";
     readonly ACCEPT: "ACCEPT";
-    readonly ALREADY: "ALREADY";
     readonly UNRECOGNIZED: "UNRECOGNIZED";
 };
 export type InviteResponse_Decision = typeof InviteResponse_Decision[keyof typeof InviteResponse_Decision];

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -1,12 +1,7 @@
 /* eslint-disable */
 import _m0 from "protobufjs/minimal.js";
 import { EncryptionKeys } from "./keys.js";
-export var InviteResponse_Decision = {
-    REJECT: "REJECT",
-    ACCEPT: "ACCEPT",
-    ALREADY: "ALREADY",
-    UNRECOGNIZED: "UNRECOGNIZED",
-};
+export var InviteResponse_Decision = { REJECT: "REJECT", ACCEPT: "ACCEPT", UNRECOGNIZED: "UNRECOGNIZED" };
 export function inviteResponse_DecisionFromJSON(object) {
     switch (object) {
         case 0:
@@ -15,9 +10,6 @@ export function inviteResponse_DecisionFromJSON(object) {
         case 1:
         case "ACCEPT":
             return InviteResponse_Decision.ACCEPT;
-        case 2:
-        case "ALREADY":
-            return InviteResponse_Decision.ALREADY;
         case -1:
         case "UNRECOGNIZED":
         default:
@@ -30,8 +22,6 @@ export function inviteResponse_DecisionToNumber(object) {
             return 0;
         case InviteResponse_Decision.ACCEPT:
             return 1;
-        case InviteResponse_Decision.ALREADY:
-            return 2;
         case InviteResponse_Decision.UNRECOGNIZED:
         default:
             return -1;

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -21,12 +21,7 @@ export interface InviteResponse {
   decision: InviteResponse_Decision;
 }
 
-export const InviteResponse_Decision = {
-  REJECT: "REJECT",
-  ACCEPT: "ACCEPT",
-  ALREADY: "ALREADY",
-  UNRECOGNIZED: "UNRECOGNIZED",
-} as const;
+export const InviteResponse_Decision = { REJECT: "REJECT", ACCEPT: "ACCEPT", UNRECOGNIZED: "UNRECOGNIZED" } as const;
 
 export type InviteResponse_Decision = typeof InviteResponse_Decision[keyof typeof InviteResponse_Decision];
 
@@ -38,9 +33,6 @@ export function inviteResponse_DecisionFromJSON(object: any): InviteResponse_Dec
     case 1:
     case "ACCEPT":
       return InviteResponse_Decision.ACCEPT;
-    case 2:
-    case "ALREADY":
-      return InviteResponse_Decision.ALREADY;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -54,8 +46,6 @@ export function inviteResponse_DecisionToNumber(object: InviteResponse_Decision)
       return 0;
     case InviteResponse_Decision.ACCEPT:
       return 1;
-    case InviteResponse_Decision.ALREADY:
-      return 2;
     case InviteResponse_Decision.UNRECOGNIZED:
     default:
       return -1;

--- a/src/invite-api.js
+++ b/src/invite-api.js
@@ -75,7 +75,7 @@ export class InviteApi extends TypedEmitter {
     const isAlreadyMember = await this.#isMember(projectId)
 
     if (isAlreadyMember) {
-      this.#sendAlreadyResponse({ peerId, projectId })
+      this.#sendRejectResponse({ peerId, projectId })
       return
     }
 
@@ -112,7 +112,7 @@ export class InviteApi extends TypedEmitter {
 
     if (isAlreadyMember) {
       for (const peerId of peersToRespondTo) {
-        await this.#sendAlreadyResponse({ peerId, projectId })
+        await this.#sendRejectResponse({ peerId, projectId })
       }
       return
     }
@@ -145,10 +145,10 @@ export class InviteApi extends TypedEmitter {
       throw new Error('Failed to join project')
     }
 
-    // Respond to the remaining peers with ALREADY
+    // Reject the remaining peers
     for (const peerId of peersToRespondTo) {
       if (peerId === pendingInvite.fromPeerId) continue
-      this.#sendAlreadyResponse({ peerId, projectId })
+      this.#sendRejectResponse({ peerId, projectId })
     }
   }
 
@@ -180,24 +180,6 @@ export class InviteApi extends TypedEmitter {
       projectKey,
       decision: InviteResponse_Decision.ACCEPT,
     })
-  }
-
-  /**
-   * Will not throw, will silently fail if the response fails to send.
-   *
-   * @param {{ peerId: string, projectId: string }} opts
-   */
-  async #sendAlreadyResponse({ peerId, projectId }) {
-    const projectKey = Buffer.from(projectId, 'hex')
-    try {
-      await this.rpc.inviteResponse(peerId, {
-        projectKey,
-        decision: InviteResponse_Decision.ALREADY,
-      })
-    } catch (e) {
-      // Ignore errors trying to send an already response because the invitor
-      // will consider the invite failed anyway
-    }
   }
 
   /**

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -248,7 +248,7 @@ export class LocalPeers extends TypedEmitter {
 
   /**
    * Invite a peer to a project. Resolves with the response from the invitee:
-   * one of "ACCEPT", "REJECT", or "ALREADY" (already on project)
+   * "ACCEPT" or "REJECT"
    *
    * @param {string} peerId
    * @param {object} options
@@ -309,7 +309,7 @@ export class LocalPeers extends TypedEmitter {
    * @param {string} peerId id of the peer you want to respond to (publicKey of peer as hex string)
    * @param {object} options
    * @param {InviteResponse['projectKey']} options.projectKey project key of the invite you are responding to
-   * @param {InviteResponse['decision']} options.decision response to invite, one of "ACCEPT", "REJECT", or "ALREADY" (already on project)
+   * @param {InviteResponse['decision']} options.decision response to invite, either "ACCEPT" or "REJECT"
    */
   async inviteResponse(peerId, options) {
     await this.#waitForPendingConnections()

--- a/tests/local-peers.js
+++ b/tests/local-peers.js
@@ -229,35 +229,6 @@ test('Invite to unknown peer', async (t) => {
   )
 })
 
-test('Send invite and already on project', async (t) => {
-  t.plan(3)
-  const r1 = new LocalPeers()
-  const r2 = new LocalPeers()
-
-  const projectKey = Buffer.allocUnsafe(32).fill(0)
-
-  r1.on('peers', async (peers) => {
-    t.is(peers.length, 1)
-    const response = await r1.invite(peers[0].deviceId, {
-      projectKey,
-      encryptionKeys: { auth: randomBytes(32) },
-      roleName: ROLES[MEMBER_ROLE_ID].name,
-      invitorName: 'device0',
-    })
-    t.is(response, LocalPeers.InviteResponse.ALREADY)
-  })
-
-  r2.on('invite', (peerId, invite) => {
-    t.ok(invite.projectKey.equals(projectKey), 'invite project key correct')
-    r2.inviteResponse(peerId, {
-      projectKey: invite.projectKey,
-      decision: LocalPeers.InviteResponse.ALREADY,
-    })
-  })
-
-  replicate(r1, r2)
-})
-
 test('Send invite with encryption key', async (t) => {
   t.plan(4)
   const r1 = new LocalPeers()


### PR DESCRIPTION
For simplicity, we decided to remove the "ALREADY" invite response and use "REJECT" in its place. We can add it back in the future if needed, but this makes the code simpler on the front-end and back-end.
