### PR TITLE
chore: add `createPersistentProject` helper for e2e tests

### DIFF
--- a/test-e2e/project-crud.js
+++ b/test-e2e/project-crud.js
@@ -88,7 +88,7 @@ function getUpdateFixture(value) {
 const CREATE_COUNT = 100
 
 test('CRUD operations', async (t) => {
-  const manager = createManager('device0', t)
+  const manager = createManager({ seed: 'device0', t })
 
   for (const value of fixtures) {
     const { schemaName } = value

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -195,22 +195,25 @@ export async function createManagers(count, t, deviceType) {
  * @param {string | (() => RAM)} [opts.coreStorage]
  * @param {import('../src/generated/rpc.js').DeviceInfo['deviceType']} [opts.deviceType]
  */
-export function createManager({ seed, t, deviceType, dbFolder, coreStorage }) {
-  const db = dbFolder || (FAST_TESTS ? ':memory:' : temporaryDirectory())
-  const core =
-    coreStorage || (FAST_TESTS ? () => new RAM() : temporaryDirectory())
+export function createManager({
+  seed,
+  t,
+  deviceType,
+  dbFolder = FAST_TESTS ? ':memory:' : temporaryDirectory(),
+  coreStorage = FAST_TESTS ? () => new RAM() : temporaryDirectory(),
+}) {
   t.teardown(async () => {
     if (FAST_TESTS) return
     await Promise.all([
-      fsPromises.rm(db, {
+      fsPromises.rm(dbFolder, {
         recursive: true,
         force: true,
         maxRetries: 2,
       }),
       // @ts-ignore
       () => {
-        if (typeof core === 'string') {
-          fsPromises.rm(core, {
+        if (typeof coreStorage === 'string') {
+          fsPromises.rm(coreStorage, {
             recursive: true,
             force: true,
             maxRetries: 2,
@@ -223,8 +226,8 @@ export function createManager({ seed, t, deviceType, dbFolder, coreStorage }) {
     rootKey: getRootKey(seed),
     projectMigrationsFolder,
     clientMigrationsFolder,
-    dbFolder: db,
-    coreStorage: core,
+    dbFolder,
+    coreStorage,
     fastify: Fastify(),
     deviceType,
   })


### PR DESCRIPTION
This would help with testing with stuff related to persitent storage.

the function needs a path, and creates a project when run the first time. It will also saved the created `projectId` on a file in the passed path. On subsequent runs it will load the `projectId` from the path