### PR TITLE
test: remove `t.plan()` calls

### DIFF
--- a/test-e2e/members.js
+++ b/test-e2e/members.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { test } from 'brittle'
 import { randomBytes } from 'crypto'
+import { once } from 'node:events'
 
 import {
   COORDINATOR_ROLE_ID,
@@ -166,7 +167,6 @@ test('getting invited member after invite accepted', async (t) => {
 })
 
 test('invite uses custom role name when provided', async (t) => {
-  t.plan(1)
   const managers = await createManagers(2, t)
   const [invitor, invitee] = managers
   connectPeers(managers)
@@ -174,9 +174,7 @@ test('invite uses custom role name when provided', async (t) => {
 
   const projectId = await invitor.createProject({ name: 'Mapeo' })
 
-  invitee.invite.on('invite-received', ({ roleName }) => {
-    t.is(roleName, 'friend', 'roleName should be equal')
-  })
+  const inviteReceivedPromise = once(invitee.invite, 'invite-received')
 
   await invite({
     invitor,
@@ -186,11 +184,13 @@ test('invite uses custom role name when provided', async (t) => {
     reject: true,
   })
 
+  const [{ roleName }] = await inviteReceivedPromise
+  t.is(roleName, 'friend', 'roleName should be equal')
+
   await disconnectPeers(managers)
 })
 
 test('invite uses default role name when not provided', async (t) => {
-  t.plan(1)
   const managers = await createManagers(2, t)
   const [invitor, invitee] = managers
   connectPeers(managers)
@@ -198,13 +198,7 @@ test('invite uses default role name when not provided', async (t) => {
 
   const projectId = await invitor.createProject({ name: 'Mapeo' })
 
-  invitee.invite.on('invite-received', ({ roleName }) => {
-    t.is(
-      roleName,
-      ROLES[MEMBER_ROLE_ID].name,
-      '`roleName` should use the fallback by deriving `roleId`'
-    )
-  })
+  const inviteReceivedPromise = once(invitee.invite, 'invite-received')
 
   await invite({
     invitor,
@@ -212,6 +206,13 @@ test('invite uses default role name when not provided', async (t) => {
     invitees: [invitee],
     reject: true,
   })
+
+  const [{ roleName }] = await inviteReceivedPromise
+  t.is(
+    roleName,
+    ROLES[MEMBER_ROLE_ID].name,
+    '`roleName` should use the fallback by deriving `roleId`'
+  )
 
   await disconnectPeers(managers)
 })

--- a/tests/config-import.js
+++ b/tests/config-import.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test } from 'brittle'
-import { size } from 'iterpal'
+import { arrayFrom, size } from 'iterpal'
 import { defaultConfigPath } from './helpers/default-config.js'
 import { readConfig } from '../src/config-import.js'
 
@@ -133,8 +133,9 @@ test('config import - icons', async (t) => {
   )
 
   config = await readConfig('./tests/fixtures/config/validIcons.zip')
-  t.plan(15) // 2 icon assertions + (3+9) variant assertions + 1 no warnings
-  for await (const icon of config.icons()) {
+  const icons = await arrayFrom(config.icons())
+  t.is(icons.length, 2)
+  for (const icon of icons) {
     if (icon.name === 'plant') {
       t.is(icon.variants.length, 3, '3 variants of plant icons')
     } else if (icon.name === 'tree') {

--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -168,8 +168,6 @@ test('multiplexing waits for cores to be added', async function (t) {
   // Mapeo code expects replication to work when cores are not added to the
   // replication stream at the same time. This is not explicitly tested in
   // Hypercore so we check here that this behaviour works.
-  t.plan(2)
-
   const a1 = await createCore()
   const a2 = await createCore()
 

--- a/tests/discovery/local-discovery.js
+++ b/tests/discovery/local-discovery.js
@@ -119,7 +119,6 @@ async function testMultiple(t, { period, nPeers = 20 }) {
   const peersById = new Map()
   /** @type {Map<string, OpenedNoiseStream[]>} */
   const connsById = new Map()
-  // t.plan(3 * nPeers + 1)
 
   const { promise: fullyConnectedPromise, resolve: onFullyConnected } = pDefer()
 

--- a/tests/local-peers.js
+++ b/tests/local-peers.js
@@ -6,7 +6,7 @@ import {
   UnknownPeerError,
   kTestOnlySendRawInvite,
 } from '../src/local-peers.js'
-import { once } from 'events'
+import { on, once } from 'events'
 import { Duplex } from 'streamx'
 import { replicate } from './helpers/local-peers.js'
 import { randomBytes } from 'node:crypto'
@@ -16,8 +16,6 @@ import Protomux from 'protomux'
 import { InviteResponse_Decision } from '../src/generated/rpc.js'
 
 test('sending and receiving invites', async (t) => {
-  t.plan(2)
-
   const r1 = new LocalPeers()
   const r2 = new LocalPeers()
 
@@ -33,24 +31,23 @@ test('sending and receiving invites', async (t) => {
     { ...validInvite, projectName: '' },
   ]
 
-  r1.on('peers', async (peers) => {
-    t.is(peers.length, 1)
-    await Promise.all(
-      invalidInvites.map((i) => r1.sendInvite(peers[0].deviceId, i))
-    )
-    await r1.sendInvite(peers[0].deviceId, validInvite)
-  })
-
-  r2.on('invite', (_peerId, receivedInvite) => {
-    t.alike(receivedInvite, validInvite, 'received invite')
-  })
+  const r1PeersPromise = once(r1, 'peers')
+  const r2InvitePromise = once(r2, 'invite')
 
   replicate(r1, r2)
+
+  const [peers] = await r1PeersPromise
+  t.is(peers.length, 1)
+  await Promise.all(
+    invalidInvites.map((i) => r1.sendInvite(peers[0].deviceId, i))
+  )
+  await r1.sendInvite(peers[0].deviceId, validInvite)
+
+  const [_, receivedInvite] = await r2InvitePromise
+  t.alike(receivedInvite, validInvite, 'received invite')
 })
 
 test('sending and receiving invite responses', async (t) => {
-  t.plan(2)
-
   const r1 = new LocalPeers()
   const r2 = new LocalPeers()
 
@@ -63,22 +60,21 @@ test('sending and receiving invite responses', async (t) => {
     inviteId: testInviteId().slice(0, 31),
   }
 
-  r1.on('peers', async (peers) => {
-    t.is(peers.length, 1)
-    await r1.sendInviteResponse(peers[0].deviceId, invalidInviteResponse)
-    await r1.sendInviteResponse(peers[0].deviceId, validInviteResponse)
-  })
-
-  r2.on('invite-response', (_peerId, receivedResponse) => {
-    t.alike(receivedResponse, validInviteResponse, 'received invite response')
-  })
+  const r1PeersPromise = once(r1, 'peers')
+  const r2InviteResponsePromise = once(r2, 'invite-response')
 
   replicate(r1, r2)
+
+  const [peers] = await r1PeersPromise
+  t.is(peers.length, 1)
+  await r1.sendInviteResponse(peers[0].deviceId, invalidInviteResponse)
+  await r1.sendInviteResponse(peers[0].deviceId, validInviteResponse)
+
+  const [_, receivedResponse] = await r2InviteResponsePromise
+  t.alike(receivedResponse, validInviteResponse, 'received invite response')
 })
 
 test('sending and receiving project join details', async (t) => {
-  t.plan(2)
-
   const r1 = new LocalPeers()
   const r2 = new LocalPeers()
 
@@ -93,21 +89,22 @@ test('sending and receiving project join details', async (t) => {
     { ...validProjectJoinDetails, encryptionKeys: { auth: Buffer.alloc(0) } },
   ]
 
-  r1.on('peers', async (peers) => {
-    t.is(peers.length, 1)
-    await Promise.all(
-      invalidProjectJoinDetails.map((d) =>
-        r1.sendProjectJoinDetails(peers[0].deviceId, d)
-      )
-    )
-    await r1.sendProjectJoinDetails(peers[0].deviceId, validProjectJoinDetails)
-  })
-
-  r2.on('got-project-details', (_peerId, details) => {
-    t.alike(details, validProjectJoinDetails, 'received project join details')
-  })
+  const r1PeersPromise = once(r1, 'peers')
+  const r2GotProjectDetailsPromise = once(r2, 'got-project-details')
 
   replicate(r1, r2)
+
+  const [peers] = await r1PeersPromise
+  t.is(peers.length, 1)
+  await Promise.all(
+    invalidProjectJoinDetails.map((d) =>
+      r1.sendProjectJoinDetails(peers[0].deviceId, d)
+    )
+  )
+  await r1.sendProjectJoinDetails(peers[0].deviceId, validProjectJoinDetails)
+
+  const [_, details] = await r2GotProjectDetailsPromise
+  t.alike(details, validProjectJoinDetails, 'received project join details')
 })
 
 test('messages to unknown peers', async (t) => {
@@ -156,8 +153,6 @@ test('messages to unknown peers', async (t) => {
 })
 
 test('handles invalid invites', async (t) => {
-  t.plan(1)
-
   const r1 = new LocalPeers()
   const r2 = new LocalPeers()
 
@@ -169,33 +164,34 @@ test('handles invalid invites', async (t) => {
     t.fail('should not receive invite')
   })
 
-  r2.once('failed-to-handle-message', (messageType) => {
-    t.is(messageType, 'Invite')
-  })
+  const r2FailedToHandleMessagePromise = once(r2, 'failed-to-handle-message')
 
   const destroy = replicate(r1, r2)
   t.teardown(destroy)
+
+  const [messageType] = await r2FailedToHandleMessagePromise
+  t.is(messageType, 'Invite')
 })
 
 test('Disconnected peer shows in state', async (t) => {
-  t.plan(6)
   const r1 = new LocalPeers()
   const r2 = new LocalPeers()
   let peerStateUpdates = 0
 
-  r1.on('peers', async (peers) => {
+  const destroy = replicate(r1, r2)
+
+  for await (const [peers] of on(r1, 'peers')) {
     t.is(peers.length, 1, 'one peer in state')
     if (peers[0].status === 'connected') {
       t.pass('peer appeared as connected')
       t.is(++peerStateUpdates, 1)
       destroy(new Error())
+      break
     } else {
       t.pass('peer appeared as disconnected')
       t.is(++peerStateUpdates, 2)
     }
-  })
-
-  const destroy = replicate(r1, r2)
+  }
 })
 
 test('next tick disconnect does not throw', async (t) => {

--- a/tests/sync/namespace-sync-state.js
+++ b/tests/sync/namespace-sync-state.js
@@ -1,5 +1,6 @@
 //@ts-check
 import test from 'brittle'
+import pDefer from 'p-defer'
 import { KeyManager } from '@mapeo/crypto'
 import { NamespaceSyncState } from '../../src/sync/namespace-sync-state.js'
 import {
@@ -11,7 +12,6 @@ import {
 import { randomBytes } from 'crypto'
 
 test('sync cores in a namespace', async function (t) {
-  t.plan(2)
   const projectKeyPair = KeyManager.generateProjectKeypair()
   const rootKey1 = randomBytes(16)
   const rootKey2 = randomBytes(16)
@@ -38,8 +38,8 @@ test('sync cores in a namespace', async function (t) {
     waitForCores(cm2, getKeys(cm1, 'auth')),
   ])
 
-  let syncState1Synced = false
-  let syncState2Synced = false
+  const syncState1Sync = pDefer()
+  const syncState2Sync = pDefer()
 
   const syncState1 = new NamespaceSyncState({
     coreManager: cm1,
@@ -50,20 +50,9 @@ test('sync cores in a namespace', async function (t) {
         state.localState.want === 0 &&
         state.localState.wanted === 0 &&
         state.localState.have === 30 &&
-        state.localState.missing === 10 &&
-        !syncState1Synced
+        state.localState.missing === 10
       ) {
-        const expected = {
-          [km2.getIdentityKeypair().publicKey.toString('hex')]: {
-            want: 0,
-            wanted: 0,
-            have: 30,
-            missing: 10,
-            status: 'connected',
-          },
-        }
-        t.alike(state.remoteStates, expected, 'syncState1 is synced')
-        syncState1Synced = true
+        syncState1Sync.resolve(state.remoteStates)
       }
     },
     peerSyncControllers: new Map(),
@@ -78,20 +67,9 @@ test('sync cores in a namespace', async function (t) {
         state.localState.want === 0 &&
         state.localState.wanted === 0 &&
         state.localState.have === 30 &&
-        state.localState.missing === 10 &&
-        !syncState2Synced
+        state.localState.missing === 10
       ) {
-        const expected = {
-          [km1.getIdentityKeypair().publicKey.toString('hex')]: {
-            want: 0,
-            wanted: 0,
-            have: 30,
-            missing: 10,
-            status: 'connected',
-          },
-        }
-        t.alike(state.remoteStates, expected, 'syncState2 is synced')
-        syncState2Synced = true
+        syncState2Sync.resolve(state.remoteStates)
       }
     },
     peerSyncControllers: new Map(),
@@ -118,10 +96,37 @@ test('sync cores in a namespace', async function (t) {
     const core = cm2.getCoreByKey(key)
     core?.download({ start: 0, end: -1 })
   }
+
+  t.alike(
+    await syncState1Sync.promise,
+    {
+      [km2.getIdentityKeypair().publicKey.toString('hex')]: {
+        want: 0,
+        wanted: 0,
+        have: 30,
+        missing: 10,
+        status: 'connected',
+      },
+    },
+    'syncState1 is synced'
+  )
+
+  t.alike(
+    await syncState2Sync.promise,
+    {
+      [km1.getIdentityKeypair().publicKey.toString('hex')]: {
+        want: 0,
+        wanted: 0,
+        have: 30,
+        missing: 10,
+        status: 'connected',
+      },
+    },
+    'syncState2 is synced'
+  )
 })
 
-test('replicate with updating data', async function (t) {
-  t.plan(2)
+test('replicate with updating data', async function () {
   const fillLength = 5000
 
   const projectKeyPair = KeyManager.generateProjectKeypair()
@@ -151,8 +156,8 @@ test('replicate with updating data', async function (t) {
     waitForCores(cm2, getKeys(cm1, 'auth')),
   ])
 
-  let syncState1AlreadyDone = false
-  let syncState2AlreadyDone = false
+  const syncState1Sync = pDefer()
+  const syncState2Sync = pDefer()
 
   const syncState1 = new NamespaceSyncState({
     coreManager: cm1,
@@ -161,10 +166,7 @@ test('replicate with updating data', async function (t) {
       const { localState } = syncState1.getState()
       const synced =
         localState.wanted === 0 && localState.have === fillLength * 2
-      if (synced && !syncState1AlreadyDone) {
-        t.ok(synced, 'syncState1 is synced')
-        syncState1AlreadyDone = true
-      }
+      if (synced) syncState1Sync.resolve()
     },
     peerSyncControllers: new Map(),
   })
@@ -176,10 +178,7 @@ test('replicate with updating data', async function (t) {
       const { localState } = syncState2.getState()
       const synced =
         localState.wanted === 0 && localState.have === fillLength * 2
-      if (synced && !syncState2AlreadyDone) {
-        t.ok(synced, 'syncState2 is synced')
-        syncState2AlreadyDone = true
-      }
+      if (synced) syncState2Sync.resolve()
     },
     peerSyncControllers: new Map(),
   })
@@ -198,4 +197,6 @@ test('replicate with updating data', async function (t) {
     const core = cm2.getCoreByKey(key)
     core?.download({ start: 0, end: -1 })
   }
+
+  await Promise.all([syncState1Sync.promise, syncState2Sync.promise])
 })

--- a/types/brittle.d.ts
+++ b/types/brittle.d.ts
@@ -64,6 +64,7 @@ declare module 'brittle' {
   }
 
   export interface TestInstance extends Assertion {
+    plan(n: number): void
     teardown(
       fn: () => unknown | Promise<unknown>,
       options?: { order?: number }
@@ -72,10 +73,6 @@ declare module 'brittle' {
     comment(message: string): void
     end(): void
     test: TestFn
-
-    // We plan to replace Brittle with `node:test` which doesn't support `plan`.
-    // Disable it to prevent new code from being written with `t.plan`.
-    // plan(n: number): void
   }
 
   type TestCallback = (t: TestInstance) => void | Promise<void>

--- a/types/brittle.d.ts
+++ b/types/brittle.d.ts
@@ -64,7 +64,6 @@ declare module 'brittle' {
   }
 
   export interface TestInstance extends Assertion {
-    plan(n: number): void
     teardown(
       fn: () => unknown | Promise<unknown>,
       options?: { order?: number }
@@ -73,6 +72,10 @@ declare module 'brittle' {
     comment(message: string): void
     end(): void
     test: TestFn
+
+    // We plan to replace Brittle with `node:test` which doesn't support `plan`.
+    // Disable it to prevent new code from being written with `t.plan`.
+    // plan(n: number): void
   }
 
   type TestCallback = (t: TestInstance) => void | Promise<void>


### PR DESCRIPTION
We plan to replace Brittle with `node:test` which doesn't have an equivalent for `t.plan`. Remove it to make it easier to migrate.

Notably, this removes `t.plan` from the type definitions to discourage its use.