### PR TITLE
chore: disallow `==` and `!=`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
       "sourceType": "module"
     },
     "rules": {
+      "eqeqeq": "error",
       "no-unused-vars": [
         "error",
         {

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -632,7 +632,7 @@ export class MapeoProject extends TypedEmitter {
 
       // Determine if the the device is a coordinator based on the role docs
       const isCoordinator = roleDocs.some(
-        (doc) => doc.docId === deviceId && doc.roleId == COORDINATOR_ROLE_ID
+        (doc) => doc.docId === deviceId && doc.roleId === COORDINATOR_ROLE_ID
       )
 
       if (isCoordinator) {


### PR DESCRIPTION
This enables the [ESLint eqeqeq rule][0], requiring `===` and `!==` over `==` and `!=`.

[0]: https://eslint.org/docs/latest/rules/eqeqeq