### PR TITLE
chore: enable strictFunctionTypes TypeScript option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "strictBindCallApply": true,
+    "strictFunctionTypes": true,
     "strictPropertyInitialization": true,
     "useUnknownInCatchVariables": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This enables the [strictFunctionTypes] TypeScript option, which brings us a little more type safety.

[strictFunctionTypes]: https://www.typescriptlang.org/tsconfig/#strictFunctionTypes