### PR TITLE
chore: enable noImplicitThis TypeScript option

### DIFF
--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -578,9 +578,7 @@ export class LocalPeers extends TypedEmitter {
         reject(new UnknownPeerError('Unknown peer ' + deviceId.slice(0, 7)))
       }, DEDUPE_TIMEOUT)
 
-      this.on('peers', onPeers)
-
-      function onPeers() {
+      const onPeers = () => {
         if (!devicePeers) return // Not possible, but let's keep TS happy
         const peer = chooseDevicePeer(devicePeers)
         if (!peer) return
@@ -588,6 +586,8 @@ export class LocalPeers extends TypedEmitter {
         this.off('peers', onPeers)
         resolve(peer)
       }
+
+      this.on('peers', onPeers)
     })
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2019",
     "lib": ["es2020"],
     "noImplicitAny": true,
+    "noImplicitThis": true,
     "strictNullChecks": true,
     "strictBindCallApply": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This enables the [noImplicitThis] TypeScript option for improved type safety.

We had one small violation which I fixed here.

[noImplicitThis]: https://www.typescriptlang.org/tsconfig/#noImplicitThis