### PR TITLE
Fix "use before define" issue with DataType & TranslationApi

### DIFF
--- a/src/datatype/index.d.ts
+++ b/src/datatype/index.d.ts
@@ -13,6 +13,7 @@ import { SQLiteSelectBase } from 'drizzle-orm/sqlite-core'
 import { RunResult } from 'better-sqlite3'
 import type Hypercore from 'hypercore'
 import { TypedEmitter } from 'tiny-typed-emitter'
+import TranslationApi from '../translation-api.js'
 
 type MapeoDocTableName = `${MapeoDoc['schemaName']}Table`
 type GetMapeoDocTables<T> = T[keyof T & MapeoDocTableName]
@@ -52,13 +53,13 @@ export class DataType<
     table,
     getPermissions,
     db,
-    translation,
+    getTranslations,
   }: {
     table: TTable
     dataStore: TDataStore
     db: import('drizzle-orm/better-sqlite3').BetterSQLite3Database
     getPermissions?: () => any
-    translation: TranslationApi
+    getTranslations: TranslationApi['get']
   })
 
   get [kTable](): TTable

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -72,7 +72,7 @@ export class DataType extends TypedEmitter {
   #schemaName
   #sql
   #db
-  #translation
+  #getTranslations
 
   /**
    *
@@ -80,17 +80,17 @@ export class DataType extends TypedEmitter {
    * @param {TTable} opts.table
    * @param {TDataStore} opts.dataStore
    * @param {import('drizzle-orm/better-sqlite3').BetterSQLite3Database} opts.db
-   * @param {import('../translation-api.js').default} opts.translation
+   * @param {import('../translation-api.js').default['get']} opts.getTranslations
    * @param {() => any} [opts.getPermissions]
    */
-  constructor({ dataStore, table, getPermissions, db, translation }) {
+  constructor({ dataStore, table, getPermissions, db, getTranslations }) {
     super()
     this.#dataStore = dataStore
     this.#table = table
     this.#schemaName = /** @type {TSchemaName} */ (getTableConfig(table).name)
     this.#getPermissions = getPermissions
     this.#db = db
-    this.#translation = translation
+    this.#getTranslations = getTranslations
     this.#sql = {
       getByDocId: db
         .select()
@@ -214,12 +214,12 @@ export class DataType extends TypedEmitter {
       docIdRef: doc.docId,
       regionCode: region !== null ? region : undefined,
     }
-    let translations = await this.#translation.get(value)
+    let translations = await this.#getTranslations(value)
     // if passing a region code returns no matches,
     // fallback to matching only languageCode
     if (translations.length === 0 && value.regionCode) {
       value.regionCode = undefined
-      translations = await this.#translation.get(value)
+      translations = await this.#getTranslations(value)
     }
 
     for (let translation of translations) {
@@ -239,10 +239,9 @@ export class DataType extends TypedEmitter {
     return await Promise.all(
       rows.map(
         async (doc) =>
-          await this.#translate(
-            deNullify(/** @type {MapeoDoc} */ (doc)),
-            { lang }
-          )
+          await this.#translate(deNullify(/** @type {MapeoDoc} */ (doc)), {
+            lang,
+          })
       )
     )
   }

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -178,6 +178,7 @@ export class MapeoProject extends TypedEmitter {
       },
       logger: this.#l,
     })
+
     this.#dataStores = {
       auth: new DataStore({
         coreManager: this.#coreManager,
@@ -202,66 +203,71 @@ export class MapeoProject extends TypedEmitter {
         storage: indexerStorage,
       }),
     }
