### PR TITLE
chore: prefer strict Node assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,21 @@
           "varsIgnorePattern": "^_",
           "argsIgnorePattern": "^_"
         }
+      ],
+      "no-restricted-imports": [
+        "error",
+        {
+          "paths": [
+            {
+              "name": "assert",
+              "message": "Prefer importing node:assert/strict."
+            },
+            {
+              "name": "node:assert",
+              "message": "Prefer importing node:assert/strict."
+            }
+          ]
+        }
       ]
     }
   },

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { TypedEmitter } from 'tiny-typed-emitter'
 import Corestore from 'corestore'
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { sql, eq } from 'drizzle-orm'
 import { discoveryKey } from 'hypercore-crypto'
 import Hypercore from 'hypercore'

--- a/src/core-ownership.js
+++ b/src/core-ownership.js
@@ -1,7 +1,7 @@
 import { verifySignature, sign } from '@mapeo/crypto'
 import { parseVersionId } from '@mapeo/schema'
 import { defaultGetWinner } from '@mapeo/sqlite-indexer'
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import sodium from 'sodium-universal'
 import { kTable, kSelect, kCreateWithDocId } from './datatype/index.js'
 import { eq, or } from 'drizzle-orm'

--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -12,7 +12,7 @@ import {
   kCoreManagerReplicate,
 } from '../src/core-manager/index.js'
 import RemoteBitfield from '../src/core-manager/remote-bitfield.js'
-import assert from 'assert'
+import assert from 'node:assert/strict'
 import { once } from 'node:events'
 import { temporaryDirectoryTask } from 'tempy'
 import { exec } from 'child_process'


### PR DESCRIPTION
This change should have no impact on functionality.

`node:assert` has two modes: [strict] and [legacy]. The latter can have some strange behavior. This adds an [ESLint rule][no-restricted-imports] to prefer the strict mode, and fixes all violations.

I think this is a useful change on its own but it should make it a little easier to drop Brittle in the future.

[strict]: https://nodejs.org/api/assert.html#strict-assertion-mode
[legacy]: https://nodejs.org/api/assert.html#legacy-assertion-mode
[no-restricted-imports]: https://eslint.org/docs/latest/rules/no-restricted-imports