### PR TITLE
chore: remove `any` type in local peers test

### DIFF
--- a/test-e2e/local-peers.js
+++ b/test-e2e/local-peers.js
@@ -38,8 +38,10 @@ test('Local peers discovery each other and share device info', async (t) => {
 })
 
 /**
- * @param {any[]} array
+ * @template T
+ * @param {ReadonlyArray<T>} array
  * @param {number} i
+ * @returns {Array<T>}
  */
 function removeElementAt(array, i) {
   return array.slice(0, i).concat(array.slice(i + 1))


### PR DESCRIPTION
This minor test-only change improves the types for a helper function.
