### PR TITLE
test: move test/lib/ to `node:test`

### DIFF
--- a/tests/lib/hashmap.js
+++ b/tests/lib/hashmap.js
@@ -1,14 +1,15 @@
 // @ts-check
-import test from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import HashMap from '../../src/lib/hashmap.js'
 
-test('empty init', (t) => {
+test('empty init', () => {
   const map = new HashMap(join)
 
-  t.is(map.size, 0)
+  assert.equal(map.size, 0)
 })
 
-test('init from iterable', (t) => {
+test('init from iterable', () => {
   const map = new HashMap(
     join,
     new Set([
@@ -17,71 +18,71 @@ test('init from iterable', (t) => {
     ])
   )
 
-  t.is(map.size, 2)
-  t.is(map.get([1, 2]), 3)
-  t.is(map.get([4, 5]), 6)
-  t.is(map.get([7, 8]), undefined)
-  t.ok(map.has([1, 2]))
-  t.ok(map.has([4, 5]))
-  t.absent(map.has([7, 8]))
+  assert.equal(map.size, 2)
+  assert.equal(map.get([1, 2]), 3)
+  assert.equal(map.get([4, 5]), 6)
+  assert.equal(map.get([7, 8]), undefined)
+  assert(map.has([1, 2]))
+  assert(map.has([4, 5]))
+  assert(!map.has([7, 8]))
 })
 
-test('creating, reading, updating, and deleting', (t) => {
+test('creating, reading, updating, and deleting', () => {
   const map = new HashMap(join)
 
   map.set([1, 2], 3)
 
-  t.is(map.size, 1)
-  t.is(map.get([1, 2]), 3)
-  t.is(map.get([4, 5]), undefined)
-  t.ok(map.has([1, 2]))
-  t.absent(map.has([4, 5]))
+  assert.equal(map.size, 1)
+  assert.equal(map.get([1, 2]), 3)
+  assert.equal(map.get([4, 5]), undefined)
+  assert(map.has([1, 2]))
+  assert(!map.has([4, 5]))
 
   map.set([1, 2], 100)
 
-  t.is(map.get([1, 2]), 100)
+  assert.equal(map.get([1, 2]), 100)
 
   map.delete([1, 2])
 
-  t.is(map.size, 0)
-  t.is(map.get([1, 2]), undefined)
-  t.absent(map.has([1, 2]))
+  assert.equal(map.size, 0)
+  assert.equal(map.get([1, 2]), undefined)
+  assert(!map.has([1, 2]))
 })
 
-test('uses same-value-zero equality for keys', (t) => {
+test('uses same-value-zero equality for keys', () => {
   /** @param {number} n */
   const identity = (n) => n
   const map = new HashMap(identity)
 
   map.set(0, 'foo')
-  t.is(map.get(0), 'foo')
-  t.is(map.get(0), map.get(-0))
+  assert.equal(map.get(0), 'foo')
+  assert.equal(map.get(0), map.get(-0))
 
   map.set(NaN, 'bar')
-  t.is(map.get(NaN), 'bar')
+  assert.equal(map.get(NaN), 'bar')
 })
 
-test('delete() returns whether the key was present', (t) => {
+test('delete() returns whether the key was present', () => {
   const map = new HashMap(join)
   map.set([1, 2], 3)
 
-  t.ok(map.delete([1, 2]))
-  t.absent(map.delete([1, 2]))
+  assert(map.delete([1, 2]))
+  assert(!map.delete([1, 2]))
 })
 
-test('set() returns the map', (t) => {
+test('set() returns the map', () => {
   const map = new HashMap(join)
 
-  t.is(map.set([1, 2], 3), map)
+  assert.equal(map.set([1, 2], 3), map)
 })
 
-test('values()', (t) => {
+test('values()', () => {
   const map = new HashMap(join, [
     [[1, 2], 3],
     [[4, 5], 6],
   ])
 
-  t.alike(Array.from(map.values()), [3, 6])
+  assert.deepEqual(Array.from(map.values()), [3, 6])
 })
 
 /**

--- a/tests/lib/ponyfills.js
+++ b/tests/lib/ponyfills.js
@@ -1,13 +1,14 @@
 // @ts-check
-import test from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { abortSignalAny } from '../../src/lib/ponyfills.js'
 
-test('abortSignalAny() handles empty iterables', (t) => {
-  t.not(abortSignalAny([]).aborted, 'not immediately aborted')
-  t.not(abortSignalAny(new Set()).aborted, 'not immediately aborted')
+test('abortSignalAny() handles empty iterables', () => {
+  assert.notEqual(abortSignalAny([]).aborted, 'not immediately aborted')
+  assert.notEqual(abortSignalAny(new Set()).aborted, 'not immediately aborted')
 })
 
-test('abortSignalAny() aborts immediately if one of the arguments was aborted', (t) => {
+test('abortSignalAny() aborts immediately if one of the arguments was aborted', () => {
   const result = abortSignalAny([
     new AbortController().signal,
     AbortSignal.abort('foo'),
@@ -15,27 +16,27 @@ test('abortSignalAny() aborts immediately if one of the arguments was aborted', 
     new AbortController().signal,
   ])
 
-  t.ok(result.aborted, 'immediately aborted')
-  t.is(result.reason, 'foo', 'gets first abort reason')
+  assert(result.aborted, 'immediately aborted')
+  assert.equal(result.reason, 'foo', 'gets first abort reason')
 })
 
-test('abortSignalAny() aborts as soon as one of its arguments aborts', (t) => {
+test('abortSignalAny() aborts as soon as one of its arguments aborts', () => {
   const a = new AbortController()
   const b = new AbortController()
   const c = new AbortController()
 
   const result = abortSignalAny([a.signal, b.signal, c.signal])
 
-  t.not(result.aborted, 'not immediately aborted')
+  assert.notEqual(result.aborted, 'not immediately aborted')
 
   b.abort('foo')
   c.abort('ignored')
 
-  t.ok(result.aborted, 'aborted')
-  t.is(result.reason, 'foo', 'gets first abort reason')
+  assert(result.aborted, 'aborted')
+  assert.equal(result.reason, 'foo', 'gets first abort reason')
 })
 
-test('abortSignalAny() handles non-array iterables', (t) => {
+test('abortSignalAny() handles non-array iterables', () => {
   const a = new AbortController()
   const b = new AbortController()
   const c = new AbortController()
@@ -44,5 +45,5 @@ test('abortSignalAny() handles non-array iterables', (t) => {
 
   b.abort('foo')
 
-  t.ok(result.aborted, 'aborted')
+  assert(result.aborted, 'aborted')
 })

--- a/tests/lib/string.js
+++ b/tests/lib/string.js
@@ -1,8 +1,9 @@
 // @ts-check
-import test from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { isBlank } from '../../src/lib/string.js'
 
-test('isBlank()', (t) => {
+test('isBlank()', () => {
   // See [what JavaScript considers white space][0].
   // [0]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#white_space
   const unicodeWhitespace = [
@@ -16,7 +17,7 @@ test('isBlank()', (t) => {
     ...unicodeWhitespace.flatMap((a) => unicodeWhitespace.map((b) => a + b)),
   ]
   for (const str of blanks) {
-    t.ok(isBlank(str), `${formatCodePoints(str)} is blank`)
+    assert(isBlank(str), `${formatCodePoints(str)} is blank`)
   }
 
   const notBlanks = [
@@ -25,7 +26,7 @@ test('isBlank()', (t) => {
     ...unicodeWhitespace.map((c) => 'x' + c),
   ]
   for (const str of notBlanks) {
-    t.absent(isBlank(str), `${formatCodePoints(str)} is not blank`)
+    assert(!isBlank(str), `${formatCodePoints(str)} is not blank`)
   }
 })
 

--- a/tests/lib/timing-safe-equal.js
+++ b/tests/lib/timing-safe-equal.js
@@ -1,30 +1,30 @@
-// @ts-check
-import test from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import timingSafeEqual from '../../src/lib/timing-safe-equal.js'
 
-test('comparing buffers', (t) => {
+test('comparing buffers', () => {
   const a = Buffer.from([1, 2, 3])
   const b = Buffer.from([1, 2, 3])
   const c = Buffer.from([4, 5, 6])
   const d = Buffer.from([7])
 
-  t.ok(timingSafeEqual(a, a))
-  t.ok(timingSafeEqual(a, b))
+  assert(timingSafeEqual(a, a))
+  assert(timingSafeEqual(a, b))
 
-  t.absent(timingSafeEqual(a, c))
-  t.absent(timingSafeEqual(a, d))
+  assert(!timingSafeEqual(a, c))
+  assert(!timingSafeEqual(a, d))
 })
 
-test('comparing strings', (t) => {
-  t.ok(timingSafeEqual('foo', 'foo'))
-  t.absent(timingSafeEqual('foo', 'bar'))
-  t.absent(timingSafeEqual('foo', 'x'))
-  t.absent(
-    timingSafeEqual(String.fromCharCode(0x49), String.fromCharCode(0x6c49)),
+test('comparing strings', () => {
+  assert(timingSafeEqual('foo', 'foo'))
+  assert(!timingSafeEqual('foo', 'bar'))
+  assert(!timingSafeEqual('foo', 'x'))
+  assert(
+    !timingSafeEqual(String.fromCharCode(0x49), String.fromCharCode(0x6c49)),
     'characters that might truncate the same are still different'
   )
-  t.absent(
-    timingSafeEqual('\udc69', '\udc6a'),
+  assert(
+    !timingSafeEqual('\udc69', '\udc6a'),
     'lone surrogates compare correctly'
   )
 })


### PR DESCRIPTION
This test-only change drops Brittle from test/lib/ and replaces it with `node:test` and `node:assert`.
