### PR TITLE
chore: require `default` case in `switch` statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     },
     "rules": {
       "eqeqeq": "error",
+      "default-case": "error",
+      "default-case-last": "error",
       "no-unused-vars": [
         "error",
         {

--- a/src/fastify-plugins/icons.js
+++ b/src/fastify-plugins/icons.js
@@ -4,6 +4,7 @@ import { docSchemas } from '@mapeo/schema'
 
 import { kGetIconBlob } from '../icon-api.js'
 import { HEX_REGEX_32_BYTES, Z_BASE_32_REGEX_32_BYTES } from './constants.js'
+import { ExhaustivenessError } from '../utils.js'
 
 export default fp(iconServerPlugin, {
   fastify: '4.x',
@@ -40,6 +41,8 @@ const PARAMS_JSON_SCHEMA = T.Object({
           return T.Literal('png')
         case 'image/svg+xml':
           return T.Literal('svg')
+        default:
+          throw new ExhaustivenessError(mimeType)
       }
     })
   ),


### PR DESCRIPTION
This enables ESLint's [`default-case`][0] and [`default-case-last`][1] rules to ensure that all `switch` statements end with a `default`.

There was one spot where we weren't doing this, which I fixed.

[0]: https://eslint.org/docs/rules/default-case
[1]: https://eslint.org/docs/rules/default-case-last
