### PR TITLE
test: move bitfield-rle tests to `node:test`

### DIFF
--- a/tests/bitfield-rle.js
+++ b/tests/bitfield-rle.js
@@ -1,39 +1,48 @@
-import test from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import Bitfield from 'bitfield'
 import * as rle from '../src/core-manager/bitfield-rle.js'
 
-test('encodes and decodes', function (t) {
+test('encodes and decodes', function () {
   var bits = new Bitfield(1024)
   var deflated = rle.encode(toUint32Array(bits.buffer))
-  t.ok(deflated.length < bits.buffer.length, 'is smaller')
+  assert(deflated.length < bits.buffer.length, 'is smaller')
   var inflated = rle.decode(deflated)
-  t.alike(inflated, toUint32Array(bits.buffer), 'decodes to same buffer')
+  assert.deepEqual(
+    inflated,
+    toUint32Array(bits.buffer),
+    'decodes to same buffer'
+  )
 })
 
-test('encodingLength', function (t) {
+test('encodingLength', function () {
   var bits = new Bitfield(1024)
   var len = rle.encodingLength(bits.buffer)
-  t.ok(len < bits.buffer.length, 'is smaller')
+  assert(len < bits.buffer.length, 'is smaller')
   var deflated = rle.encode(bits.buffer)
-  t.alike(
+  assert.deepEqual(
     len,
     deflated.length,
     'encoding length is similar to encoded buffers length'
   )
 })
 
-test('encodes and decodes with all bits set', function (t) {
+test('encodes and decodes with all bits set', function () {
   var bits = new Bitfield(1024)
 
   for (var i = 0; i < 1024; i++) bits.set(i, true)
 
   var deflated = rle.encode(toUint32Array(bits.buffer))
-  t.ok(deflated.length < bits.buffer.length, 'is smaller')
+  assert(deflated.length < bits.buffer.length, 'is smaller')
   var inflated = rle.decode(deflated)
-  t.alike(inflated, toUint32Array(bits.buffer), 'decodes to same buffer')
+  assert.deepEqual(
+    inflated,
+    toUint32Array(bits.buffer),
+    'decodes to same buffer'
+  )
 })
 
-test('encodes and decodes with some bits set', function (t) {
+test('encodes and decodes with some bits set', function () {
   var bits = new Bitfield(1024)
 
   bits.set(500, true)
@@ -45,12 +54,16 @@ test('encodes and decodes with some bits set', function (t) {
   bits.set(0, true)
 
   var deflated = rle.encode(toUint32Array(bits.buffer))
-  t.ok(deflated.length < bits.buffer.length, 'is smaller')
+  assert(deflated.length < bits.buffer.length, 'is smaller')
   var inflated = rle.decode(deflated)
-  t.alike(inflated, toUint32Array(bits.buffer), 'decodes to same buffer')
+  assert.deepEqual(
+    inflated,
+    toUint32Array(bits.buffer),
+    'decodes to same buffer'
+  )
 })
 
-test('encodes and decodes with random bits set', function (t) {
+test('encodes and decodes with random bits set', function () {
   var bits = new Bitfield(8 * 1024)
 
   for (var i = 0; i < 512; i++) {
@@ -58,12 +71,16 @@ test('encodes and decodes with random bits set', function (t) {
   }
 
   var deflated = rle.encode(toUint32Array(bits.buffer))
-  t.ok(deflated.length < bits.buffer.length, 'is smaller')
+  assert(deflated.length < bits.buffer.length, 'is smaller')
   var inflated = rle.decode(deflated)
-  t.alike(inflated, toUint32Array(bits.buffer), 'decodes to same buffer')
+  assert.deepEqual(
+    inflated,
+    toUint32Array(bits.buffer),
+    'decodes to same buffer'
+  )
 })
 
-test('encodes and decodes with random bits set (not power of two)', function (t) {
+test('encodes and decodes with random bits set (not power of two)', function () {
   var bits = new Bitfield(8 * 1024)
 
   for (var i = 0; i < 313; i++) {
@@ -71,36 +88,48 @@ test('encodes and decodes with random bits set (not power of two)', function (t)
   }
 
   var deflated = rle.encode(toUint32Array(bits.buffer))
-  t.ok(deflated.length < bits.buffer.length, 'is smaller')
+  assert(deflated.length < bits.buffer.length, 'is smaller')
   var inflated = rle.decode(deflated)
-  t.alike(inflated, toUint32Array(bits.buffer), 'decodes to same buffer')
+  assert.deepEqual(
+    inflated,
+    toUint32Array(bits.buffer),
+    'decodes to same buffer'
+  )
 })
 
-test('encodes empty bitfield', function (t) {
+test('encodes empty bitfield', function () {
   var deflated = rle.encode(new Uint32Array())
   var inflated = rle.decode(deflated)
-  t.alike(inflated, new Uint32Array(), 'still empty')
+  assert.deepEqual(inflated, new Uint32Array(), 'still empty')
 })
 
-test('throws on bad input', function (t) {
-  t.exception(function () {
-    rle.decode(toUint32Array([100, 0, 0, 0]))
-  }, 'invalid delta count')
+test('throws on bad input', function () {
+  assert.throws(
+    function () {
+      rle.decode(toUint32Array([100, 0, 0, 0]))
+    },
+    undefined,
+    'invalid delta count'
+  )
   // t.exception.all also catches RangeErrors, which is what we expect from this
-  t.exception.all(function () {
-    rle.decode(
-      toUint32Array([
-        10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0,
-        10, 0,
-      ])
-    )
-  }, 'missing delta')
+  assert.throws(
+    function () {
+      rle.decode(
+        toUint32Array([
+          10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0,
+          10, 0,
+        ])
+      )
+    },
+    undefined,
+    'missing delta'
+  )
 })
 
-test('not power of two', function (t) {
+test('not power of two', function () {
   var deflated = rle.encode(toUint32Array([255, 255, 255, 240]))
   var inflated = rle.decode(deflated)
-  t.alike(
+  assert.deepEqual(
     inflated,
     toUint32Array([255, 255, 255, 240]),
     'output equal to input'


### PR DESCRIPTION
_I recommend [reviewing this with whitespace changes disabled](https://github.com/digidem/mapeo-core-next/pull/636/files?w=1)._

This test-only change drops Brittle from our bitfield run length encoding tests and replaces them with `node:test` and `node:assert`.