### PR TITLE
chore: enable type checking for all tests

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "files": [],
-  "include": ["./**/*", "../types/**/*.d.ts"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
       "*": ["./types", "./node_modules/@digidem/types/vendor/*/index.d.ts"]
     }
   },
-  "include": ["src/**/*", "types/**/*.d.ts", "test-e2e/**/*"],
+  "include": ["src/**/*", "types/**/*.d.ts", "tests/**/*", "test-e2e/**/*"],
   "exclude": ["node_modules", "src/generated/*.js"]
 }


### PR DESCRIPTION
_This only affects type-checking in tests and should have no user
impact._

Before this change, we weren't type-checking the `tests/` folder. Now we
are!

Prerequisites that made this change possible (list might be incomplete):

- ebcd4d2f9ec33f05f2f681f0fcf4d03c6b8e1401
- df666568383e50bccf4d87edf85b58ae917be0d5
- 91d8c9ce97ce2df15a9cacf4110caa45464baf97
- eca4741c5ce22c6720f1ccd5a329684db7ee86ff
- f64ca17daf646e8fd0e2dca2bad63e464aec21ab
- 0d3d8d93fa531c45f5a48ed9bb410481050461ef
- 57cfe729f933236dd0cc8e568eed364bd83bb0f0
- 95a1fa9bf1e7e38577ba8d892ab4417767ac539e
- b7226aa73dfc153302b00856b5b3e4a28cd660f9
- 0121b2d8281e282232db8dc0d43d597fafc93d23
- 079c7e57674a6509a035e90bb9bac3542870521a
- d7b0268293c81e6fefc7fd79a3e0fbb1ee33dde6
- 3bb941f6916108ea7308d09e04c514b2d8353303
- 2fe45ee14bf8d06366d60eecfc6193e9948b23d9
- bf564519d7183809ae7f0ba64e1deb79665728be
- 23416ab4855ee869c2f09b8e7f43d9f487cbd59b
