### PR TITLE
test: move RemoteBitfield tests to `node:test`

### DIFF
--- a/tests/remote-bitfield.js
+++ b/tests/remote-bitfield.js
@@ -1,17 +1,18 @@
 // @ts-check
-import test from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import RemoteBitfield from '../src/core-manager/remote-bitfield.js'
 
-test('remote bitfield - findFirst, findLast', function (t) {
+test('remote bitfield - findFirst, findLast', () => {
   const b = new RemoteBitfield()
 
   b.set(1_000_000, true)
 
-  t.is(b.findFirst(true, 0), 1_000_000)
-  t.is(b.findLast(true, 2_000_000), 1_000_000)
+  assert.equal(b.findFirst(true, 0), 1_000_000)
+  assert.equal(b.findLast(true, 2_000_000), 1_000_000)
 })
 
-test('remote bitfield - findLast, findFirst from insert', function (t) {
+test('remote bitfield - findLast, findFirst from insert', () => {
   // Regression test for bug in RemoteBitfield which was not updating the index
   // when inserting a new bitfield.
   const b = new RemoteBitfield()
@@ -20,6 +21,6 @@ test('remote bitfield - findLast, findFirst from insert', function (t) {
   const arr = new Uint32Array(size).fill(2 ** 32 - 1)
   b.insert(0, arr)
 
-  t.is(b.findFirst(false, 0), size * 32)
-  t.is(b.findLast(true, size * 32 + 1_000_000), size * 32 - 1)
+  assert.equal(b.findFirst(false, 0), size * 32)
+  assert.equal(b.findLast(true, size * 32 + 1_000_000), size * 32 - 1)
 })


### PR DESCRIPTION
This test-only change drops Brittle from our RemoteBitfield tests and
replaces them with `node:test` and `node:assert`.
