### PR TITLE
feat: add "received at" timestamp to invites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "eslint": "^8.57.0",
         "filter-obj": "^6.0.0",
         "husky": "^8.0.0",
-        "iterpal": "^0.3.0",
+        "iterpal": "^0.4.0",
         "light-my-request": "^5.10.0",
         "lint-staged": "^14.0.1",
         "mapeo-offline-map": "^2.0.0",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/iterpal": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/iterpal/-/iterpal-0.3.0.tgz",
-      "integrity": "sha512-s7fZOi2hrko1W96PVV5dYDZs1KJ3yi18ahSe3xEcBEcc6BaWSPS72eFcDhVrJS/D7ShcaOxPzY3gS/4pw9qK2w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/iterpal/-/iterpal-0.4.0.tgz",
+      "integrity": "sha512-Z/KMdj4T9D9n5FAkY0Y4j46f875PeRddgLrEZh77SBQ6WERvViDNh6pjp6+oA5q30Z+2ShbvVrnJXMTN4JSp2Q==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,15 @@
       "ecmaVersion": 13,
       "sourceType": "module"
     },
-    "rules": {}
+    "rules": {
+      "no-unused-vars": [
+        "error",
+        {
+          "varsIgnorePattern": "^_",
+          "argsIgnorePattern": "^_"
+        }
+      ]
+    }
   },
   "repository": {
     "type": "git",
@@ -90,7 +98,7 @@
     "eslint": "^8.57.0",
     "filter-obj": "^6.0.0",
     "husky": "^8.0.0",
-    "iterpal": "^0.3.0",
+    "iterpal": "^0.4.0",
     "light-my-request": "^5.10.0",
     "lint-staged": "^14.0.1",
     "mapeo-offline-map": "^2.0.0",

--- a/src/invite-api.js
+++ b/src/invite-api.js
@@ -6,12 +6,20 @@ import { assert, keyToId, noop } from './utils.js'
 import HashMap from './lib/hashmap.js'
 import timingSafeEqual from './lib/timing-safe-equal.js'
 
+// There are three slightly different invite types:
+//
+// - InviteRpcMessage comes from the protobuf.
+// - InviteInternal adds a locally-generated receive timestamp.
+// - Invite is the externally-facing type.
+
 /**
- * Internally, we typically use the `Invite` type from the protobuf. We also use
- * an external type for public consumers.
- *
  * @internal
- * @typedef {import('./generated/rpc.js').Invite} InviteInternal
+ * @typedef {import('./generated/rpc.js').Invite} InviteRpcMessage
+ */
+
+/**
+ * @internal
+ * @typedef {InviteRpcMessage & { receivedAt: number }} InviteInternal
  */
 
 /** @typedef {import('./types.js').MapBuffers<InviteInternal>} Invite */
@@ -153,7 +161,7 @@ export class InviteApi extends TypedEmitter {
 
     this.rpc.on('invite', (...args) => {
       try {
-        this.#handleInvite(...args)
+        this.#handleInviteRpcMessage(...args)
       } catch (err) {
         console.error('Error handling invite', err)
       }
@@ -162,9 +170,11 @@ export class InviteApi extends TypedEmitter {
 
   /**
    * @param {string} peerId
-   * @param {InviteInternal} invite
+   * @param {InviteRpcMessage} inviteRpcMessage
    */
-  #handleInvite(peerId, invite) {
+  #handleInviteRpcMessage(peerId, inviteRpcMessage) {
+    const invite = { ...inviteRpcMessage, receivedAt: Date.now() }
+
     const isAlreadyMember = this.#isMember(invite.projectPublicId)
     if (isAlreadyMember) {
       this.rpc

--- a/tests/invite-api.js
+++ b/tests/invite-api.js
@@ -1101,8 +1101,11 @@ function setup() {
 }
 
 /**
- * Assert that invites are alike, allowing for some wiggle room around
- * "received at" timestamps.
+ * Assert that invites are alike, with two special cases for "received at"
+ * timestamps:
+ *
+ * 1. They are are ignored during equality comparison
+ * 2. If present, the timestamps must be within the last 30 seconds
  *
  * @param {import('brittle').TestInstance} t
  * @param {unknown} actual

--- a/tests/invite-api.js
+++ b/tests/invite-api.js
@@ -1,6 +1,7 @@
 // @ts-check
 import test from 'brittle'
 import { once } from 'node:events'
+import { compact, concat, map, every } from 'iterpal'
 import { onTimes } from './helpers/events.js'
 import { randomBytes } from 'crypto'
 import { KeyManager } from '@mapeo/crypto'
@@ -101,8 +102,18 @@ test('invite-received event has expected payload', async (t) => {
     },
   ]
   const receivedInvitesArgs = await invitesReceivedPromise
-  t.alike(receivedInvitesArgs, expectedInvites, 'received expected invites')
-  t.alike(inviteApi.getPending(), expectedInvites)
+  assertInvitesAlike(
+    t,
+    receivedInvitesArgs,
+    expectedInvites,
+    'received expected invites'
+  )
+  assertInvitesAlike(
+    t,
+    inviteApi.getPending(),
+    expectedInvites,
+    'pending invites are expected'
+  )
 })
 
 test('Accept invite', async (t) => {
@@ -139,7 +150,12 @@ test('Accept invite', async (t) => {
 
   await inviteReceivedPromise
 
-  t.alike(inviteApi.getPending(), [inviteExternal], 'has one pending invite')
+  assertInvitesAlike(
+    t,
+    inviteApi.getPending(),
+    [inviteExternal],
+    'has one pending invite'
+  )
 
   // Invitor: prepare to share project join details upon acceptance
 
@@ -177,8 +193,8 @@ test('Accept invite', async (t) => {
   )
 
   const [removedInvite] = await inviteRemovedPromise
-  t.alike(removedInvite, inviteExternal, 'invite was removed')
-  t.alike(inviteApi.getPending(), [], 'no invites remain')
+  assertInvitesAlike(t, removedInvite, inviteExternal, 'invite was removed')
+  assertInvitesAlike(t, inviteApi.getPending(), [], 'no invites remain')
 })
 
 test('Reject invite', async (t) => {
@@ -204,7 +220,12 @@ test('Reject invite', async (t) => {
 
   await inviteReceivedPromise
 
-  t.alike(inviteApi.getPending(), [inviteExternal], 'has one pending invite')
+  assertInvitesAlike(
+    t,
+    inviteApi.getPending(),
+    [inviteExternal],
+    'has one pending invite'
+  )
 
   // Invitor: prepare to receive response
 
@@ -217,8 +238,8 @@ test('Reject invite', async (t) => {
   inviteApi.reject(inviteExternal)
 
   const [removedInvite] = await inviteRemovedPromise
-  t.alike(removedInvite, inviteExternal, 'invite was removed')
-  t.alike(inviteApi.getPending(), [], 'pending invites removed')
+  assertInvitesAlike(t, removedInvite, inviteExternal, 'invite was removed')
+  assertInvitesAlike(t, inviteApi.getPending(), [], 'pending invites removed')
 
   // Invitor: check rejection
 
@@ -259,7 +280,7 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
 
     rpc.emit('invite', invitorPeerId, invite)
 
-    t.alike(inviteApi.getPending(), [], 'has no pending invites')
+    assertInvitesAlike(t, inviteApi.getPending(), [], 'has no pending invites')
 
     // Invitor: check invite response
 
@@ -277,7 +298,7 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
       'got "already" response'
     )
 
-    t.alike(inviteApi.getPending(), [], 'has no pending invites')
+    assertInvitesAlike(t, inviteApi.getPending(), [], 'has no pending invites')
   })
 
   t.test(
@@ -307,7 +328,12 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
 
       await inviteReceivedPromise
 
-      t.alike(inviteApi.getPending(), [inviteExternal], 'has a pending invite')
+      assertInvitesAlike(
+        t,
+        inviteApi.getPending(),
+        [inviteExternal],
+        'has a pending invite'
+      )
 
       isMember = true
 
@@ -322,8 +348,13 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
       await inviteApi.accept(inviteExternal)
 
       const [removedInvite] = await inviteRemovedPromise
-      t.alike(removedInvite, inviteExternal, 'invite was removed')
-      t.alike(inviteApi.getPending(), [], 'has no pending invites')
+      assertInvitesAlike(t, removedInvite, inviteExternal, 'invite was removed')
+      assertInvitesAlike(
+        t,
+        inviteApi.getPending(),
+        [],
+        'has no pending invites'
+      )
 
       // Invitor: check invite response
 
@@ -406,7 +437,8 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
 
     await invitesReceivedPromise
 
-    t.alike(
+    assertInvitesAlike(
+      t,
       inviteApi.getPending(),
       [
         inviteExternal,
@@ -491,7 +523,8 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
     const removedInvites = await invitesRemovedPromise
     const allButLastRemoved = removedInvites.slice(0, -1)
     const lastRemoved = removedInvites[removedInvites.length - 1]
-    t.alike(
+    assertInvitesAlike(
+      t,
       new Set(allButLastRemoved),
       new Set([
         secondInviteExternalFromPeer1,
@@ -501,12 +534,14 @@ test('Receiving invite for project that peer already belongs to', async (t) => {
       ]),
       'other invites are removed first, to avoid UI jitter'
     )
-    t.alike(
+    assertInvitesAlike(
+      t,
       lastRemoved,
       inviteExternal,
       'accepted invite was removed last, to avoid UI jitter'
     )
-    t.alike(
+    assertInvitesAlike(
+      t,
       inviteApi.getPending(),
       [unrelatedInviteExternal],
       'unaffected invites stick around'
@@ -535,7 +570,7 @@ test('trying to accept or reject non-existent invite throws', async (t) => {
   await t.exception(inviteApi.accept(inviteExternal))
   t.exception(() => inviteApi.reject(inviteExternal))
 
-  t.alike(inviteApi.getPending(), [], 'has no pending invites')
+  assertInvitesAlike(t, inviteApi.getPending(), [], 'has no pending invites')
 })
 
 test('throws when quickly double-accepting the same invite', async (t) => {
@@ -753,7 +788,12 @@ test('receiving project join details from an unknown peer is a no-op', async (t)
 
   await inviteReceivedPromise
 
-  t.alike(inviteApi.getPending(), [inviteExternal], 'has one pending invite')
+  assertInvitesAlike(
+    t,
+    inviteApi.getPending(),
+    [inviteExternal],
+    'has one pending invite'
+  )
 
   // Invitor: prepare to share project join details with the wrong invite ID
 
@@ -782,7 +822,8 @@ test('receiving project join details from an unknown peer is a no-op', async (t)
 
   // The original invite should still be around
 
-  t.alike(
+  assertInvitesAlike(
+    t,
     inviteApi.getPending(),
     [inviteExternal],
     'has original pending invite'
@@ -819,7 +860,12 @@ test('receiving project join details for an unknown invite ID is a no-op', async
 
   await inviteReceivedPromise
 
-  t.alike(inviteApi.getPending(), [inviteExternal], 'has one pending invite')
+  assertInvitesAlike(
+    t,
+    inviteApi.getPending(),
+    [inviteExternal],
+    'has one pending invite'
+  )
 
   // Invitor: prepare to share project join details with the wrong invite ID
 
@@ -847,7 +893,8 @@ test('receiving project join details for an unknown invite ID is a no-op', async
 
   // The original invite should still be around
 
-  t.alike(
+  assertInvitesAlike(
+    t,
     inviteApi.getPending(),
     [inviteExternal],
     'has original pending invite'
@@ -912,14 +959,19 @@ test('failures to send acceptances cause accept to reject, no project to be adde
 
   await inviteReceivedPromise
 
-  t.alike(inviteApi.getPending(), [inviteExternal], 'has a pending invite')
+  assertInvitesAlike(
+    t,
+    inviteApi.getPending(),
+    [inviteExternal],
+    'has a pending invite'
+  )
 
   await t.exception(inviteApi.accept(inviteExternal), 'fails to accept')
 
   t.is(acceptsAttempted, 1)
   const [removedInvite] = await inviteRemovedPromise
-  t.alike(removedInvite, inviteExternal, 'invite was removed')
-  t.alike(inviteApi.getPending(), [], 'has no pending invites')
+  assertInvitesAlike(t, removedInvite, inviteExternal, 'invite was removed')
+  assertInvitesAlike(t, inviteApi.getPending(), [], 'has no pending invites')
 })
 
 test('failures to send rejections are ignored, but invite is still removed', async (t) => {
@@ -958,7 +1010,7 @@ test('failures to send rejections are ignored, but invite is still removed', asy
 
   t.is(rejectionsAttempted, 1)
   const [removedInvite] = await inviteRemovedPromise
-  t.alike(removedInvite, inviteExternal, 'invite was removed')
+  assertInvitesAlike(t, removedInvite, inviteExternal, 'invite was removed')
 })
 
 test('failures to add project cause accept() to reject and invite to be removed', async (t) => {
@@ -1014,7 +1066,7 @@ test('failures to add project cause accept() to reject and invite to be removed'
   await t.exception(inviteApi.accept(inviteExternal), 'accept should fail')
 
   const [removedInvite] = await inviteRemovedPromise
-  t.alike(removedInvite, inviteExternal, 'invite was removed')
+  assertInvitesAlike(t, removedInvite, inviteExternal, 'invite was removed')
 })
 
 function setup() {
@@ -1046,4 +1098,74 @@ function setup() {
     projectKey,
     encryptionKeys,
   }
+}
+
+/**
+ * Assert that invites are alike, allowing for some wiggle room around
+ * "received at" timestamps.
+ *
+ * @param {import('brittle').TestInstance} t
+ * @param {unknown} actual
+ * @param {unknown} expected
+ * @param {string} message
+ * @returns {void}
+ */
+function assertInvitesAlike(t, actual, expected, message) {
+  t.alike(removeReceivedAt(actual), removeReceivedAt(expected), message)
+
+  const allReceivedAts = concat(
+    getReceivedAts(actual),
+    getReceivedAts(expected)
+  )
+  const now = Date.now()
+  t.ok(
+    every(
+      allReceivedAts,
+      (receivedAt) => receivedAt > now - 30_000 && receivedAt <= now
+    ),
+    message
+  )
+}
+
+/**
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function removeReceivedAt(value) {
+  if (typeof value !== 'object' || !value) return value
+
+  if (Array.isArray(value)) return value.map(removeReceivedAt)
+
+  if (value instanceof Set) return new Set(map(value, removeReceivedAt))
+
+  if ('receivedAt' in value) {
+    const { receivedAt: _, ...result } = value
+    return result
+  }
+
+  return value
+}
+
+/**
+ * @param {unknown} value
+ * @returns {Iterable<number>}
+ */
+function getReceivedAts(value) {
+  const asIterable =
+    Array.isArray(value) || value instanceof Set ? value : [value]
+  const recievedAts = map(asIterable, getReceivedAt)
+  return compact(recievedAts)
+}
+
+/**
+ * @param {unknown} value
+ * @returns {null | number}
+ */
+function getReceivedAt(value) {
+  return typeof value === 'object' &&
+    value &&
+    'receivedAt' in value &&
+    typeof value.receivedAt === 'number'
+    ? value.receivedAt
+    : null
 }


### PR DESCRIPTION
This will make it possible for the frontend to sort incoming invites, and was requested by Erik.
