### PR TITLE
test: move Fastify plugin tests to `node:test` and `node:assert`

### DIFF
--- a/tests/fastify-plugins/icons.js
+++ b/tests/fastify-plugins/icons.js
@@ -1,17 +1,20 @@
 // @ts-check
-import { test } from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { randomBytes } from 'crypto'
 import fastify from 'fastify'
 
 import IconServerPlugin from '../../src/fastify-plugins/icons.js'
 import { projectKeyToPublicId } from '../../src/utils.js'
 
-test('Plugin throws error if missing getProject option', async (t) => {
+test('Plugin throws error if missing getProject option', async () => {
   const server = fastify()
-  await t.exception(() => server.register(IconServerPlugin))
+  await assert.rejects(async () => {
+    await server.register(IconServerPlugin)
+  })
 })
 
-test('Plugin handles prefix option properly', async (t) => {
+test('Plugin handles prefix option properly', async () => {
   const prefix = 'icons'
 
   const server = fastify()
@@ -33,10 +36,10 @@ test('Plugin handles prefix option properly', async (t) => {
     })}`,
   })
 
-  t.not(response.statusCode, 404, 'returns non-404 status code')
+  assert.notEqual(response.statusCode, 404, 'returns non-404 status code')
 })
 
-test('url param validation', async (t) => {
+test('url param validation', async () => {
   const server = fastify()
 
   server.register(IconServerPlugin, {
@@ -99,16 +102,14 @@ test('url param validation', async (t) => {
   ]
 
   await Promise.all(
-    fixtures.map(async ([name, input]) => {
+    fixtures.map(async ([_, input]) => {
       const response = await server.inject({
         method: 'GET',
         url: buildIconUrl(input),
       })
 
-      t.comment(name)
-
-      t.is(response.statusCode, 400, 'returns expected status code')
-      t.is(
+      assert.equal(response.statusCode, 400, 'returns expected status code')
+      assert.equal(
         response.json().code,
         'FST_ERR_VALIDATION',
         'error is validation error'

--- a/tests/fastify-plugins/maps.js
+++ b/tests/fastify-plugins/maps.js
@@ -1,4 +1,5 @@
-import { test } from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import path from 'node:path'
 import Fastify from 'fastify'
 import { MockAgent, setGlobalDispatcher } from 'undici'
@@ -28,7 +29,7 @@ setupFetchMock()
 test('fails to register when dependent plugins are not registered', async (t) => {
   const server = setup(t)
 
-  await t.exception(async () => {
+  await assert.rejects(async () => {
     await server.register(MapServerPlugin)
   }, 'fails to register if dependencies are not registered')
 })
@@ -56,12 +57,12 @@ test('prefix opt is handled correctly', async (t) => {
       url: '/style.json',
     })
 
-    t.is(response.statusCode, 404, 'endpoint missing at root prefix')
+    assert.equal(response.statusCode, 404, 'endpoint missing at root prefix')
   }
 
   {
     // TODO: Use inject approach when necessary fixtures are set up
-    t.ok(
+    assert(
       server.hasRoute({
         method: 'GET',
         url: '/maps/style.json',
@@ -89,11 +90,11 @@ test('mapeoMaps decorator context', async (t) => {
 
   const address = await server.listen()
 
-  t.ok(server.hasDecorator('mapeoMaps'), 'decorator added')
+  assert(server.hasDecorator('mapeoMaps'), 'decorator added')
 
-  t.test('mapeoMaps.getStyleJsonUrl()', async (st) => {
+  t.test('mapeoMaps.getStyleJsonUrl()', async () => {
     const styleJsonUrl = await server.mapeoMaps.getStyleJsonUrl()
-    st.is(styleJsonUrl, new URL('/maps/style.json', address).href)
+    assert.equal(styleJsonUrl, new URL('/maps/style.json', address).href)
   })
 })
 
@@ -118,7 +119,7 @@ test('/style.json resolves style.json of local "default" static map when availab
     url: '/style.json',
   })
 
-  t.is(response.statusCode, 200)
+  assert.equal(response.statusCode, 200)
 })
 
 test('/style.json resolves online style.json when local static is not available', async (t) => {
@@ -145,9 +146,9 @@ test('/style.json resolves online style.json when local static is not available'
     query: `?key=pk.abc-123`,
   })
 
-  t.is(response.statusCode, 200)
+  assert.equal(response.statusCode, 200)
 
-  t.is(
+  assert.equal(
     response.json().name,
     // Based on the mapbox-outdoors-v12.json fixture
     'Mapbox Outdoors',
@@ -182,8 +183,8 @@ test('defaultOnlineStyleUrl opt works', async (t) => {
     query: `?key=abc-123`,
   })
 
-  t.is(response.statusCode, 200)
-  t.is(
+  assert.equal(response.statusCode, 200)
+  assert.equal(
     response.json().name,
     // Based on the protomaps-dark.v2.json fixture
     'style@2.0.0-alpha.4 theme@dark',
@@ -214,17 +215,17 @@ test('/style.json resolves style.json of offline fallback map when static and on
     // Omitting the `key` query param here to simulate not being able to get the online style.json
   })
 
-  t.is(response.json().id, 'blank', 'gets fallback style.json')
-  t.is(response.statusCode, 200)
+  assert.equal(response.json().id, 'blank', 'gets fallback style.json')
+  assert.equal(response.statusCode, 200)
 })
 
 /**
- * @param {import('brittle').TestInstance} t
+ * @param {import('node:test').TestContext} t
  */
 function setup(t) {
   const server = Fastify({ logger: false, forceCloseConnections: true })
 
-  t.teardown(async () => {
+  t.after(async () => {
     await server.close()
   })
 

--- a/tests/fastify-plugins/offline-fallback-map.js
+++ b/tests/fastify-plugins/offline-fallback-map.js
@@ -1,5 +1,6 @@
 import path from 'node:path'
-import { test } from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import Fastify from 'fastify'
 
 import { plugin as OfflineFallbackMapPlugin } from '../../src/fastify-plugins/maps/offline-fallback-map.js'
@@ -12,7 +13,7 @@ const MAPEO_FALLBACK_MAP_PATH = new URL(
 test('decorator', async (t) => {
   const server = setup(t)
   await server.ready()
-  t.ok(server.hasDecorator('mapeoFallbackMap'), 'decorator is set up')
+  assert(server.hasDecorator('mapeoFallbackMap'), 'decorator is set up')
 })
 
 test('/style.json', async (t) => {
@@ -24,11 +25,11 @@ test('/style.json', async (t) => {
     url: '/style.json',
   })
 
-  t.is(response.statusCode, 200)
+  assert.equal(response.statusCode, 200)
 
   const styleJson = response.json()
 
-  t.alike(
+  assert.deepEqual(
     styleJson.sources,
     {
       'boundaries-source': {
@@ -61,12 +62,12 @@ test('/style.json', async (t) => {
       url: data,
     })
 
-    t.is(response.statusCode, 200, `can reach ${sourceName}`)
+    assert.equal(response.statusCode, 200, `can reach ${sourceName}`)
   }
 })
 
 /**
- * @param {import('brittle').TestInstance} t
+ * @param {import('node:test').TestContext} t
  */
 function setup(t) {
   const server = Fastify({ logger: false, forceCloseConnections: true })
@@ -76,7 +77,7 @@ function setup(t) {
     sourcesDir: path.join(MAPEO_FALLBACK_MAP_PATH, 'dist'),
   })
 
-  t.teardown(async () => {
+  t.after(async () => {
     await server.close()
   })
 


### PR DESCRIPTION
This test-only change drops Brittle from our Fastify plugin tests and replaces them with `node:test` and `node:assert`.