### PR TITLE
chore: remove unused "device type" property from MapeoManager

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -93,8 +93,6 @@ export class MapeoManager extends TypedEmitter {
   #loggerBase
   #l
   #defaultConfigPath
-  /** @readonly */
-  #deviceType
 
   /**
    * @param {Object} opts
@@ -104,7 +102,6 @@ export class MapeoManager extends TypedEmitter {
    * @param {string} opts.clientMigrationsFolder path for drizzle migrations folder for client database
    * @param {string | import('./types.js').CoreStorage} opts.coreStorage Folder for hypercore storage or a function that returns a RandomAccessStorage instance
    * @param {import('fastify').FastifyInstance} opts.fastify Fastify server instance
-   * @param {import('./generated/rpc.js').DeviceInfo['deviceType']} [opts.deviceType] Device type, shared with local peers and project members
    * @param {String} [opts.defaultConfigPath]
    */
   constructor({
@@ -114,13 +111,11 @@ export class MapeoManager extends TypedEmitter {
     clientMigrationsFolder,
     coreStorage,
     fastify,
-    deviceType,
     defaultConfigPath,
   }) {
     super()
     this.#keyManager = new KeyManager(rootKey)
     this.#deviceId = getDeviceId(this.#keyManager)
-    this.#deviceType = deviceType
     this.#defaultConfigPath = defaultConfigPath
     const logger = (this.#loggerBase = new Logger({ deviceId: this.#deviceId }))
     this.#l = Logger.create('manager', logger)

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -181,7 +181,7 @@ export async function createManagers(count, t, deviceType) {
       .fill(null)
       .map(async (_, i) => {
         const name = 'device' + i + (deviceType ? `-${deviceType}` : '')
-        const manager = createManager(name, t, deviceType)
+        const manager = createManager(name, t)
         await manager.setDeviceInfo({ name, deviceType })
         return manager
       })
@@ -191,9 +191,8 @@ export async function createManagers(count, t, deviceType) {
 /**
  * @param {string} seed
  * @param {import('brittle').TestInstance} t
- * @param {import('../src/generated/rpc.js').DeviceInfo['deviceType']} [deviceType]
  */
-export function createManager(seed, t, deviceType) {
+export function createManager(seed, t) {
   /** @type {string} */ let dbFolder
   /** @type {string | import('../src/types.js').CoreStorage} */ let coreStorage
 
@@ -223,7 +222,6 @@ export function createManager(seed, t, deviceType) {
     dbFolder,
     coreStorage,
     fastify: Fastify(),
-    deviceType,
   })
 }
 


### PR DESCRIPTION
This change should have no impact.

This property was never used, so we can remove it.
