### PR TITLE
chore: disable flaky project leave test

### DIFF
--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test } from 'brittle'
+import { test, skip } from 'brittle'
 
 import {
   BLOCKED_ROLE_ID,
@@ -112,7 +112,8 @@ test('Blocked member cannot leave project', async (t) => {
   await disconnectPeers(managers)
 })
 
-test('Creator can leave project if another coordinator exists', async (t) => {
+// TODO: Re-enable this test. See <https://github.com/digidem/mapeo-core-next/issues/540>.
+skip('Creator can leave project if another coordinator exists', async (t) => {
   const managers = await createManagers(2, t)
 
   connectPeers(managers)


### PR DESCRIPTION
*This might be a controversial change. Feel free to close!*

We should fix this, but I think it's disruptive enough that we should disable it for now. See #540 for a task to properly fix this.