### PR TITLE
chore: save schema integers in INTEGER SQLite columns

### DIFF
--- a/src/schema/schema-to-drizzle.js
+++ b/src/schema/schema-to-drizzle.js
@@ -39,8 +39,10 @@ export function jsonSchemaToDrizzleColumns(schema) {
         columns[key] = integer(key, { mode: 'boolean' })
         break
       case 'number':
-      case 'integer':
         columns[key] = real(key)
+        break
+      case 'integer':
+        columns[key] = integer(key)
         break
       case 'string': {
         const enumValue = isStringArray(value.enum)

--- a/src/schema/schema-to-drizzle.js
+++ b/src/schema/schema-to-drizzle.js
@@ -15,8 +15,7 @@ Convert a JSONSchema definition to a Drizzle Columns Map (the parameter for
 
 **NOTE**: The return of this function is _not_ type-checked (it is coerced with
 `as`, because it's not possible to type-check what this function is doing), but
-the return type _should_ be correct when using this function. TODO: tests for
-the return type of this function.
+the return type _should_ be correct when using this function.
 @template {import('./types.js').JSONSchema7WithProps} TSchema
 NB: The inline typescript checker often marks this next line as an error, but this seems to be a bug with JSDoc parsing - running `tsc` does not show this as an error.
 @template {import('type-fest').Get<TSchema, 'properties.schemaName.const'>} TSchemaName

--- a/tests/schema/schema-to-drizzle.js
+++ b/tests/schema/schema-to-drizzle.js
@@ -38,7 +38,7 @@ test('number', (t) => {
 
 test('integer', (t) => {
   const col = getColumn({ type: 'integer' })
-  t.is(col.getSQLType(), 'real', 'integers are stored in REAL columns')
+  t.is(col.getSQLType(), 'integer', 'integers are stored in INTEGER columns')
 })
 
 test('string', (t) => {

--- a/tests/schema/schema-to-drizzle.js
+++ b/tests/schema/schema-to-drizzle.js
@@ -1,0 +1,89 @@
+// @ts-check
+import test from 'brittle'
+import { jsonSchemaToDrizzleColumns } from '../../src/schema/schema-to-drizzle.js'
+import { sqliteTable } from 'drizzle-orm/sqlite-core'
+
+test('throws if not passed an object schema', (t) => {
+  t.exception(() => {
+    jsonSchemaToDrizzleColumns({ type: 'number', properties: {} })
+  })
+})
+
+test('always adds "forks" column', (t) => {
+  t.ok(
+    'forks' in jsonSchemaToDrizzleColumns({ type: 'object', properties: {} }),
+    'forks column is added'
+  )
+})
+
+test('skips null', (t) => {
+  t.absent(
+    'foo' in
+      jsonSchemaToDrizzleColumns({
+        type: 'object',
+        properties: { foo: { type: 'null' } },
+      })
+  )
+})
+
+test('boolean', (t) => {
+  const col = getColumn({ type: 'boolean' })
+  t.is(col.getSQLType(), 'integer', 'booleans are stored in INTEGER columns')
+})
+
+test('number', (t) => {
+  const col = getColumn({ type: 'number' })
+  t.is(col.getSQLType(), 'real', 'numbers are stored in REAL columns')
+})
+
+test('integer', (t) => {
+  const col = getColumn({ type: 'integer' })
+  t.is(col.getSQLType(), 'real', 'integers are stored in REAL columns')
+})
+
+test('string', (t) => {
+  const col = getColumn({ type: 'string' })
+  t.is(col.getSQLType(), 'text', 'strings are stored in TEXT columns')
+})
+
+test('string with enum', (t) => {
+  const col = getColumn({ type: 'string', enum: ['foo', 'bar'] })
+  t.is(col.getSQLType(), 'text', 'strings are stored in TEXT columns')
+  t.alike(col.enumValues, ['foo', 'bar'], 'enums are saved')
+})
+
+test('array', (t) => {
+  const col = getColumn({ type: 'array' })
+  t.is(col.getSQLType(), 'text', 'arrays are stored in TEXT columns')
+})
+
+test('object', (t) => {
+  const col = getColumn({ type: 'object' })
+  t.is(col.getSQLType(), 'text', 'objects are stored in TEXT columns')
+})
+
+test('required columns', (t) => {
+  const col = getColumn({ type: 'number' }, { required: ['property'] })
+  t.ok(col.notNull, 'required columns are NOT NULL')
+})
+
+test('default values', (t) => {
+  const col = getColumn(
+    { type: 'number', default: 123 },
+    { required: ['property'] }
+  )
+  t.is(col.default, 123, 'sets default value')
+})
+
+/**
+ * @param {import('../../src/schema/types.js').JSONSchema7} property
+ * @param {Omit<import('../../src/schema/types.js').JSONSchema7WithProps, 'type' | 'properties'>} [additionalSchema={}]
+ */
+function getColumn(property, additionalSchema = {}) {
+  const cols = jsonSchemaToDrizzleColumns({
+    type: 'object',
+    properties: { property },
+    ...additionalSchema,
+  })
+  return sqliteTable('test', cols).property
+}


### PR DESCRIPTION
_Depends on #530._

If we use the ["integer" JSON Schema type][0], we should save that as an INTEGER column, not a REAL column. Both will work for many numbers, but larger integers (like `2**63`) can only be safely stored in INTEGERs.  This should be a bit more reliable.

As of this patch, we don't have any integer types in our schemas, so this has no effect. However, that may change as we address [upcoming issues][1].

[0]: https://json-schema.org/understanding-json-schema/reference/numeric#integer
[1]: https://github.com/digidem/mapeo-core-next/issues/150
