### PR TITLE
feat: return project public ID when accepting invite

### DIFF
--- a/src/invite-api.js
+++ b/src/invite-api.js
@@ -261,7 +261,7 @@ export class InviteApi extends TypedEmitter {
    * part of this project.
    *
    * @param {Pick<Invite, 'inviteId'>} invite
-   * @returns {Promise<void>}
+   * @returns {Promise<string>}
    */
   async accept({ inviteId: inviteIdString }) {
     const inviteId = Buffer.from(inviteIdString, 'hex')
@@ -301,7 +301,7 @@ export class InviteApi extends TypedEmitter {
           'accepted'
         )
       }
-      return
+      return projectPublicId
     }
 
     assert(
@@ -373,6 +373,8 @@ export class InviteApi extends TypedEmitter {
     }
 
     this.emit('invite-removed', internalToExternal(invite), 'accepted')
+
+    return projectPublicId
   }
 
   /**

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -36,13 +36,14 @@ test('member invite accepted', async (t) => {
   )
   t.is(invite.projectName, 'Mapeo', 'project name of invite matches')
 
-  await joiner.invite.accept(invite)
+  const acceptResult = await joiner.invite.accept(invite)
 
   t.is(
     await responsePromise,
     InviteResponse_Decision.ACCEPT,
     'correct invite response'
   )
+  t.is(acceptResult, createdProjectId, 'accept returns invite ID')
 
   /// After invite flow has completed...
 
@@ -84,7 +85,8 @@ test('chain of invites', async (t) => {
       roleId: COORDINATOR_ROLE_ID,
     })
     const [invite] = await once(joiner.invite, 'invite-received')
-    await joiner.invite.accept(invite)
+    const acceptResult = await joiner.invite.accept(invite)
+    t.is(acceptResult, createdProjectId, 'accept returns invite ID')
     t.is(
       await responsePromise,
       InviteResponse_Decision.ACCEPT,

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -99,6 +99,8 @@ export async function invite({
   reject = false,
 }) {
   const invitorProject = await invitor.getProject(projectId)
+
+  /** @type {Array<Promise<unknown>>} */
   const promises = []
 
   for (const invitee of invitees) {
@@ -109,10 +111,10 @@ export async function invite({
       })
     )
     promises.push(
-      once(invitee.invite, 'invite-received').then(([invite]) => {
-        return reject
+      once(invitee.invite, 'invite-received').then(async ([invite]) => {
+        await (reject
           ? invitee.invite.reject(invite)
-          : invitee.invite.accept(invite)
+          : invitee.invite.accept(invite))
       })
     )
   }

--- a/tests/invite-api.js
+++ b/tests/invite-api.js
@@ -123,6 +123,7 @@ test('Accept invite', async (t) => {
     invite,
     inviteExternal,
     projectKey,
+    projectPublicId,
     encryptionKeys,
   } = setup()
 
@@ -185,8 +186,9 @@ test('Accept invite', async (t) => {
 
   // Invitee: accept
 
-  await inviteApi.accept(inviteExternal)
+  const acceptResult = await inviteApi.accept(inviteExternal)
 
+  t.is(acceptResult, projectPublicId, 'accept returns project public ID')
   t.ok(
     projectKeysFound.some((k) => k.equals(projectKey)),
     'added to project'
@@ -584,7 +586,7 @@ test('trying to accept or reject non-existent invite throws', async (t) => {
     t.fail('should not emit an "removed" event')
   })
 
-  await t.exception(inviteApi.accept(inviteExternal))
+  await t.exception(() => inviteApi.accept(inviteExternal))
   t.exception(() => inviteApi.reject(inviteExternal))
 
   assertInvitesAlike(t, inviteApi.getPending(), [], 'has no pending invites')
@@ -645,7 +647,10 @@ test('throws when quickly double-accepting the same invite', async (t) => {
 
   const firstAcceptPromise = inviteApi.accept(inviteExternal)
 
-  await t.exception(inviteApi.accept(inviteExternal), 'second accept fails')
+  await t.exception(
+    () => inviteApi.accept(inviteExternal),
+    'second accept fails'
+  )
 
   await firstAcceptPromise
   t.ok(
@@ -765,7 +770,10 @@ test('throws when quickly accepting two invites for the same project', async (t)
 
   const firstAcceptPromise = inviteApi.accept(invite1External)
 
-  await t.exception(inviteApi.accept(invite2External), 'second accept fails')
+  await t.exception(
+    () => inviteApi.accept(invite2External),
+    'second accept fails'
+  )
 
   await firstAcceptPromise
   t.ok(
@@ -983,7 +991,7 @@ test('failures to send acceptances cause accept to reject, no project to be adde
     'has a pending invite'
   )
 
-  await t.exception(inviteApi.accept(inviteExternal), 'fails to accept')
+  await t.exception(() => inviteApi.accept(inviteExternal), 'fails to accept')
 
   t.is(acceptsAttempted, 1)
   const [removedInvite, removalReason] = await inviteRemovedPromise
@@ -1086,7 +1094,10 @@ test('failures to add project cause accept() to reject and invite to be removed'
 
   const inviteRemovedPromise = once(inviteApi, 'invite-removed')
 
-  await t.exception(inviteApi.accept(inviteExternal), 'accept should fail')
+  await t.exception(
+    () => inviteApi.accept(inviteExternal),
+    'accept should fail'
+  )
 
   const [removedInvite, removalReason] = await inviteRemovedPromise
   assertInvitesAlike(t, removedInvite, inviteExternal, 'invite was removed')


### PR DESCRIPTION
When you accept an invite, we should return the project public ID.  Without it, the frontend has to pull it out of the invite object, which feels like an implementation detail to me and Erik.