### PR TITLE
chore: update Undici to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "typedoc": "^0.24.8",
         "typedoc-plugin-markdown": "^3.15.3",
         "typescript": "^5.1.6",
-        "undici": "^5.27.2"
+        "undici": "^6.7.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7825,15 +7825,15 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.0.tgz",
+      "integrity": "sha512-IcWssIyDN1gk6Mcae44q04oRoWTKrW8OKz0effVK1xdWwAgMPnfpxhn9RXUSL5JlwSikO18R7Ibk7Nukz6kxWA==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "typedoc": "^0.24.8",
     "typedoc-plugin-markdown": "^3.15.3",
     "typescript": "^5.1.6",
-    "undici": "^5.27.2"
+    "undici": "^6.7.0"
   },
   "dependencies": {
     "@digidem/types": "^2.2.0",


### PR DESCRIPTION
This updates Undici to v6.7.0.

This is a test-only dependency so I think this is safe to merge as long as tests pass.