+
+    /** @type {typeof TranslationApi.prototype.get} */
+    const getTranslations = (...args) => this.$translation.get(...args)
     this.#dataTypes = {
       observation: new DataType({
         dataStore: this.#dataStores.data,
         table: observationTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       track: new DataType({
         dataStore: this.#dataStores.data,
         table: trackTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       preset: new DataType({
         dataStore: this.#dataStores.config,
         table: presetTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       field: new DataType({
         dataStore: this.#dataStores.config,
         table: fieldTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       projectSettings: new DataType({
         dataStore: this.#dataStores.config,
         table: projectSettingsTable,
         db: sharedDb,
-        translation: this.$translation,
+        getTranslations,
       }),
       coreOwnership: new DataType({
         dataStore: this.#dataStores.auth,
         table: coreOwnershipTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       role: new DataType({
         dataStore: this.#dataStores.auth,
         table: roleTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       deviceInfo: new DataType({
         dataStore: this.#dataStores.config,
         table: deviceInfoTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       icon: new DataType({
         dataStore: this.#dataStores.config,
         table: iconTable,
         db,
-        translation: this.$translation,
+        getTranslations,
       }),
       translation: new DataType({
         dataStore: this.#dataStores.config,
         table: translationTable,
         db,
-        translation: this.$translation,
+        getTranslations: () => {
+          throw new Error('Cannot get translation for translations')
+        },
       }),
     }
     const identityKeypair = keyManager.getIdentityKeypair()

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -55,6 +55,9 @@ test('private createWithDocId() method', async (t) => {
     dataStore,
     table: observationTable,
     db,
+    getTranslations() {
+      throw new Error('Translations should not be fetched in this test')
+    },
   })
   const customId = randomBytes(8).toString('hex')
   const obs = await dataType[kCreateWithDocId](customId, obsFixture)
@@ -87,6 +90,9 @@ test('private createWithDocId() method throws when doc exists', async (t) => {
     dataStore,
     table: observationTable,
     db,
+    getTranslations() {
+      throw new Error('Translations should not be fetched in this test')
+    },
   })
   const customId = randomBytes(8).toString('hex')
   await dataType[kCreateWithDocId](customId, obsFixture)
@@ -256,8 +262,6 @@ async function testenv(opts) {
     batch: async (entries) => indexWriter.batch(entries),
     storage: () => new RAM(),
   })
-  /** @type {TranslationApi} */
-  let translationApi
 
   const configDataStore = new DataStore({
     coreManager,
@@ -294,10 +298,12 @@ async function testenv(opts) {
     dataStore: configDataStore,
     table: translationTable,
     db,
-    translation: translationApi,
+    getTranslations: () => {
+      throw new Error('Cannot get translations for translations')
+    },
   })
 
-  translationApi = new TranslationApi({
+  const translationApi = new TranslationApi({
     dataType: translationDataType,
     table: translationTable,
   })
@@ -306,7 +312,7 @@ async function testenv(opts) {
     dataStore,
     table: observationTable,
     db,
-    translation: translationApi,
+    getTranslations: translationApi.get.bind(translationApi),
   })
 
   return { coreManager, dataType, dataStore, translationApi }

--- a/tests/icon-api.js
+++ b/tests/icon-api.js
@@ -685,6 +685,9 @@ function setup({
     dataStore: iconDataStore,
     table: iconTable,
     db,
+    getTranslations() {
+      throw new Error('Translations should not be fetched in this test')
+    },
   })
 
   const iconApi = new IconApi({

--- a/tests/translation-api.js
+++ b/tests/translation-api.js
@@ -102,8 +102,6 @@ test(`translation api - put() and get()`, async (t) => {
 function setup() {
   const sqlite = new Database(':memory:')
   const db = drizzle(sqlite)
-  /** @type {TranslationApi} */
-  let translationApi
 
   migrate(db, {
     migrationsFolder: new URL('../drizzle/project', import.meta.url).pathname,
@@ -127,13 +125,13 @@ function setup() {
     dataStore,
     table,
     db,
-    translation: translationApi,
+    getTranslations() {
+      throw new Error('Cannot get translations from translations')
+    },
   })
 
-  translationApi = new TranslationApi({
+  return new TranslationApi({
     dataType,
     table,
   })
-
-  return translationApi
 }


### PR DESCRIPTION
To be merged into #473.

`DataType` needs access to `TranslationApi.prototype.get`, but `TranslationApi` needs access to `DataType`. To avoid this circular reference, pass a `getTranslations` function into `DataType`.