### PR TITLE
test: move config import tests to `node:test`

### DIFF
--- a/tests/config-import.js
+++ b/tests/config-import.js
@@ -143,7 +143,7 @@ test('config import - icons', async () => {
       assert.equal(icon.variants.length, 9, '9 - all - variants of tree icons')
     }
     for (let variant of icon.variants) {
-      assert.equal(variant.mimeType, 'image/png', 'varianassert.equal a png')
+      assert.equal(variant.mimeType, 'image/png', 'variant is a png')
     }
   }
   assert.equal(config.warnings.length, 0, 'no warnings on the file')
@@ -199,7 +199,7 @@ test('config import - presets', async () => {
   )
   assert(
     /invalid preset nullPreset/.test(config.warnings[1].message),
-    'the second error is because the preseassert.equal null'
+    'the second error is because the preset is null'
   )
 
   config = await readConfig('./tests/fixtures/config/validPreset.zip')

--- a/tests/config-import.js
+++ b/tests/config-import.js
@@ -1,81 +1,85 @@
 // @ts-check
-import { test } from 'brittle'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { arrayFrom, size } from 'iterpal'
 import { defaultConfigPath } from './helpers/default-config.js'
 import { readConfig } from '../src/config-import.js'
 
-test('config import - loading', async (t) => {
-  await t.exception(
+test('config import - loading', async () => {
+  await assert.rejects(
     async () => await readConfig(''),
     /ENOENT/,
     'file not found'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () => await readConfig('./tests/fixtures/config/notAZip.txt'),
     /End of Central Directory Record not found/,
     'not a zip file'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () => await readConfig('./tests/fixtures/config/tooBigOfAZip.zip'),
     /Error: Zip file contains too many entries. Max is 10000/,
     'number of files in zip is above MAX_ENTRIES'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () =>
       await readConfig('./tests/fixtures/config/configWithoutPresets.zip'),
     /Error: Zip file does not contain presets.json/,
     'missing presets.json'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () =>
       await readConfig('./tests/fixtures/config/invalidPresetsJSON.zip'),
     /Error: Could not parse presets.json/,
     'JSON.parse error of presets.json'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () =>
       await readConfig('./tests/fixtures/config/invalidPresetsFile.zip'),
     /Error: Invalid presets.json file/,
     'presets.json is not an object'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () =>
       await readConfig('./tests/fixtures/config/missingPresetsField.zip'),
     /Error: Invalid presets.json file/,
     'no presets field in presets.json'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () =>
       await readConfig('./tests/fixtures/config/presetsFieldNotAnObject.zip'),
     /Error: Invalid presets.json file/,
     'presets field in presets.json is not an object'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () =>
       await readConfig('./tests/fixtures/config/missingFieldsField.zip'),
     /Error: Invalid presets.json file/,
     'no fields field in presets.json'
   )
 
-  await t.exception(
+  await assert.rejects(
     async () =>
       await readConfig('./tests/fixtures/config/fieldsFieldNotAnObject.zip'),
     /Error: Invalid presets.json file/,
     'fields field in presets.json is not an object'
   )
 
-  t.ok(await readConfig('./tests/fixtures/config/validConfig.zip'), 'valid zip')
+  assert(
+    await readConfig('./tests/fixtures/config/validConfig.zip'),
+    'valid zip'
+  )
 })
 
-test('config import - icons', async (t) => {
+test('config import - icons', async () => {
   // filename
   let config = await readConfig(
     './tests/fixtures/config/invalidIconFilename.zip'
@@ -83,14 +87,13 @@ test('config import - icons', async (t) => {
   /* eslint-disable-next-line */
   for await (const icon of config.icons()) {
   }
-  t.is(
+  assert.equal(
     config.warnings.length,
     1,
     'we got one error when reading icon with wrong filename'
   )
-  t.not(
-    config.warnings[0].message.match(/Unexpected icon filename/),
-    null,
+  assert(
+    /Unexpected icon filename/.test(config.warnings[0].message),
     'the error message is about badly formed icon name'
   )
 
@@ -103,14 +106,13 @@ test('config import - icons', async (t) => {
   for await (const icon of config.icons()) {
   }
 
-  t.is(
+  assert.equal(
     config.warnings.length,
     1,
     'we got one error when reading icon with wrong pixel density'
   )
-  t.not(
-    config.warnings[0].message.match(/invalid pixel density/),
-    null,
+  assert(
+    /invalid pixel density/.test(config.warnings[0].message),
     'the error message is about invalid pixel density'
   )
 
@@ -121,103 +123,105 @@ test('config import - icons', async (t) => {
   for await (const icon of config.icons()) {
   }
 
-  t.is(
+  assert.equal(
     config.warnings.length,
     1,
     'we got one error when reading icon with wrong size'
   )
-  t.not(
-    config.warnings[0].message.match(/invalid size/),
-    null,
+  assert(
+    /invalid size/.test(config.warnings[0].message),
     'the error message is about invalid size'
   )
 
   config = await readConfig('./tests/fixtures/config/validIcons.zip')
   const icons = await arrayFrom(config.icons())
-  t.is(icons.length, 2)
+  assert.equal(icons.length, 2)
   for (const icon of icons) {
     if (icon.name === 'plant') {
-      t.is(icon.variants.length, 3, '3 variants of plant icons')
+      assert.equal(icon.variants.length, 3, '3 variants of plant icons')
     } else if (icon.name === 'tree') {
-      t.is(icon.variants.length, 9, '9 - all - variants of tree icons')
+      assert.equal(icon.variants.length, 9, '9 - all - variants of tree icons')
     }
     for (let variant of icon.variants) {
-      t.is(variant.mimeType, 'image/png', 'variant is a png')
+      assert.equal(variant.mimeType, 'image/png', 'varianassert.equal a png')
     }
   }
-  t.is(config.warnings.length, 0, 'no warnings on the file')
+  assert.equal(config.warnings.length, 0, 'no warnings on the file')
 })
 
-test('config import - fields', async (t) => {
+test('config import - fields', async () => {
   let config = await readConfig('./tests/fixtures/config/invalidField.zip')
 
   /* eslint-disable-next-line */
   for (const field of config.fields()) {
   }
-  t.is(config.warnings.length, 3, 'we got 3 errors when reading fields')
-  t.not(
-    config.warnings[0].message.match(/Invalid field noKeyField/),
-    null,
+  assert.equal(config.warnings.length, 3, 'we got 3 errors when reading fields')
+  assert(
+    /Invalid field noKeyField/.test(config.warnings[0].message),
     'the first error is because the field has no "key" field'
   )
-  t.not(
-    config.warnings[1].message.match(/Invalid field nullField/),
-    null,
+  assert(
+    /Invalid field nullField/.test(config.warnings[1].message),
     'the second error is because the field is null'
   )
-  t.not(
-    config.warnings[2].message.match(/Invalid field noObjectField/),
-    null,
+  assert(
+    /Invalid field noObjectField/.test(config.warnings[2].message),
     'the third error is because the field is not an object'
   )
 
   config = await readConfig('./tests/fixtures/config/validField.zip')
   for (let field of config.fields()) {
-    t.is(field.name, 'nombre-monitor', `field.name is 'nombre-monitor'`)
-    t.is(
+    assert.equal(field.name, 'nombre-monitor', `field.name is 'nombre-monitor'`)
+    assert.equal(
       field.value.tagKey,
       'nombre-monitor',
       `tagKey of field is 'nombre-monitor'`
     )
-    t.is(field.value.schemaName, 'field', `schemaName is 'field'`)
+    assert.equal(field.value.schemaName, 'field', `schemaName is 'field'`)
   }
-  t.is(config.warnings.length, 0, 'no warnings on the file')
+  assert.equal(config.warnings.length, 0, 'no warnings on the file')
 })
 
-test('config import - presets', async (t) => {
+test('config import - presets', async () => {
   let config = await readConfig('./tests/fixtures/config/invalidPreset.zip')
 
   /* eslint-disable-next-line */
   for (const preset of config.presets()) {
   }
-  t.is(config.warnings.length, 2, 'we got two errors when reading presets')
-  t.not(
-    config.warnings[0].message.match(/invalid preset noObjectPreset/),
-    null,
-    'the first error is because the preset is not an object'
+  assert.equal(
+    config.warnings.length,
+    2,
+    'we got two errors when reading presets'
   )
-  t.not(
-    config.warnings[1].message.match(/invalid preset nullPreset/),
-    null,
-    'the second error is because the preset is null'
+  assert(
+    /invalid preset noObjectPreset/.test(config.warnings[0].message),
+    'the first error is because the preseassert.equal not an object'
+  )
+  assert(
+    /invalid preset nullPreset/.test(config.warnings[1].message),
+    'the second error is because the preseassert.equal null'
   )
 
   config = await readConfig('./tests/fixtures/config/validPreset.zip')
   for (const preset of config.presets()) {
-    t.is(preset.value.schemaName, 'preset', `schemaName is 'preset'`)
-    t.ok(
+    assert.equal(preset.value.schemaName, 'preset', `schemaName is 'preset'`)
+    assert(
       preset.value.name === 'Planta' || 'Punto de Entrada',
-      `the preset name is what is expected`
+      'the preset name is expected'
     )
   }
-  t.is(config.warnings.length, 0, `no warnings on the file`)
+  assert.equal(config.warnings.length, 0, `no warnings on the file`)
 })
 
-test('config import - load default config', async (t) => {
+test('config import - load default config', async () => {
   const config = await readConfig(defaultConfigPath)
-  t.ok(config, 'valid config file')
+  assert(config, 'valid config file')
 
-  t.is(size(config.fields()), 11, 'correct number of fields in default config')
+  assert.equal(
+    size(config.fields()),
+    11,
+    'correct number of fields in default config'
+  )
   let nIcons = 0
   let nVariants = 0
   /* eslint-disable-next-line */
@@ -225,14 +229,18 @@ test('config import - load default config', async (t) => {
     nIcons++
     nVariants += size(icon.variants)
   }
-  t.is(nIcons, 26, 'correct number of icons in default config')
-  t.is(nVariants, 234, 'correct number of icon variants in default config')
+  assert.equal(nIcons, 26, 'correct number of icons in default config')
+  assert.equal(
+    nVariants,
+    234,
+    'correct number of icon variants in default config'
+  )
 
-  t.is(
+  assert.equal(
     size(config.presets()),
     28,
     'correct number of presets in default config'
   )
 
-  t.is(config.warnings.length, 0, 'no warnings on config file')
+  assert.equal(config.warnings.length, 0, 'no warnings on config file')
 })


### PR DESCRIPTION
This test-only change drops Brittle from our config import tests and replaces them with `node:test` and `node:assert`.