### PR TITLE
chore: fix flaky "project leave" tests

### DIFF
--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -144,6 +144,8 @@ test('Creator can leave project if another coordinator exists', async (t) => {
     'creator successfully added from creator perspective'
   )
 
+  await waitForSync(projects, 'initial')
+
   await creator.leaveProject(projectId)
 
   t.alike(
@@ -194,6 +196,8 @@ test('Member can leave project if creator exists', async (t) => {
     await memberProject.$member.getById(creator.deviceId),
     'creator successfully added from member perspective'
   )
+
+  await waitForSync(projects, 'initial')
 
   await member.leaveProject(projectId)
 


### PR DESCRIPTION
These tests have been very flaky. After a few hours of investigation it seems that peers weren't synced before someone left the project, which caused `waitForSync` to hang indefinitely.

We likely want our leave code to be more robust. In the short term, however, I think it's worth fixing these tests. (See https://github.com/digidem/mapeo-core-next/pull/469#issuecomment-2050255602 for these "make it more robust" tasks.)

Closes #540.