### PR TITLE
chore: throttle pre-have updates to avoid network flooding

### DIFF
--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { TypedEmitter } from 'tiny-typed-emitter'
 import Corestore from 'corestore'
-import { throttle } from 'throttle-debounce'
+import { debounce } from 'throttle-debounce'
 import assert from 'node:assert/strict'
 import { sql, eq } from 'drizzle-orm'
 import { discoveryKey } from 'hypercore-crypto'
@@ -310,7 +310,7 @@ export class CoreManager extends TypedEmitter {
     })
 
     if (writer) {
-      const sendHaves = throttle(WRITER_CORE_PREHAVES_DEBOUNCE_DELAY, () => {
+      const sendHaves = debounce(WRITER_CORE_PREHAVES_DEBOUNCE_DELAY, () => {
         for (const peer of this.#creatorCore.peers) {
           this.#sendHaves(peer, [{ core, namespace }]).catch(() => {
             this.#l.log('Failed to send new pre-haves to other peers')

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -15,7 +15,7 @@ import { coresTable } from '../schema/project.js'
 import * as rle from './bitfield-rle.js'
 import { CoreIndex } from './core-index.js'
 
-const WRITER_CORE_PREHAVES_DEBOUNCE_DELAY = 3000
+const WRITER_CORE_PREHAVES_DEBOUNCE_DELAY = 1000
 
 export const kCoreManagerReplicate = Symbol('replicate core manager')
 


### PR DESCRIPTION
Followup to 6ad3beaaff8d10d4a23a52380e73d8f76c833928. If we're adding lots of data at once (like during a config import), we shouldn't flood the network.

See [this comment](https://github.com/digidem/mapeo-core-next/commit/6ad3beaaff8d10d4a23a52380e73d8f76c833928#r141813463).