### PR TITLE
chore: use stricter function type for callback

### DIFF
--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -410,7 +410,11 @@ export class LocalPeers extends TypedEmitter {
     for (const [type, id] of Object.entries(MESSAGE_TYPES)) {
       messages[id] = {
         encoding: cenc.raw,
-        onmessage: this.#handleMessage.bind(this, protomux, type),
+        onmessage: this.#handleMessage.bind(
+          this,
+          protomux,
+          /** @type {keyof typeof MESSAGE_TYPES} */ (type)
+        ),
       }
     }
 


### PR DESCRIPTION
This change, which should have no user impact, improves the type for a local peer callback. This is one of the last remaining changes required to enable the [strictFunctionTypes] TypeScript compiler option.

[strictFunctionTypes]: https://www.typescriptlang.org/tsconfig/#strictFunctionTypes