### PR TITLE
chore: use `Map`, not `Record`, for listing all roles

### DIFF
--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -568,20 +568,20 @@ export class MapeoProject extends TypedEmitter {
       throw new Error('Cannot leave a project as a blocked device')
     }
 
-    const knownDevices = Array.from((await this.#roles.getAll()).keys())
-    const projectCreatorDeviceId = await this.#coreOwnership.getOwner(
-      this.#projectId
-    )
+    const allRoles = await this.#roles.getAll()
 
     // 1.2 Check that we are not the only device in the project
-    if (knownDevices.length === 1) {
+    if (allRoles.size <= 1) {
       throw new Error('Cannot leave a project as the only device')
     }
 
     // 1.3 Check if there are other known devices that are either the project creator or a coordinator
+    const projectCreatorDeviceId = await this.#coreOwnership.getOwner(
+      this.#projectId
+    )
     let otherCreatorOrCoordinatorExists = false
 
-    for (const deviceId of knownDevices) {
+    for (const deviceId of allRoles.keys()) {
       // Skip self (see 1.1 and 1.2 for relevant checks)
       if (deviceId === this.#deviceId) continue
 

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -568,7 +568,7 @@ export class MapeoProject extends TypedEmitter {
       throw new Error('Cannot leave a project as a blocked device')
     }
 
-    const knownDevices = Object.keys(await this.#roles.getAll())
+    const knownDevices = Array.from((await this.#roles.getAll()).keys())
     const projectCreatorDeviceId = await this.#coreOwnership.getOwner(
       this.#projectId
     )

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -132,7 +132,7 @@ export class MemberApi extends TypedEmitter {
     ])
 
     return Promise.all(
-      Object.entries(allRoles).map(async ([deviceId, role]) => {
+      [...allRoles.entries()].map(async ([deviceId, role]) => {
         /** @type {MemberInfo} */
         const memberInfo = { deviceId, role }
 

--- a/src/roles.js
+++ b/src/roles.js
@@ -280,12 +280,12 @@ export class Roles {
    * returned. The project creator will have the creator role unless a
    * different one has been assigned.
    *
-   * @returns {Promise<Record<string, Role>>} Map of deviceId to Role
+   * @returns {Promise<Map<string, Role>>} Map of deviceId to Role
    */
   async getAll() {
     const roles = await this.#dataType.getMany()
-    /** @type {Record<string, Role>} */
-    const result = {}
+    /** @type {Map<string, Role>} */
+    const result = new Map()
     /** @type {undefined | string} */
     let projectCreatorDeviceId
     try {
@@ -294,7 +294,7 @@ export class Roles {
       )
       // Default to creator role, but can be overwritten if a different role is
       // set below
-      result[projectCreatorDeviceId] = CREATOR_ROLE
+      result.set(projectCreatorDeviceId, CREATOR_ROLE)
     } catch (e) {
       // Not found, we don't know who the project creator is so we can't include
       // them in the returned map
@@ -310,16 +310,12 @@ export class Roles {
         continue
       }
       const deviceId = role.docId
-      result[deviceId] = ROLES[role.roleId]
+      result.set(deviceId, ROLES[role.roleId])
     }
-    const includesSelf = Boolean(result[this.#ownDeviceId])
+    const includesSelf = result.has(this.#ownDeviceId)
     if (!includesSelf) {
       const isProjectCreator = this.#ownDeviceId === projectCreatorDeviceId
-      if (isProjectCreator) {
-        result[this.#ownDeviceId] = CREATOR_ROLE
-      } else {
-        result[this.#ownDeviceId] = NO_ROLE
-      }
+      result.set(this.#ownDeviceId, isProjectCreator ? CREATOR_ROLE : NO_ROLE)
     }
     return result
   }


### PR DESCRIPTION
_This change should have no user impact, and is not urgent._

I generally prefer `Map`s to `Record`s when the keys are variable. This is mainly due to bugs with keys like `hasOwnProperty` or `__proto__`, but they also allow non-string keys.

As far as I could tell, we were always using `Map`s in relevant spots except for `Roles.prototype.getAll()`...but no longer!