### PR TITLE
chore: make prettier ignore coverage/ and proto/build/ directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@
 *.snapshot.cjs
 /tests/fixtures/
 /docs/
+/coverage/
+/proto/build/


### PR DESCRIPTION
Seems like Prettier will completely ignore the `.gitignore` if `.prettierignore` also exists. Can apparently use both if you use the [`--ignore-path` CLI flag](https://prettier.io/docs/en/cli#--ignore-path)), but that doesn't seem ideal.