### PR TITLE
test: move schema tests to `node:test`

### DIFF
--- a/tests/schema.js
+++ b/tests/schema.js
@@ -1,6 +1,6 @@
 // @ts-check
-/* eslint-disable no-unused-vars */
-import { test } from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { getTableConfig } from 'drizzle-orm/sqlite-core'
 import * as clientTableSchemas from '../src/schema/client.js'
 import * as projectTableSchemas from '../src/schema/project.js'
@@ -15,7 +15,7 @@ import { deNullify } from '../src/utils.js'
 
 const MAPEO_DATATYPE_NAMES = Object.keys(jsonSchemas)
 
-test('Expected table config', (t) => {
+test('Expected table config', () => {
   const allTableSchemas = [
     ...Object.values(clientTableSchemas),
     ...Object.values(projectTableSchemas),
@@ -28,24 +28,18 @@ test('Expected table config', (t) => {
     if (!MAPEO_DATATYPE_NAMES.includes(config.name)) continue
 
     const schemaName = config.name
-    if (!(schemaName in jsonSchemas)) {
-      t.fail()
-      continue
-    }
+    assert(schemaName in jsonSchemas)
     const jsonSchema =
       jsonSchemas[/** @type {keyof typeof jsonSchemas} */ (schemaName)]
     for (const [key, value] of Object.entries(jsonSchema.properties)) {
       const columnConfig = config.columns.find((v) => v.name === key)
-      if (!columnConfig) {
-        t.fail()
-        continue
-      }
+      assert(columnConfig)
       if (key === 'docId') {
-        t.is(columnConfig.primary, true, 'docId is primary key')
+        assert.equal(columnConfig.primary, true, 'docId is primary key')
       } else {
-        t.is(columnConfig.primary, false, key + ' is not primary key')
+        assert.equal(columnConfig.primary, false, key + ' is not primary key')
       }
-      t.is(
+      assert.equal(
         columnConfig.notNull,
         // @ts-ignore
         jsonSchema.required.includes(key),
@@ -55,7 +49,7 @@ test('Expected table config', (t) => {
       const expectedDefault =
         // @ts-ignore
         jsonSchema.required.includes(key) ? value.default : undefined
-      t.is(columnConfig.default, expectedDefault, 'Default is correct')
+      assert.equal(columnConfig.default, expectedDefault, 'Default is correct')
     }
   }
 })
@@ -72,7 +66,7 @@ test('Expected table config', (t) => {
  * @typedef {Extract<MapeoDoc, { schemaName: T }>} MapeoType
  */
 
-test('Types match', { skip: true }, (t) => {
+test('Types match', { skip: true }, () => {
   // No brittle tests here, it's the typescript that must pass
   // This fails at runtime anyway because we don't create tables in the db
 
@@ -86,23 +80,20 @@ test('Types match', { skip: true }, (t) => {
   const fResult = db.select().from(fieldTable).get()
 
   if (!(oResult && pResult && fResult)) {
-    t.fail()
-    return
+    assert.fail()
   }
 
   /** @type {MapeoType<'observation'>} */
-  const o = deNullify(oResult)
+  const _o = deNullify(oResult)
 
   /** @type {MapeoType<'preset'>} */
-  const p = deNullify(pResult)
+  const _p = deNullify(pResult)
 
   /** @type {MapeoType<'field'>} */
-  const f = deNullify(fResult)
-
-  t.pass()
+  const _f = deNullify(fResult)
 })
 
-test('backlink table exists for every indexed data type', (t) => {
+test('backlink table exists for every indexed data type', () => {
   // Every indexed datatype needs a backlink table, which is used by
   // sqlite-indexer to track backlinks
   const allTableNames = [
@@ -120,7 +111,7 @@ test('backlink table exists for every indexed data type', (t) => {
   )
 
   for (const name of dataTypeTableNames) {
-    t.ok(
+    assert(
       backlinkTableNames.includes(getBacklinkTableName(name)),
       `backlink table for ${name}`
     )

--- a/tests/schema/schema-to-drizzle.js
+++ b/tests/schema/schema-to-drizzle.js
@@ -1,78 +1,89 @@
 // @ts-check
-import test from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { jsonSchemaToDrizzleColumns } from '../../src/schema/schema-to-drizzle.js'
 import { sqliteTable } from 'drizzle-orm/sqlite-core'
 
-test('throws if not passed an object schema', (t) => {
-  t.exception(() => {
+test('throws if not passed an object schema', () => {
+  assert.throws(() => {
     jsonSchemaToDrizzleColumns({ type: 'number', properties: {} })
   })
 })
 
-test('always adds "forks" column', (t) => {
-  t.ok(
+test('always adds "forks" column', () => {
+  assert(
     'forks' in jsonSchemaToDrizzleColumns({ type: 'object', properties: {} }),
     'forks column is added'
   )
 })
 
-test('skips null', (t) => {
-  t.absent(
-    'foo' in
+test('skips null', () => {
+  assert(
+    !(
+      'foo' in
       jsonSchemaToDrizzleColumns({
         type: 'object',
         properties: { foo: { type: 'null' } },
       })
+    )
   )
 })
 
-test('boolean', (t) => {
+test('boolean', () => {
   const col = getColumn({ type: 'boolean' })
-  t.is(col.getSQLType(), 'integer', 'booleans are stored in INTEGER columns')
+  assert.equal(
+    col.getSQLType(),
+    'integer',
+    'booleans are stored in INTEGER columns'
+  )
 })
 
-test('number', (t) => {
+test('number', () => {
   const col = getColumn({ type: 'number' })
-  t.is(col.getSQLType(), 'real', 'numbers are stored in REAL columns')
+  assert.equal(col.getSQLType(), 'real', 'numbers are stored in REAL columns')
 })
 
-test('integer', (t) => {
+test('integer', () => {
   const col = getColumn({ type: 'integer' })
-  t.is(col.getSQLType(), 'integer', 'integers are stored in INTEGER columns')
+  assert.equal(
+    col.getSQLType(),
+    'integer',
+    'integers are stored in INTEGER columns'
+  )
 })
 
-test('string', (t) => {
+test('string', () => {
   const col = getColumn({ type: 'string' })
-  t.is(col.getSQLType(), 'text', 'strings are stored in TEXT columns')
+  assert.equal(col.getSQLType(), 'text', 'strings are stored in TEXT columns')
 })
 
-test('string with enum', (t) => {
+test('string with enum', () => {
   const col = getColumn({ type: 'string', enum: ['foo', 'bar'] })
-  t.is(col.getSQLType(), 'text', 'strings are stored in TEXT columns')
-  t.alike(col.enumValues, ['foo', 'bar'], 'enums are saved')
+  assert.equal(col.getSQLType(), 'text', 'strings are stored in TEXT columns')
+  assert.deepEqual(col.enumValues, ['foo', 'bar'], 'enums are saved')
 })
 
-test('array', (t) => {
+test('array', () => {
   const col = getColumn({ type: 'array' })
-  t.is(col.getSQLType(), 'text', 'arrays are stored in TEXT columns')
+  assert.equal(col.getSQLType(), 'text', 'arrays are stored in TEXT columns')
 })
 
-test('object', (t) => {
+test('object', () => {
   const col = getColumn({ type: 'object' })
-  t.is(col.getSQLType(), 'text', 'objects are stored in TEXT columns')
+  assert.equal(col.getSQLType(), 'text', 'objects are stored in TEXT columns')
 })
 
-test('required columns', (t) => {
+test('required columns', () => {
   const col = getColumn({ type: 'number' }, { required: ['property'] })
-  t.ok(col.notNull, 'required columns are NOT NULL')
+  assert(col.notNull, 'required columns are NOT NULL')
 })
 
-test('default values', (t) => {
+test('default values', () => {
   const col = getColumn(
     { type: 'number', default: 123 },
     { required: ['property'] }
   )
-  t.is(col.default, 123, 'sets default value')
+  assert.equal(col.default, 123, 'sets default value')
 })
 
 /**


### PR DESCRIPTION
This test-only change drops Brittle from our schema tests and replaces
them with `node:test` and `node:assert`.
