### PR TITLE
chore: add types to fix datastore test type errors

### DIFF
--- a/tests/datastore.js
+++ b/tests/datastore.js
@@ -26,6 +26,7 @@ test('read and write', async (t) => {
   const cm = createCoreManager()
   const writerCore = cm.getWriterCore('data').core
   await writerCore.ready()
+  /** @type {Array<string>} */
   const indexedVersionIds = []
   const dataStore = new DataStore({
     coreManager: cm,
@@ -84,6 +85,7 @@ test('index events', async (t) => {
   const cm = createCoreManager()
   const writerCore = cm.getWriterCore('data').core
   await writerCore.ready()
+  /** @type {Array<Omit<import('multi-core-indexer').IndexState, 'entriesPerSecond'>>} */
   const indexStates = []
   const dataStore = new DataStore({
     coreManager: cm,


### PR DESCRIPTION
This types-only change fixes the type errors in this file.
