### PR TITLE
chore: move `@digidem/types` package to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@digidem/types": "^2.3.0",
         "@electron/asar": "^3.2.8",
         "@fastify/error": "^3.4.1",
         "@fastify/static": "^7.0.3",
@@ -61,6 +60,7 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.26.1",
+        "@digidem/types": "^2.3.0",
         "@hyperswarm/testnet": "^3.1.2",
         "@mapeo/default-config": "4.0.0-alpha.2",
         "@mapeo/mock-data": "^1.0.1",
@@ -252,6 +252,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@digidem/types/-/types-2.3.0.tgz",
       "integrity": "sha512-05dj9Z/xEmKQ5s9bl5doBHmmefgYoOQPn2BNu4eAbf6qgm6kylT1N94Ynr1zpdww+sB4sT9vjzAbc3BXtxQAKw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "^18.16.19",
         "@types/streamx": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   "homepage": "https://github.com/digidem/mapeo-core#readme",
   "devDependencies": {
     "@bufbuild/buf": "^1.26.1",
+    "@digidem/types": "^2.3.0",
     "@hyperswarm/testnet": "^3.1.2",
     "@mapeo/default-config": "4.0.0-alpha.2",
     "@mapeo/mock-data": "^1.0.1",
@@ -138,7 +139,6 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@digidem/types": "^2.3.0",
     "@electron/asar": "^3.2.8",
     "@fastify/error": "^3.4.1",
     "@fastify/static": "^7.0.3",


### PR DESCRIPTION
*This change is not urgent.*

This change should have no user impact.

This is a types-only dependency. We don't need it in production.
