### PR TITLE
fix: sync state prior to full sync should be correct

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "cpy-cli": "^5.0.0",
         "drizzle-kit": "^0.19.12",
         "eslint": "^8.57.0",
+        "filter-obj": "^6.0.0",
         "husky": "^8.0.0",
         "iterpal": "^0.3.0",
         "light-my-request": "^5.10.0",
@@ -3346,6 +3347,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-6.0.0.tgz",
+      "integrity": "sha512-lscJ1kdwOyW2Nb3wcoU/LnNLoHg+Weoe7r8NT8xjNAdIZPm/JQuKoMcu3FnWrlKOjtAcf98pewuUyjeD6GoKig==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-my-way": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "cpy-cli": "^5.0.0",
     "drizzle-kit": "^0.19.12",
     "eslint": "^8.57.0",
+    "filter-obj": "^6.0.0",
     "husky": "^8.0.0",
     "iterpal": "^0.3.0",
     "light-my-request": "^5.10.0",

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -164,9 +164,11 @@ export class CoreManager extends TypedEmitter {
     })
 
     this.#creatorCore.on('peer-add', (peer) => {
+      console.log('PEER-ADD', peer.remotePublicKey.toString('hex'))
       this.#sendHaves(peer)
     })
     this.#creatorCore.on('peer-remove', (peer) => {
+      console.log('PEER-REMOVE', peer.remotePublicKey.toString('hex'))
       // When a peer is removed we clean up any unanswered key requests, so that
       // we will request from a different peer, and to avoid the tracking of key
       // requests growing without bounds.
