### PR TITLE
chore: fix types for Corestore.prototype.replicate

### DIFF
--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -519,14 +519,8 @@ test('deleteOthersData()', async (t) => {
     const n1 = new NoiseSecretStream(true)
     const n2 = new NoiseSecretStream(false)
     n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
-    cm1[kCoreManagerReplicate](
-      // @ts-expect-error
-      n1
-    )
-    cm2[kCoreManagerReplicate](
-      // @ts-expect-error
-      n2
-    )
+    cm1[kCoreManagerReplicate](n1)
+    cm2[kCoreManagerReplicate](n2)
 
     // This delay is needed in order for replication to finish properly
     await new Promise((res) => setTimeout(res, 200))

--- a/types/corestore.d.ts
+++ b/types/corestore.d.ts
@@ -3,6 +3,8 @@ declare module 'corestore' {
   import Hypercore, {
     type HypercoreStorage,
     type HypercoreOptions,
+    type ReplicationStream,
+    type CreateProtocolStreamOpts,
   } from 'hypercore'
   import { SetRequired } from 'type-fest'
 
@@ -30,7 +32,16 @@ declare module 'corestore' {
         sparse?: boolean
       }
     ): Hypercore<Hypercore.ValueEncoding, Buffer>
-    replicate: typeof Hypercore.prototype.replicate
+    replicate(
+      stream:
+        | boolean
+        | Duplex
+        | NodeDuplex
+        | NoiseStream
+        | ProtocolStream
+        | Protomux,
+      opts?: CreateProtocolStreamOpts
+    ): ReplicationStream
     namespace(name: string): Corestore
     ready(): Promise<void>
     close(): Promise<void>


### PR DESCRIPTION
This is a types-only change.

These types were wrong which caused type errors in tests.

Once this is fixed, we can start type-checking tests (which we currently don't).