### PR TITLE
chore: use `size` helper in config import tests

### DIFF
--- a/tests/config-import.js
+++ b/tests/config-import.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { test } from 'brittle'
+import { size } from 'iterpal'
 import { readConfig } from '../src/config-import.js'
 
 test('config import - loading', async (t) => {
@@ -214,30 +215,22 @@ test('config import - load default config', async (t) => {
   let config = await readConfig('./config/defaultConfig.mapeoconfig')
   t.ok(config, 'valid config file')
 
-  let nFields = 0
-  /* eslint-disable-next-line */
-  for (const field of config.fields()) {
-    nFields++
-  }
-  t.is(nFields, 2, 'correct number of fields in default config')
+  t.is(size(config.fields()), 2, 'correct number of fields in default config')
   let nIcons = 0
   let nVariants = 0
   /* eslint-disable-next-line */
   for await (const icon of config.icons()) {
     nIcons++
-    /* eslint-disable-next-line */
-    for (let variant of icon.variants) {
-      nVariants++
-    }
+    nVariants += size(icon.variants)
   }
   t.is(nIcons, 41, 'correct number of icons in default config')
   t.is(nVariants, 369, 'correct number of icon variants in default config')
 
-  let nPresets = 0
-  /* eslint-disable-next-line */
-  for (const preset of config.presets()) {
-    nPresets++
-  }
-  t.is(nPresets, 43, 'correct number of presets in default config')
+  t.is(
+    size(config.presets()),
+    43,
+    'correct number of presets in default config'
+  )
+
   t.is(config.warnings.length, 0, 'no warnings on config file')
 })


### PR DESCRIPTION
Iterpal's `size` function can save us a few lines and avoid a few `eslint-disable`s.
