### PR TITLE
feat!: invite cancelations

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -11,6 +11,10 @@ message Invite {
   string invitorName = 6;
 }
 
+message InviteCancel {
+  bytes inviteId = 1;
+}
+
 message InviteResponse {
   enum Decision {
     REJECT = 0;

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -9,6 +9,9 @@ export interface Invite {
     roleDescription?: string | undefined;
     invitorName: string;
 }
+export interface InviteCancel {
+    inviteId: Buffer;
+}
 export interface InviteResponse {
     inviteId: Buffer;
     decision: InviteResponse_Decision;
@@ -73,6 +76,20 @@ export declare const Invite: {
         roleDescription?: string | undefined;
         invitorName?: string;
     } & { [K_1 in Exclude<keyof I_1, keyof Invite>]: never; }>(object: I_1): Invite;
+};
+export declare const InviteCancel: {
+    encode(message: InviteCancel, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): InviteCancel;
+    create<I extends {
+        inviteId?: Buffer;
+    } & {
+        inviteId?: Buffer;
+    } & { [K in Exclude<keyof I, "inviteId">]: never; }>(base?: I): InviteCancel;
+    fromPartial<I_1 extends {
+        inviteId?: Buffer;
+    } & {
+        inviteId?: Buffer;
+    } & { [K_1 in Exclude<keyof I_1, "inviteId">]: never; }>(object: I_1): InviteCancel;
 };
 export declare const InviteResponse: {
     encode(message: InviteResponse, writer?: _m0.Writer): _m0.Writer;

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -165,6 +165,48 @@ export var Invite = {
         return message;
     },
 };
+function createBaseInviteCancel() {
+    return { inviteId: Buffer.alloc(0) };
+}
+export var InviteCancel = {
+    encode: function (message, writer) {
+        if (writer === void 0) { writer = _m0.Writer.create(); }
+        if (message.inviteId.length !== 0) {
+            writer.uint32(10).bytes(message.inviteId);
+        }
+        return writer;
+    },
+    decode: function (input, length) {
+        var reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+        var end = length === undefined ? reader.len : reader.pos + length;
+        var message = createBaseInviteCancel();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    if (tag !== 10) {
+                        break;
+                    }
+                    message.inviteId = reader.bytes();
+                    continue;
+            }
+            if ((tag & 7) === 4 || tag === 0) {
+                break;
+            }
+            reader.skipType(tag & 7);
+        }
+        return message;
+    },
+    create: function (base) {
+        return InviteCancel.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a;
+        var message = createBaseInviteCancel();
+        message.inviteId = (_a = object.inviteId) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        return message;
+    },
+};
 function createBaseInviteResponse() {
     return { inviteId: Buffer.alloc(0), decision: InviteResponse_Decision.REJECT };
 }

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -11,6 +11,10 @@ export interface Invite {
   invitorName: string;
 }
 
