### PR TITLE
chore: add Brittle's `t.snapshot()` to type definitions

### DIFF
--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -373,7 +373,6 @@ test('Consistent storage folders', async (t) => {
     await project.$getOwnRole()
   }
 
-  // @ts-ignore snapshot() is missing from typedefs
   t.snapshot(storageNames.sort())
 })
 

--- a/types/brittle.d.ts
+++ b/types/brittle.d.ts
@@ -53,6 +53,7 @@ declare module 'brittle' {
     fail(message?: string): void
     exception: ExceptionAssertion
     execution<T>(fn: T | Promise<T>, message?: string): Promise<number>
+    snapshot(actual: unknown, message?: string): void
   }
 
   interface TestOptions {


### PR DESCRIPTION
Brittle has `t.snapshot()` which checks a value against a snapshot. It's undocumented but we use it. This commit adds it to the type definitions and removes a `@ts-ignore`.

See also: [a PR on Brittle to document this function][0].

[0]: https://github.com/holepunchto/brittle/pull/45