### PR TITLE
chore: remove unnecessary await from test utility

### DIFF
--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -244,7 +244,7 @@ export function round(value, decimalPlaces) {
  * @param {'initial' | 'full'} [type]
  */
 async function waitForProjectSync(project, peerIds, type = 'initial') {
-  const state = await project.$sync[kSyncState].getState()
+  const state = project.$sync[kSyncState].getState()
   if (hasPeerIds(state.auth.remoteStates, peerIds)) {
     return project.$sync.waitForSync(type)
   }


### PR DESCRIPTION
This method returns synchronously, so we don't need to await it.

`git grep -w getState | grep -w await` returns no results after this change, so I think this is the only spot where we do this.