### PR TITLE
chore: update dot-prop dependency to 9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "compact-encoding": "^2.12.0",
         "corestore": "^6.8.4",
         "debug": "^4.3.4",
-        "dot-prop": "^8.0.2",
+        "dot-prop": "^9.0.0",
         "drizzle-orm": "^0.30.8",
         "fastify": ">= 4",
         "fastify-plugin": "^4.5.1",
@@ -3189,25 +3189,14 @@
       }
     },
     "node_modules/dot-prop": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-8.0.2.tgz",
-      "integrity": "sha512-xaBe6ZT4DHPkg0k4Ytbvn5xoxgpG0jOS1dYxSOwAHPuNLjP3/OzN0gH55SrLqpx8cBfSaVt91lXYkApjb+nYdQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
       "dependencies": {
-        "type-fest": "^3.8.0"
+        "type-fest": "^4.18.2"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dot-prop/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8738,9 +8727,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.1.tgz",
-      "integrity": "sha512-ShaaYnjf+0etG8W/FumARKMjjIToy/haCaTjN2dvcewOSoNqCQzdgG7m2JVOlM5qndGTHjkvsrWZs+k/2Z7E0Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "compact-encoding": "^2.12.0",
     "corestore": "^6.8.4",
     "debug": "^4.3.4",
-    "dot-prop": "^8.0.2",
+    "dot-prop": "^9.0.0",
     "drizzle-orm": "^0.30.8",
     "fastify": ">= 4",
     "fastify-plugin": "^4.5.1",


### PR DESCRIPTION
This updates dot-prop to its latest version, v9.0.0.

The only breaking change in [the release notes][0] doesn't affect us: Node 18+ is now required.

[0]: https://github.com/sindresorhus/dot-prop/releases/tag/v9.0.0
