### PR TITLE
chore: fix const type error in sync test

### DIFF
--- a/tests/sync/core-sync-state.js
+++ b/tests/sync/core-sync-state.js
@@ -264,7 +264,7 @@ test('deriveState() have at index beyond bitfield page size', (t) => {
     localState,
     remoteStates: new Map([['peer0', remoteState]]),
     peerSyncControllers: new Map(),
-    namespace: /** @type {const} */ 'auth',
+    namespace: /** @type {const} */ ('auth'),
   }
   const expected = {
     coreLength: BITS_PER_PAGE + 10,


### PR DESCRIPTION
We weren't using the right syntax to mark a string as const, so its type was `string` when we meant it to be `'auth'`. That caused a type error, which is fixed by this change.