### PR TITLE
chore: update @types/node to latest v18 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "@types/json-schema": "^7.0.11",
         "@types/json-stable-stringify": "^1.0.36",
         "@types/nanobench": "^3.0.0",
-        "@types/node": "^18.16.3",
+        "@types/node": "^18.19.33",
         "@types/sinonjs__fake-timers": "^8.1.2",
         "@types/streamx": "^2.9.1",
         "@types/sub-encoder": "^2.1.0",
@@ -1922,8 +1922,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.19",
-      "license": "MIT"
+      "version": "18.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
+      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8920,6 +8924,11 @@
       "engines": {
         "node": ">=18.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-string": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/json-schema": "^7.0.11",
     "@types/json-stable-stringify": "^1.0.36",
     "@types/nanobench": "^3.0.0",
-    "@types/node": "^18.16.3",
+    "@types/node": "^18.19.33",
     "@types/sinonjs__fake-timers": "^8.1.2",
     "@types/streamx": "^2.9.1",
     "@types/sub-encoder": "^2.1.0",


### PR DESCRIPTION
I think this is a useful change on its own, but it will make our migration from Brittle to `node:test` easier because [`TestContext` is now exported][0], which we'll need.

[0]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69497
