### PR TITLE
chore: improve ExpectionAssertion type in Brittle TypeScript definitions

### DIFF
--- a/types/brittle.d.ts
+++ b/types/brittle.d.ts
@@ -9,15 +9,28 @@ declare module 'brittle' {
   type AnyErrorConstructor = new () => Error
 
   interface ExceptionAssertion {
+    (
+      fn: Promise<unknown> | (() => Promise<unknown>),
+      message?: string
+    ): Promise<void>
+    (
+      fn: Promise<unknown> | (() => Promise<unknown>),
+      error?: RegExp | AnyErrorConstructor,
+      message?: string
+    ): Promise<void>
     (fn: () => unknown, message?: string): void
     (
       fn: () => unknown,
       error?: RegExp | AnyErrorConstructor,
       message?: string
     ): void
-    (fn: Promise<unknown>, message?: string): Promise<void>
-    (
-      fn: Promise<unknown>,
+
+    all(
+      fn: Promise<unknown> | (() => Promise<unknown>),
+      message?: string
+    ): Promise<void>
+    all(
+      fn: Promise<unknown> | (() => Promise<unknown>),
       error?: RegExp | AnyErrorConstructor,
       message?: string
     ): Promise<void>
@@ -27,12 +40,6 @@ declare module 'brittle' {
       error?: RegExp | AnyErrorConstructor,
       message?: string
     ): void
-    all(fn: Promise<unknown>, message?: string): Promise<void>
-    all(
-      fn: Promise<unknown>,
-      error?: RegExp | AnyErrorConstructor,
-      message?: string
-    ): Promise<void>
   }
 
   interface Assertion {
@@ -57,7 +64,10 @@ declare module 'brittle' {
 
   export interface TestInstance extends Assertion {
     plan(n: number): void
-    teardown(fn: () => unknown | Promise<unknown>, options?: { order?: number }): void
+    teardown(
+      fn: () => unknown | Promise<unknown>,
+      options?: { order?: number }
+    ): void
     timeout(ms: number): void
     comment(message: string): void
     end(): void


### PR DESCRIPTION
Noticed a couple of minor issues:

- types were not handling providing a promise (note, not a function returning a promise) as the first argument
- was noticing some misleading "unnecessary awaits" warnings in my editor, even though the provided function was async. narrowed it down to needing to adjust the order of the overload so that it was ordered from most specific to least specific (i.e. `() => Promise<unknown>` is a subset of `() => unknown`)