### PR TITLE
chore: update config import error

### DIFF
--- a/src/config-import.js
+++ b/src/config-import.js
@@ -1,6 +1,7 @@
 import yauzl from 'yauzl-promise'
 import { validate, valueSchemas } from '@mapeo/schema'
 import { json, buffer } from 'node:stream/consumers'
+import { assert } from './utils.js'
 import path from 'node:path'
 
 // Throw error if a zipfile contains more than 10,000 entries
@@ -33,13 +34,7 @@ export async function readConfig(configPath) {
     throw new Error(`Zip file contains too many entries. Max is ${MAX_ENTRIES}`)
   }
   const entries = await zip.readEntries(MAX_ENTRIES)
-  /** @type {undefined | Entry} */
-  let presetsEntry = entries.find((entry) => entry.filename === 'presets.json')
-  if (!presetsEntry) {
-    throw new Error('Zip file does not contain presets.json')
-  }
-  const presetsFile = await json(await presetsEntry.openReadStream())
-  validatePresetsFile(presetsFile)
+  const presetsFile = await findPresetsFile(entries)
 
   return {
     get warnings() {
@@ -196,6 +191,32 @@ export async function readConfig(configPath) {
 }
 
 /**
+ * @param {ReadonlyArray<Entry>} entries
+ * @rejects if the presets file cannot be found or is invalid
+ * @returns {Promise<PresetsFile>}
+ */
+async function findPresetsFile(entries) {
+  const presetsEntry = entries.find(
+    (entry) => entry.filename === 'presets.json'
+  )
+  assert(presetsEntry, 'Zip file does not contain presets.json')
+
+  /** @type {unknown} */
+  let result
+  try {
+    result = await json(await presetsEntry.openReadStream())
+  } catch (err) {
+    throw new Error('Could not parse presets.json')
+  }
+
+  assert(isRecord(result), 'Invalid presets.json file')
+  const { presets, fields } = result
+  assert(isRecord(presets) && isRecord(fields), 'Invalid presets.json file')
+
+  return { presets, fields }
+}
+
+/**
  * @param {string} filename
  * @param {Buffer} buf
  * @returns {{ name: string, variant: IconData['variants'][Number] }}}
@@ -240,20 +261,6 @@ function parseIcon(filename, buf) {
       pixelDensity,
       blob: buf,
     },
-  }
-}
-
-/**
- * @param {unknown} presetsFile
- * @returns {asserts presetsFile is PresetsFile}
- */
-function validatePresetsFile(presetsFile) {
-  if (
-    !isRecord(presetsFile) ||
-    !isRecord(presetsFile.presets) ||
-    !isRecord(presetsFile.fields)
-  ) {
-    throw new Error('Invalid presets.json file')
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,7 +75,7 @@ export class ExhaustivenessError extends Error {
 }
 
 /**
- * @param {boolean} condition
+ * @param {unknown} condition
  * @param {string} message
  * @returns {asserts condition}
  */

--- a/tests/config-import.js
+++ b/tests/config-import.js
@@ -28,10 +28,10 @@ test('config import - loading', async (t) => {
     'missing presets.json'
   )
 
-  await t.exception.all(
+  await t.exception(
     async () =>
       await readConfig('./tests/fixtures/config/invalidPresetsJSON.zip'),
-    /SyntaxError: Unexpected string in JSON/,
+    /Error: Could not parse presets.json/,
     'JSON.parse error of presets.json'
   )
 


### PR DESCRIPTION
I had a problem where the config import tests failed. This seemed to be because the `JSON.parse()` error message can change.

For example, `JSON.parse('{bad')` gives the following error message in Firefox v123:

    expected property name or '}' at line 1 column 2 of the JSON data

But Node v20 gives the following:

    Expected property name or '}' in JSON at position 1

We now catch this error and return a consistent message, which should make the tests more reliable. Because this code was getting a little long, I moved it into its own function.