### PR TITLE
test: move schema type tests to test-types/

### DIFF
--- a/test-types/schema.ts
+++ b/test-types/schema.ts
@@ -1,0 +1,19 @@
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import Database from 'better-sqlite3'
+import { deNullify } from '../src/utils.js'
+import type { MapeoDoc, MapeoValue } from '@mapeo/schema'
+import * as projectTableSchemas from '../src/schema/project.js'
+
+const sqlite = new Database(':memory:')
+const db = drizzle(sqlite)
+
+const { observationTable, presetTable, fieldTable } = projectTableSchemas
+
+const oResult = db.select().from(observationTable).get()!
+const pResult = db.select().from(presetTable).get()!
+const fResult = db.select().from(fieldTable).get()!
+
+type MapeoType<T> = Extract<MapeoValue, { schemaName: T }>
+const _o: MapeoType<'observation'> = deNullify(oResult)
+const _p: MapeoType<'preset'> = deNullify(pResult)
+const _f: MapeoType<'field'> = deNullify(fResult)

--- a/test-types/tsconfig.json
+++ b/test-types/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": ".."
   },
   "files": [],
-  "include": ["../dist", "."]
+  "include": ["../dist", "../types/**/*.d.ts", "."]
 }

--- a/tests/schema.js
+++ b/tests/schema.js
@@ -5,13 +5,10 @@ import { getTableConfig } from 'drizzle-orm/sqlite-core'
 import * as clientTableSchemas from '../src/schema/client.js'
 import * as projectTableSchemas from '../src/schema/project.js'
 import { dereferencedDocSchemas as jsonSchemas } from '@mapeo/schema'
-import { drizzle } from 'drizzle-orm/better-sqlite3'
-import Database from 'better-sqlite3'
 import {
   BACKLINK_TABLE_POSTFIX,
   getBacklinkTableName,
 } from '../src/schema/utils.js'
-import { deNullify } from '../src/utils.js'
 
 const MAPEO_DATATYPE_NAMES = Object.keys(jsonSchemas)
 
@@ -52,45 +49,6 @@ test('Expected table config', () => {
       assert.equal(columnConfig.default, expectedDefault, 'Default is correct')
     }
   }
-})
-
-/**
- * @template {object} T
- * @typedef {import('../src/schema/types.js').OptionalToNull<T>} OptionalToNull
- */
-/**
- * @typedef {import('@mapeo/schema').MapeoDoc} MapeoDoc
- */
-/**
- * @template {MapeoDoc['schemaName']} T
- * @typedef {Extract<MapeoDoc, { schemaName: T }>} MapeoType
- */
-
-test('Types match', { skip: true }, () => {
-  // No brittle tests here, it's the typescript that must pass
-  // This fails at runtime anyway because we don't create tables in the db
-
-  const sqlite = new Database(':memory:')
-  const db = drizzle(sqlite)
-
-  const { observationTable, presetTable, fieldTable } = projectTableSchemas
-
-  const oResult = db.select().from(observationTable).get()
-  const pResult = db.select().from(presetTable).get()
-  const fResult = db.select().from(fieldTable).get()
-
-  if (!(oResult && pResult && fResult)) {
-    assert.fail()
-  }
-
-  /** @type {MapeoType<'observation'>} */
-  const _o = deNullify(oResult)
-
-  /** @type {MapeoType<'preset'>} */
-  const _p = deNullify(pResult)
-
-  /** @type {MapeoType<'field'>} */
-  const _f = deNullify(fResult)
 })
 
 test('backlink table exists for every indexed data type', () => {


### PR DESCRIPTION
This is a test-only change. `test-types/` is a better place for type tests.

See [this comment][0].

[0]: https://github.com/digidem/mapeo-core-next/pull/647#discussion_r1603406577
