### PR TITLE
test: move Fastify server tests to `node:test`

### DIFF
--- a/test-e2e/manager-fastify-server.js
+++ b/test-e2e/manager-fastify-server.js
@@ -1,5 +1,6 @@
 // @ts-check
-import { test } from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { randomBytes } from 'crypto'
 import { join } from 'path'
 import { fileURLToPath } from 'url'
@@ -33,7 +34,7 @@ const projectMigrationsFolder = new URL('../drizzle/project', import.meta.url)
 const clientMigrationsFolder = new URL('../drizzle/client', import.meta.url)
   .pathname
 
-test('start/stop lifecycle', async (t) => {
+test('start/stop lifecycle', async () => {
   const fastify = Fastify()
   const fastifyController = new FastifyController({ fastify })
 
@@ -58,7 +59,7 @@ test('start/stop lifecycle', async (t) => {
     variant: 'original',
   })
   const response1 = await fetch(blobUrl1)
-  t.is(response1.status, 404, 'server started and listening')
+  assert.equal(response1.status, 404, 'server started and listening')
 
   const blobUrl2 = await project.$blobs.getUrl({
     driveId: randomBytes(32).toString('hex'),
@@ -66,7 +67,7 @@ test('start/stop lifecycle', async (t) => {
     type: 'video',
     variant: 'original',
   })
-  t.is(
+  assert.equal(
     new URL(blobUrl1).port,
     new URL(blobUrl2).port,
     'server port is the same'
@@ -74,7 +75,7 @@ test('start/stop lifecycle', async (t) => {
 
   await fastifyController.stop()
 
-  await t.exception.all(async () => {
+  await assert.rejects(async () => {
     await fetch(blobUrl2)
   }, 'failed to fetch due to connection error')
 
@@ -88,18 +89,18 @@ test('start/stop lifecycle', async (t) => {
     variant: 'original',
   })
   const response3 = await fetch(blobUrl3)
-  t.is(response3.status, 404, 'server started and listening')
+  assert.equal(response3.status, 404, 'server started and listening')
 
   await fastifyController.stop()
 
-  await t.exception.all(async () => {
+  await assert.rejects(async () => {
     await fetch(blobUrl3)
   }, 'failed to fetch due to connection error')
 })
 
 test('retrieving blobs using url', async (t) => {
   const clock = FakeTimers.install({ shouldAdvanceTime: true })
-  t.teardown(() => clock.uninstall())
+  t.after(() => clock.uninstall())
 
   const fastify = Fastify()
   const fastifyController = new FastifyController({ fastify })
@@ -114,7 +115,7 @@ test('retrieving blobs using url', async (t) => {
 
   const project = await manager.getProject(await manager.createProject())
 
-  const exceptionPromise1 = t.exception(async () => {
+  const exceptionPromise1 = assert.rejects(async () => {
     await project.$blobs.getUrl({
       driveId: randomBytes(32).toString('hex'),
       name: 'foo',
@@ -129,7 +130,7 @@ test('retrieving blobs using url', async (t) => {
   // Manager should await for the server to start internally
   fastifyController.start()
 
-  await t.test('blob does not exist', async (st) => {
+  await t.test('blob does not exist', async () => {
     const blobUrl = await project.$blobs.getUrl({
       driveId: randomBytes(32).toString('hex'),
       name: 'foo',
@@ -137,17 +138,17 @@ test('retrieving blobs using url', async (t) => {
       variant: 'original',
     })
 
-    st.ok(
+    assert(
       new URL(blobUrl),
       'retrieving url based on HTTP server resolves after starting it'
     )
 
     const response = await fetch(blobUrl)
 
-    st.is(response.status, 404, 'response is 404')
+    assert.equal(response.status, 404, 'response is 404')
   })
 
-  await t.test('blob exists', async (st) => {
+  await t.test('blob exists', async () => {
     const blobId = await project.$blobs.create(
       { original: join(BLOB_FIXTURES_DIR, 'original.png') },
       { mimeType: 'image/png' }
@@ -158,15 +159,15 @@ test('retrieving blobs using url', async (t) => {
       variant: 'original',
     })
 
-    st.ok(
+    assert(
       new URL(blobUrl),
       'retrieving url based on HTTP server resolves after starting it'
     )
 
     const response = await fetch(blobUrl)
 
-    st.is(response.status, 200, 'response status ok')
-    st.is(
+    assert.equal(response.status, 200, 'response status ok')
+    assert.equal(
       response.headers.get('content-type'),
       'image/png',
       'matching content type header'
@@ -175,12 +176,12 @@ test('retrieving blobs using url', async (t) => {
     const expected = await fs.readFile(join(BLOB_FIXTURES_DIR, 'original.png'))
     const body = Buffer.from(await response.arrayBuffer())
 
-    st.alike(body, expected, 'matching reponse body')
+    assert.deepEqual(body, expected, 'matching reponse body')
   })
 
   await fastifyController.stop()
 
-  const exceptionPromise2 = t.exception(async () => {
+  const exceptionPromise2 = assert.rejects(async () => {
     await project.$blobs.getUrl({
       driveId: randomBytes(32).toString('hex'),
       name: 'foo',
@@ -194,7 +195,7 @@ test('retrieving blobs using url', async (t) => {
 
 test('retrieving icons using url', async (t) => {
   const clock = FakeTimers.install({ shouldAdvanceTime: true })
-  t.teardown(() => clock.uninstall())
+  t.after(() => clock.uninstall())
 
   const fastify = Fastify()
   const fastifyController = new FastifyController({ fastify })
@@ -209,7 +210,7 @@ test('retrieving icons using url', async (t) => {
 
   const project = await manager.getProject(await manager.createProject())
 
-  const exceptionPromise1 = t.exception(async () => {
+  const exceptionPromise1 = assert.rejects(async () => {
     await project.$icons.getIconUrl(randomBytes(32).toString('hex'), {
       mimeType: 'image/png',
       pixelDensity: 1,
@@ -222,7 +223,7 @@ test('retrieving icons using url', async (t) => {
 
   await fastifyController.start()
 
-  await t.test('icon does not exist', async (st) => {
+  await t.test('icon does not exist', async () => {
     const nonExistentIconId = randomBytes(32).toString('hex')
 
     const iconUrl = await project.$icons.getIconUrl(nonExistentIconId, {
@@ -231,17 +232,17 @@ test('retrieving icons using url', async (t) => {
       pixelDensity: 1,
     })
 
-    st.ok(
+    assert(
       new URL(iconUrl),
       'retrieving url based on HTTP server resolves after starting it'
     )
 
     const response = await fetch(iconUrl)
 
-    st.is(response.status, 404, 'response is 404')
+    assert.equal(response.status, 404, 'response is 404')
   })
 
-  await t.test('icon exists', async (st) => {
+  await t.test('icon exists', async () => {
     const iconBuffer = randomBytes(128)
 
     const iconId = await project.$icons.create({
@@ -262,26 +263,26 @@ test('retrieving icons using url', async (t) => {
       pixelDensity: 1,
     })
 
-    st.ok(
+    assert(
       new URL(iconUrl),
       'retrieving url based on HTTP server resolves after starting it'
     )
 
     const response = await fetch(iconUrl)
 
-    st.is(response.status, 200, 'response status ok')
-    st.is(
+    assert.equal(response.status, 200, 'response status ok')
+    assert.equal(
       response.headers.get('content-type'),
       'image/png',
       'matching content type header'
     )
     const body = Buffer.from(await response.arrayBuffer())
-    st.alike(body, iconBuffer, 'matching response body')
+    assert.deepEqual(body, iconBuffer, 'matching response body')
   })
 
   await fastifyController.stop()
 
-  const exceptionPromise2 = t.exception(async () => {
+  const exceptionPromise2 = assert.rejects(async () => {
     await project.$icons.getIconUrl(randomBytes(32).toString('hex'), {
       mimeType: 'image/png',
       pixelDensity: 1,
@@ -294,7 +295,7 @@ test('retrieving icons using url', async (t) => {
 
 test('retrieving style.json using stable url', async (t) => {
   const clock = FakeTimers.install({ shouldAdvanceTime: true })
-  t.teardown(() => clock.uninstall())
+  t.after(() => clock.uninstall())
 
   const fastify = Fastify()
 
@@ -322,7 +323,7 @@ test('retrieving style.json using stable url', async (t) => {
     fastify,
   })
 
-  const exceptionPromise1 = t.exception(async () => {
+  const exceptionPromise1 = assert.rejects(async () => {
     await manager.getMapStyleJsonUrl()
   }, 'cannot retrieve style json url before HTTP server starts')
 
@@ -333,15 +334,15 @@ test('retrieving style.json using stable url', async (t) => {
 
   const styleJsonUrl = await manager.getMapStyleJsonUrl()
 
-  t.ok(new URL(styleJsonUrl))
+  assert(new URL(styleJsonUrl))
 
   const response = await fetch(styleJsonUrl)
 
-  t.is(response.status, 200, 'response status ok')
+  assert.equal(response.status, 200, 'response status ok')
 
   await fastifyController.stop()
 
-  const exceptionPromise2 = t.exception(async () => {
+  const exceptionPromise2 = assert.rejects(async () => {
     await manager.getMapStyleJsonUrl()
   }, 'cannot retrieve style json url after HTTP server closes')
 


### PR DESCRIPTION
This test-only change drops Brittle from our Fastify server tests and
replaces them with `node:test` and `node:assert`.
