### PR TITLE
fix: remove replication error when core is closed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@digidem/types": "^2.2.0",
+        "@digidem/types": "^2.3.0",
         "@electron/asar": "^3.2.8",
         "@fastify/error": "^3.4.1",
         "@fastify/static": "^7.0.3",
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@digidem/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@digidem/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-pWFiP1Zj3U3LHa1FC87hBgFBF6HTeVWzSRy1P/IJO+ExMevQlIQMOwYvbcazqyGJJq0NxW0VsF+lPClzpllVcQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@digidem/types/-/types-2.3.0.tgz",
+      "integrity": "sha512-05dj9Z/xEmKQ5s9bl5doBHmmefgYoOQPn2BNu4eAbf6qgm6kylT1N94Ynr1zpdww+sB4sT9vjzAbc3BXtxQAKw==",
       "dependencies": {
         "@types/node": "^18.16.19",
         "@types/streamx": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@digidem/types": "^2.2.0",
+    "@digidem/types": "^2.3.0",
     "@electron/asar": "^3.2.8",
     "@fastify/error": "^3.4.1",
     "@fastify/static": "^7.0.3",

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -229,6 +229,7 @@ export class PeerSyncController {
    * @param {import('hypercore')<'binary', any>} core
    */
   #replicateCore(core) {
+    if (core.closed) return
     if (this.#replicatingCores.has(core)) return
     this.#log('replicating core %k', core.key)
     core.replicate(this.#protomux)

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -284,4 +284,48 @@ test('Data access after leaving project', async (t) => {
   await disconnectPeers(managers)
 })
 
+test('leaving a project while disconnected', async (t) => {
+  const managers = await createManagers(2, t)
+
+  let disconnectPeers = connectPeers(managers)
+  t.teardown(() => disconnectPeers())
+
+  await waitForPeers(managers)
+
+  const [creator, member] = managers
+  const projectId = await creator.createProject({ name: 'mapeo' })
+
+  await invite({
+    invitor: creator,
+    invitees: [member],
+    projectId,
+    roleId: MEMBER_ROLE_ID,
+  })
+
+  const projects = await Promise.all(
+    managers.map((m) => m.getProject(projectId))
+  )
+  const [creatorProject] = projects
+
+  await disconnectPeers()
+
+  await member.leaveProject(projectId)
+
+  t.ok(
+    await creatorProject.$member.getById(member.deviceId),
+    'creator still thinks member is part of project'
+  )
+
+  disconnectPeers = connectPeers(managers)
+  await waitForPeers(managers)
+
+  await waitForSync(projects, 'initial')
+
+  t.is(
+    (await creatorProject.$member.getById(member.deviceId)).role.roleId,
+    LEFT_ROLE_ID,
+    'creator no longer thinks member is part of project'
+  )
+})
+
 // TODO: Add test for leaving and rejoining a project


### PR DESCRIPTION
_Depends on <https://github.com/digidem/digidem-types/pull/14>. We can't merge this until that's deployed._

If a core is closed, we can't replicate it.

This can happen if you leave a project while offline, then reconnect. I added a test for this case and fixed the issue. (The fix is just one line, but it took a whole day to figure that out.)

Fixes #584.