### PR TITLE
chore: enable strictPropertyInitialization TypeScript option

### DIFF
--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -137,10 +137,8 @@ export class CoreManager extends TypedEmitter {
       }
     }
 
-    if (!this.#creatorCore) {
-      // For anyone other than the project creator, creatorCore is readonly
-      this.#creatorCore = this.#addCore({ publicKey: projectKey }, 'auth').core
-    }
+    // For anyone other than the project creator, creatorCore is readonly
+    this.#creatorCore ??= this.#addCore({ publicKey: projectKey }, 'auth').core
 
     // Load persisted cores
     const rows = db.select().from(coresTable).all()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "module": "Node16",


### PR DESCRIPTION
_I recommend [reviewing this with whitespace changes disabled](https://github.com/digidem/mapeo-core-next/pull/492/files?w=1)._

This enables the [strictPropertyInitialization] TypeScript compiler option for improved type safety.

There were two places where we were violating this rule...no longer!

[strictPropertyInitialization]: https://www.typescriptlang.org/tsconfig/#strictPropertyInitialization