+export interface InviteCancel {
+  inviteId: Buffer;
+}
+
 export interface InviteResponse {
   inviteId: Buffer;
   decision: InviteResponse_Decision;
@@ -205,6 +209,51 @@ export const Invite = {
     message.roleName = object.roleName ?? undefined;
     message.roleDescription = object.roleDescription ?? undefined;
     message.invitorName = object.invitorName ?? "";
+    return message;
+  },
+};
+
+function createBaseInviteCancel(): InviteCancel {
+  return { inviteId: Buffer.alloc(0) };
+}
+
+export const InviteCancel = {
+  encode(message: InviteCancel, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.inviteId.length !== 0) {
+      writer.uint32(10).bytes(message.inviteId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): InviteCancel {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseInviteCancel();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.inviteId = reader.bytes() as Buffer;
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  create<I extends Exact<DeepPartial<InviteCancel>, I>>(base?: I): InviteCancel {
+    return InviteCancel.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<InviteCancel>, I>>(object: I): InviteCancel {
+    const message = createBaseInviteCancel();
+    message.inviteId = object.inviteId ?? Buffer.alloc(0);
     return message;
   },
 };

--- a/src/invite-api.js
+++ b/src/invite-api.js
@@ -143,7 +143,7 @@ class PendingInvites {
 /**
  * @typedef {Object} InviteApiEvents
  * @property {(invite: Invite) => void} invite-received
- * @property {(invite: Invite, reason: InviteRemovalReason) => void} invite-removed
+ * @property {(invite: Invite, removalReason: InviteRemovalReason) => void} invite-removed
  */
 
 /**
@@ -264,11 +264,11 @@ export class InviteApi extends TypedEmitter {
     const { peerId, invite } = pendingInvite
     const { projectName, projectPublicId } = invite
 
-    /** @param {InviteRemovalReason} reason */
-    const removePendingInvite = (reason) => {
+    /** @param {InviteRemovalReason} removalReason */
+    const removePendingInvite = (removalReason) => {
       const didDelete = this.#pendingInvites.deleteByInviteId(inviteId)
       if (didDelete) {
-        this.emit('invite-removed', internalToExternal(invite), reason)
+        this.emit('invite-removed', internalToExternal(invite), removalReason)
       }
     }
 
@@ -335,7 +335,6 @@ export class InviteApi extends TypedEmitter {
       await this.#addProject({ ...details, projectName })
     } catch (e) {
       removePendingInvite('internal error')
-      // TODO: Add a reason for the user
       throw new Error('Failed to join project')
     }
 

--- a/src/lib/ponyfills.js
+++ b/src/lib/ponyfills.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+/**
+ * Ponyfill of `AbortSignal.any()`.
+ *
+ * [0]: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static
+ *
+ * @param {Iterable<AbortSignal>} iterable
+ * @returns {AbortSignal}
+ */
+export function abortSignalAny(iterable) {
+  for (const signal of iterable) {
+    if (signal.aborted) return AbortSignal.abort(signal.reason)
+  }
+
+  /** @type {Array<() => unknown>} */
+  const listeners = []
+  const controller = new AbortController()
+
+  for (const signal of iterable) {
+    const listener = () => controller.abort(signal.reason)
+    signal.addEventListener('abort', listener)
+    listeners.push(listener)
+  }
+
+  return controller.signal
+}

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -177,6 +177,10 @@ export class MemberApi extends TypedEmitter {
    * @param {AbortSignal} signal
    */
   async #sendInviteAndGetResponse(deviceId, invite, signal) {
+    const inviteAbortedError = new Error('Invite aborted')
+
+    if (signal.aborted) throw inviteAbortedError
+
     const abortController = new AbortController()
 
     const responsePromise =
@@ -207,7 +211,7 @@ export class MemberApi extends TypedEmitter {
       return await responsePromise
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
-        throw new Error('Invite aborted')
+        throw inviteAbortedError
       } else {
         throw err
       }

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -217,13 +217,14 @@ export class MemberApi extends TypedEmitter {
   }
 
   /**
-   * Cancel an outbound invite, if it exists. No-op if we weren't inviting this
-   * device.
+   * Attempt to cancel an outbound invite, if it exists.
+   *
+   * No-op if we weren't inviting this device.
    *
    * @param {string} deviceId
    * @returns {void}
    */
-  cancelInvite(deviceId) {
+  requestCancelInvite(deviceId) {
     this.#outboundInvitesByDevice.get(deviceId)?.abortController.abort()
   }
 

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -257,7 +257,7 @@ test('cancelation', async (t) => {
 
   const [invite] = await inviteReceivedPromise
 
-  creatorProject.$member.cancelInvite(joiner.deviceId)
+  creatorProject.$member.requestCancelInvite(joiner.deviceId)
   await inviteAbortedAssertionPromise
 
   const [canceledInvite, removalReason] = await inviteRemovedPromise
@@ -279,9 +279,9 @@ test('canceling nothing', async (t) => {
   const creatorProject = await creator.getProject(createdProjectId)
 
   t.execution(() => {
-    creatorProject.$member.cancelInvite(joiner.deviceId)
-    creatorProject.$member.cancelInvite(joiner.deviceId)
-    creatorProject.$member.cancelInvite(joiner.deviceId)
+    creatorProject.$member.requestCancelInvite(joiner.deviceId)
+    creatorProject.$member.requestCancelInvite(joiner.deviceId)
+    creatorProject.$member.requestCancelInvite(joiner.deviceId)
   })
 })
 

--- a/tests/helpers/events.js
+++ b/tests/helpers/events.js
@@ -9,7 +9,7 @@ import { arrayFrom } from 'iterpal'
  * @param {import('node:events').EventEmitter} emitter
  * @param {string | symbol} eventName
  * @param {number} count
- * @returns {Promise<unknown[]>}
+ * @returns {Promise<unknown[][]>}
  */
 export function onTimes(emitter, eventName, count) {
   assert(
@@ -17,6 +17,9 @@ export function onTimes(emitter, eventName, count) {
     'onTimes called with an invalid count'
   )
 
-  const events = pEventIterator(emitter, eventName, { limit: count })
+  const events = pEventIterator(emitter, eventName, {
+    multiArgs: true,
+    limit: count,
+  })
   return arrayFrom(events)
 }

--- a/tests/lib/ponyfills.js
+++ b/tests/lib/ponyfills.js
@@ -1,0 +1,48 @@
+// @ts-check
+import test from 'brittle'
+import { abortSignalAny } from '../../src/lib/ponyfills.js'
+
+test('abortSignalAny() handles empty iterables', (t) => {
+  t.not(abortSignalAny([]).aborted, 'not immediately aborted')
+  t.not(abortSignalAny(new Set()).aborted, 'not immediately aborted')
+})
+
+test('abortSignalAny() aborts immediately if one of the arguments was aborted', (t) => {
+  const result = abortSignalAny([
+    new AbortController().signal,
+    AbortSignal.abort('foo'),
+    AbortSignal.abort('ignored'),
+    new AbortController().signal,
+  ])
+
+  t.ok(result.aborted, 'immediately aborted')
+  t.is(result.reason, 'foo', 'gets first abort reason')
+})
+
+test('abortSignalAny() aborts as soon as one of its arguments aborts', (t) => {
+  const a = new AbortController()
+  const b = new AbortController()
+  const c = new AbortController()
+
+  const result = abortSignalAny([a.signal, b.signal, c.signal])
+
+  t.not(result.aborted, 'not immediately aborted')
+
+  b.abort('foo')
+  c.abort('ignored')
+
+  t.ok(result.aborted, 'aborted')
+  t.is(result.reason, 'foo', 'gets first abort reason')
+})
+
+test('abortSignalAny() handles non-array iterables', (t) => {
+  const a = new AbortController()
+  const b = new AbortController()
+  const c = new AbortController()
+
+  const result = abortSignalAny(new Set([a.signal, b.signal, c.signal]))
+
+  b.abort('foo')
+
+  t.ok(result.aborted, 'aborted')
+})


### PR DESCRIPTION
*I recommend reviewing this PR one commit at a time.*

This PR adds invite cancelations. Notable changes:

- `InviteCancel` RPC messages are now sent and received.
- `project.$member.invite()` takes an `AbortSignal`, used for cancelations. It replaces the timeout option.
- The `invite-removed` event now has a "reason" parameter which the frontend can use.

Closes #447.