### PR TITLE
chore!: drop Node 16 support

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         node-version:
-          - '16.x'
           - '18.x'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This removes Node 16 support, given that (1) it is deprecated (2) it [is no longer used in CoMapeo][0].

[0]: https://github.com/digidem/CoMapeo-mobile/pull/194
