### PR TITLE
test: move project settings tests to `node:test`

### DIFF
--- a/test-e2e/project-settings.js
+++ b/test-e2e/project-settings.js
@@ -1,5 +1,6 @@
 // @ts-check
-import { test } from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { KeyManager } from '@mapeo/crypto'
 import RAM from 'random-access-memory'
 import Fastify from 'fastify'
@@ -8,7 +9,7 @@ import { MapeoManager } from '../src/mapeo-manager.js'
 import { MapeoProject } from '../src/mapeo-project.js'
 import { removeUndefinedFields } from './utils.js'
 
-test('Project settings create, read, and update operations', async (t) => {
+test('Project settings create, read, and update operations', async () => {
   const fastify = Fastify()
 
   const manager = new MapeoManager({
@@ -24,21 +25,21 @@ test('Project settings create, read, and update operations', async (t) => {
 
   const projectId = await manager.createProject()
 
-  t.ok(
+  assert(
     projectId && typeof projectId === 'string',
     'probably valid project ID returned when creating project'
   )
 
   const project = await manager.getProject(projectId)
 
-  t.ok(
+  assert(
     project instanceof MapeoProject,
     'manager.getProject() returns MapeoProject instance'
   )
 
   const initialSettings = await project.$getProjectSettings()
 
-  t.alike(
+  assert.deepEqual(
     removeUndefinedFields(initialSettings),
     {},
     'project has no settings when initially created'
@@ -50,11 +51,15 @@ test('Project settings create, read, and update operations', async (t) => {
 
   const updatedSettings = await project.$setProjectSettings(expectedSettings)
 
-  t.is(updatedSettings.name, expectedSettings.name, 'updatable settings change')
+  assert.equal(
+    updatedSettings.name,
+    expectedSettings.name,
+    'updatable settings change'
+  )
 
   const settings = await project.$getProjectSettings()
 
-  t.alike(
+  assert.deepEqual(
     settings,
     updatedSettings,
     'retrieved settings are equivalent to most recently updated'


### PR DESCRIPTION
This test-only change drops Brittle from our project settings tests and replaces them with `node:test` and `node:assert`.
