### PR TITLE
chore: lint-staged improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --cache --fix"
+      "eslint --cache"
     ],
-    "*.{js,css,md}": "prettier --write"
+    "*": [
+      "prettier --check"
+    ]
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
This makes two improvements to `lint-staged`:

- Run Prettier on all files, not just some extensions.

- Only check files, not fix them. This addresses a race condition (search [lint-staged's docs][0] for "race condition").

(I know there's some controversy about whether to use `lint-staged` at all, but I think these are improvements we can adopt regardless.)

[0]: https://www.npmjs.com/package/lint-staged
