### PR TITLE
chore: shorten `getExpectedConfig`

### DIFF
--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -2,6 +2,7 @@
 import sodium from 'sodium-universal'
 import RAM from 'random-access-memory'
 import Fastify from 'fastify'
+import { arrayFrom } from 'iterpal'
 
 import { MapeoManager } from '../src/index.js'
 import { kManagerReplicate, kRPC } from '../src/mapeo-manager.js'
@@ -336,23 +337,10 @@ export function sortBy(arr, key) {
 /** @param {String} path */
 export async function getExpectedConfig(path) {
   const config = await readConfig(path)
-  let presets = []
-  let fields = []
-  let icons = []
-  for (let preset of config.presets()) {
-    presets.push(preset)
-  }
-  for (let field of config.fields()) {
-    fields.push(field)
-  }
-  for await (let icon of config.icons()) {
-    icons.push(icon)
-  }
-
   return {
-    presets,
-    fields,
-    icons,
+    presets: arrayFrom(config.presets()),
+    fields: arrayFrom(config.fields()),
+    icons: await arrayFrom(config.icons()),
   }
 }
 


### PR DESCRIPTION
This is a test-only change that should have no impact.

`config.presets()`, `config.fields()`, and `config.icons()` are all iterables that we can convert to arrays.