@@ -435,7 +437,7 @@ export class CoreManager extends TypedEmitter {
     for (const { core, namespace } of this.#coreIndex) {
       // We want ready() rather than update() because we are only interested in local data
       await core.ready()
-      if (core.length === 0) continue
+      // if (core.length === 0) continue
       const { discoveryKey } = core
       // This will always be defined after ready(), but need to let TS know
       if (!discoveryKey) continue

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -435,7 +435,6 @@ export class CoreManager extends TypedEmitter {
     for (const { core, namespace } of this.#coreIndex) {
       // We want ready() rather than update() because we are only interested in local data
       await core.ready()
-      // if (core.length === 0) continue
       const { discoveryKey } = core
       // This will always be defined after ready(), but need to let TS know
       if (!discoveryKey) continue

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -164,11 +164,9 @@ export class CoreManager extends TypedEmitter {
     })
 
     this.#creatorCore.on('peer-add', (peer) => {
-      console.log('PEER-ADD', peer.remotePublicKey.toString('hex'))
       this.#sendHaves(peer)
     })
     this.#creatorCore.on('peer-remove', (peer) => {
-      console.log('PEER-REMOVE', peer.remotePublicKey.toString('hex'))
       // When a peer is removed we clean up any unanswered key requests, so that
       // we will request from a different peer, and to avoid the tracking of key
       // requests growing without bounds.

--- a/src/core-manager/remote-bitfield.js
+++ b/src/core-manager/remote-bitfield.js
@@ -224,6 +224,9 @@ export default class RemoteBitfield {
     return p ? p.get(j) : false
   }
 
+  /**
+   * @param {number} index
+   */
   getBitfield(index) {
     const j = index & (BITS_PER_PAGE - 1)
     const i = (index - j) / BITS_PER_PAGE

--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -140,13 +140,6 @@ export class CoreSyncState {
       this.#preHavesLength,
       peerState.preHavesBitfield.lastSet(start + bitfield.length * 32) + 1
     )
-    console.log(
-      'insertPreHaves',
-      peerId.slice(0, 5),
-      this.#core?.discoveryKey?.toString('hex').slice(0, 5),
-      bitfield.slice(0, 5),
-      this.#preHavesLength
-    )
     this.#update()
   }
 
@@ -164,6 +157,14 @@ export class CoreSyncState {
       peerState.setWantRange({ start, length })
     }
     this.#update()
+  }
+
+  /**
+   * @param {PeerId} peerId
+   */
+  addPeer(peerId) {
+    if (this.#remoteStates.has(peerId)) return
+    this.#remoteStates.set(peerId, new PeerState())
   }
 
   /**
@@ -201,12 +202,6 @@ export class CoreSyncState {
     // A peer can have a pre-emptive "have" bitfield received via an extension
     // message, but when the peer actually connects then we switch to the actual
     // bitfield from the peer object
-    // console.log(
-    //   'setting haves',
-    //   peerId.slice(0, 5),
-    //   this.#core?.discoveryKey?.toString('hex').slice(0, 5),
-    //   peer.remoteBitfield.firstUnset(0)
-    // )
     peerState.setHavesBitfield(peer.remoteBitfield)
     this.#update()
 

--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -82,6 +82,15 @@ export class NamespaceSyncState {
   }
 
   /**
+   * @param {string} peerId
+   */
+  addPeer(peerId) {
+    for (const css of this.#coreStates.values()) {
+      css.addPeer(peerId)
+    }
+  }
+
+  /**
    * @param {import('hypercore')<"binary", Buffer>} core
    * @param {Buffer} coreKey
    */

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -197,6 +197,9 @@ export class SyncApi extends TypedEmitter {
     this.#peerSyncControllers.set(protomux, peerSyncController)
     if (peerSyncController.peerId) this.#peerIds.add(peerSyncController.peerId)
 
+    // Add peer to all core states (via namespace sync states)
+    this[kSyncState].addPeer(peerSyncController.peerId)
+
     if (this.#dataSyncEnabled.has('local')) {
       peerSyncController.enableDataSync()
     }

--- a/src/sync/sync-state.js
+++ b/src/sync/sync-state.js
@@ -26,9 +26,10 @@ export class SyncState extends TypedEmitter {
    *
    * @param {object} opts
    * @param {import('../core-manager/index.js').CoreManager} opts.coreManager
+   * @param {Map<string, import('./peer-sync-controller.js').PeerSyncController>} opts.peerSyncControllers
    * @param {number} [opts.throttleMs]
    */
-  constructor({ coreManager, throttleMs = 200 }) {
+  constructor({ coreManager, peerSyncControllers, throttleMs = 200 }) {
     super()
     const throttledHandleUpdate = throttle(throttleMs, this.#handleUpdate)
     for (const namespace of NAMESPACES) {
@@ -40,6 +41,7 @@ export class SyncState extends TypedEmitter {
           this.#updated.add(namespace)
           throttledHandleUpdate()
         },
+        peerSyncControllers,
       })
     }
   }

--- a/src/sync/sync-state.js
+++ b/src/sync/sync-state.js
@@ -45,6 +45,15 @@ export class SyncState extends TypedEmitter {
   }
 
   /**
+   * @param {string} peerId
+   */
+  addPeer(peerId) {
+    for (const nss of Object.values(this.#syncStates)) {
+      nss.addPeer(peerId)
+    }
+  }
+
+  /**
    * @returns {State}
    */
   getState() {

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -300,7 +300,7 @@ test('Sync state emitted when starting and stopping sync', async function (t) {
 })
 
 test('Correct sync state prior to data sync', async function (t) {
-  const COUNT = 2
+  const COUNT = 6
   const managers = await createManagers(COUNT, t)
   const [invitor, ...invitees] = managers
   const projectId = await invitor.createProject({ name: 'Mapeo' })
@@ -340,6 +340,9 @@ test('Correct sync state prior to data sync', async function (t) {
       connectedPeers: managers.length - 1,
     }
   })
+
+  // Wait for initial sharing of sync state
+  await delay(200)
 
   const syncState = await Promise.all(projects.map((p) => p.$sync.getState()))
 

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -259,7 +259,7 @@ test('no sync capabilities === no namespaces sync apart from auth', async (t) =>
     // "Invitor" knows blocked peer is blocked from the start, so never connects
     // and never creates a local copy of the blocked peer cores, but "Invitee"
     // does connect initially, before it realized the peer is blocked, and
-    // creates a local copy of the blocked peers cores, but never downloads
+    // creates a local copy of the blocked peer's cores, but never downloads
     // data, so it considers data to be "missing" which the Invitor does not
     // register as missing.
     t.alike(

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -288,9 +288,11 @@ export function waitForSync(projects, type = 'initial') {
 
 /**
  * @param {import('../src/mapeo-project.js').MapeoProject[]} projects
+ * @param {object} [opts]
+ * @param {readonly import('@mapeo/schema').MapeoDoc['schemaName'][]} [opts.schemas]
  */
-export function seedDatabases(projects) {
-  return Promise.all(projects.map((p) => seedProjectDatabase(p)))
+export function seedDatabases(projects, { schemas = SCHEMAS_TO_SEED } = {}) {
+  return Promise.all(projects.map((p) => seedProjectDatabase(p, { schemas })))
 }
 
 const SCHEMAS_TO_SEED = /** @type {const} */ ([
@@ -301,11 +303,16 @@ const SCHEMAS_TO_SEED = /** @type {const} */ ([
 
 /**
  * @param {import('../src/mapeo-project.js').MapeoProject} project
+ * @param {object} [opts]
+ * @param {readonly import('@mapeo/schema').MapeoDoc['schemaName'][]} [opts.schemas]
  * @returns {Promise<Array<import('@mapeo/schema').MapeoDoc & { forks: string[] }>>}
  */
-async function seedProjectDatabase(project) {
+async function seedProjectDatabase(
+  project,
+  { schemas = SCHEMAS_TO_SEED } = {}
+) {
   const promises = []
-  for (const schemaName of SCHEMAS_TO_SEED) {
+  for (const schemaName of schemas) {
     const count =
       schemaName === 'observation' ? randomInt(20, 100) : randomInt(0, 10)
     let i = 0

--- a/tests/remote-bitfield.js
+++ b/tests/remote-bitfield.js
@@ -17,7 +17,7 @@ test('remote bitfield - findLast, findFirst from insert', function (t) {
   const b = new RemoteBitfield()
 
   const size = 100
-  const arr = new Uint32Array(Array(size).fill(2 ** 32 - 1))
+  const arr = new Uint32Array(size).fill(2 ** 32 - 1)
   b.insert(0, arr)
 
   t.is(b.findFirst(false, 0), size * 32)

--- a/tests/remote-bitfield.js
+++ b/tests/remote-bitfield.js
@@ -2,10 +2,24 @@
 import test from 'brittle'
 import RemoteBitfield from '../src/core-manager/remote-bitfield.js'
 
-test('remote bitfield - findFirst', function (t) {
+test('remote bitfield - findFirst, findLast', function (t) {
   const b = new RemoteBitfield()
 
-  b.set(1000000, true)
+  b.set(1_000_000, true)
 
-  t.is(b.findFirst(true, 0), 1000000)
+  t.is(b.findFirst(true, 0), 1_000_000)
+  t.is(b.findLast(true, 2_000_000), 1_000_000)
+})
+
+test('remote bitfield - findLast, findFirst from insert', function (t) {
+  // Regression test for bug in RemoteBitfield which was not updating the index
+  // when inserting a new bitfield.
+  const b = new RemoteBitfield()
+
+  const size = 100
+  const arr = new Uint32Array(Array(size).fill(2 ** 32 - 1))
+  b.insert(0, arr)
+
+  t.is(b.findFirst(false, 0), size * 32)
+  t.is(b.findLast(true, size * 32 + 1_000_000), size * 32 - 1)
 })

--- a/tests/sync/core-sync-state.js
+++ b/tests/sync/core-sync-state.js
@@ -246,6 +246,8 @@ test('deriveState() scenarios', (t) => {
       remoteStates: new Map(
         state.remoteStates.map((s, i) => ['peer' + i, createState(s)])
       ),
+      peerSyncControllers: new Map(),
+      namespace: 'auth',
     })
     t.alike(derivedState, expected, message)
   }
@@ -261,6 +263,8 @@ test('deriveState() have at index beyond bitfield page size', (t) => {
     length: BITS_PER_PAGE + 10,
     localState,
     remoteStates: new Map([['peer0', remoteState]]),
+    peerSyncControllers: new Map(),
+    namespace: /** @type {const} */ 'auth',
   }
   const expected = {
     coreLength: BITS_PER_PAGE + 10,
@@ -288,7 +292,11 @@ test('CoreReplicationState', async (t) => {
     const localCore = await createCore()
     await localCore.ready()
     const emitter = new EventEmitter()
-    const crs = new CoreSyncState(() => emitter.emit('update'))
+    const crs = new CoreSyncState({
+      onUpdate: () => emitter.emit('update'),
+      peerSyncControllers: new Map(),
+      namespace: 'auth',
+    })
     crs.attachCore(localCore)
     const blocks = new Array(state.length).fill('block')
     await localCore.append(blocks)

--- a/tests/sync/namespace-sync-state.js
+++ b/tests/sync/namespace-sync-state.js
@@ -66,6 +66,7 @@ test('sync cores in a namespace', async function (t) {
         syncState1Synced = true
       }
     },
+    peerSyncControllers: new Map(),
   })
 
   const syncState2 = new NamespaceSyncState({
@@ -93,6 +94,7 @@ test('sync cores in a namespace', async function (t) {
         syncState2Synced = true
       }
     },
+    peerSyncControllers: new Map(),
   })
 
   const cm1Keys = getKeys(cm1, 'auth')
@@ -164,6 +166,7 @@ test('replicate with updating data', async function (t) {
         syncState1AlreadyDone = true
       }
     },
+    peerSyncControllers: new Map(),
   })
 
   const syncState2 = new NamespaceSyncState({
@@ -178,6 +181,7 @@ test('replicate with updating data', async function (t) {
         syncState2AlreadyDone = true
       }
     },
+    peerSyncControllers: new Map(),
   })
 
   const cm1Keys = getKeys(cm1, 'auth')


### PR DESCRIPTION
Before starting sync of data, the sync state should accurately show the data that needs to be synced. There were bugs in the code that meant the "data to sync" was not accurate until the user had already started to sync the data. This PR fixes things so that after doing an "initial" sync, the sync state should accurately show how much data there is to be synced before the user starts syncing.

This PR fixes several things, because each fix revealed other bugs:

- Updates `RemoteBitfield` with changes from [upstream](https://github.com/holepunchto/hypercore/blob/fa23b5bcf5745dddaf607d92f8bccaa46a8642b1/lib/bitfield.js) to fix `findLast` and a few other things (data was not being added to the Quickbit index when it was inserted from a UInt32Array (as opposed to being set bit-by-bit).
- Fix `CoreSyncState` to correctly calculate `want` `wanted` `have` for cores that have not yet been replicated, based on preHave messages. We don't get the core length without replication, so we estimate it from the preHave messages. The length will be incorrect if the connected peer is missing blocks at the end of their core (because we use the last set bit in the bitfield for the length), but this is ok, it just means that `missing` might be inaccurate before a core is actually replicated.
- Fix to ignore remote states for blocked peers - without this, because a blocked peer potentially has data which will not sync, then sync state never considers sync to be complete for a blocked peer.
- Fix to test to ignore `missing` when comparing states of sync with a blocked peer, because different peers connected to a blocked peer can have different impressions of what is missing, based on whether they have tried to sync with them before blocking them.

(Note: I don't really like how this has been fixed by passing around peer sync controllers and making `deriveState` more complex because it relies on a more complicated state.... but all I can think of for now, so hopefully "good enough").