### PR TITLE
chore: remove unnecessary `// @ts-check` directives

### DIFF
--- a/src/blob-store/live-download.js
+++ b/src/blob-store/live-download.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { TypedEmitter } from 'tiny-typed-emitter'
 import { once } from 'node:events'
 import SubEncoder from 'sub-encoder'

--- a/src/core-manager/bitfield-rle.js
+++ b/src/core-manager/bitfield-rle.js
@@ -1,4 +1,3 @@
-// @ts-check
 // https://github.com/mafintosh/bitfield-rle/blob/31a0001/index.js
 // Vendored so that we can run cross-platform tests with latest Node versions
 // Modified to encode and decode Uint32Arrays

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { TypedEmitter } from 'tiny-typed-emitter'
 import Corestore from 'corestore'
 import { debounce } from 'throttle-debounce'

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { validate } from '@mapeo/schema'
 import { getTableConfig } from 'drizzle-orm/sqlite-core'
 import { eq, inArray, sql } from 'drizzle-orm'

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 export class NotFoundError extends Error {
   constructor() {
     super('Not found')

--- a/src/invite-api.js
+++ b/src/invite-api.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { TypedEmitter } from 'tiny-typed-emitter'
 import { pEvent } from 'p-event'
 import { InviteResponse_Decision } from './generated/rpc.js'

--- a/src/lib/hashmap.js
+++ b/src/lib/hashmap.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /** @typedef {string | number | bigint | boolean | undefined | symbol | null} Primitive */
 
 /**

--- a/src/lib/ponyfills.js
+++ b/src/lib/ponyfills.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /**
  * Ponyfill of `AbortSignal.any()`.
  *

--- a/src/lib/string.js
+++ b/src/lib/string.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /**
  * Returns `true` if the string is empty or only contains whitespace, `false` otherwise.
  *

--- a/src/lib/timing-safe-equal.js
+++ b/src/lib/timing-safe-equal.js
@@ -1,4 +1,3 @@
-// @ts-check
 import * as crypto from 'node:crypto'
 
 /**

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { TypedEmitter } from 'tiny-typed-emitter'
 import Protomux from 'protomux'
 import { assert, ExhaustivenessError, keyToId, noop } from './utils.js'

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -1,4 +1,3 @@
-// @ts-check
 import path from 'path'
 import Database from 'better-sqlite3'
 import { decodeBlockPrefix, decode } from '@mapeo/schema'

--- a/test-e2e/core-ownership.js
+++ b/test-e2e/core-ownership.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 import { KeyManager } from '@mapeo/crypto'
 import { parseVersionId } from '@mapeo/schema'

--- a/test-e2e/device-info.js
+++ b/test-e2e/device-info.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 import { randomBytes } from 'crypto'
 import { KeyManager } from '@mapeo/crypto'

--- a/test-e2e/local-peers.js
+++ b/test-e2e/local-peers.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 import {
   connectPeers,

--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { randomBytes, createHash } from 'crypto'

--- a/test-e2e/manager-fastify-server.js
+++ b/test-e2e/manager-fastify-server.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { randomBytes } from 'crypto'

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test, skip } from 'brittle'
 import { InviteResponse_Decision } from '../src/generated/rpc.js'
 import { once } from 'node:events'

--- a/test-e2e/manager-restart.js
+++ b/test-e2e/manager-restart.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 import { ManagerCustodian } from './utils.js'
 

--- a/test-e2e/members.js
+++ b/test-e2e/members.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 import { randomBytes } from 'crypto'
 import { once } from 'node:events'

--- a/test-e2e/project-crud.js
+++ b/test-e2e/project-crud.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 import { randomBytes } from 'crypto'
 import { valueOf } from '../src/utils.js'

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 
 import {

--- a/test-e2e/project-settings.js
+++ b/test-e2e/project-settings.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { KeyManager } from '@mapeo/crypto'

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { test } from 'brittle'
 import { pEvent } from 'p-event'
 import { setTimeout as delay } from 'timers/promises'

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -1,4 +1,3 @@
-// @ts-check
 import sodium from 'sodium-universal'
 import RAM from 'random-access-memory'
 import Fastify from 'fastify'

--- a/tests/blob-api.js
+++ b/tests/blob-api.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { join } from 'node:path'

--- a/tests/blob-store/live-download.js
+++ b/tests/blob-store/live-download.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { DriveLiveDownload } from '../../src/blob-store/live-download.js'

--- a/tests/config-import.js
+++ b/tests/config-import.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { arrayFrom, size } from 'iterpal'

--- a/tests/core-ownership.js
+++ b/tests/core-ownership.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { KeyManager, sign } from '@mapeo/crypto'

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { DataStore } from '../src/datastore/index.js'

--- a/tests/datastore.js
+++ b/tests/datastore.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { DataStore } from '../src/datastore/index.js'

--- a/tests/fastify-controller.js
+++ b/tests/fastify-controller.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import Fastify from 'fastify'
 

--- a/tests/fastify-plugins/blobs.js
+++ b/tests/fastify-plugins/blobs.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { randomBytes } from 'node:crypto'
 import test from 'node:test'
 import assert from 'node:assert/strict'

--- a/tests/fastify-plugins/icons.js
+++ b/tests/fastify-plugins/icons.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { randomBytes } from 'crypto'

--- a/tests/helpers/default-config.js
+++ b/tests/helpers/default-config.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { createRequire } from 'node:module'
 
 const require = createRequire(import.meta.url)

--- a/tests/helpers/events.js
+++ b/tests/helpers/events.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert } from '../../src/utils.js'
 import { pEventIterator } from 'p-event'
 import { arrayFrom } from 'iterpal'

--- a/tests/icon-api.js
+++ b/tests/icon-api.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'brittle'
 import RAM from 'random-access-memory'
 import Database from 'better-sqlite3'

--- a/tests/invite-api.js
+++ b/tests/invite-api.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { once } from 'node:events'

--- a/tests/lib/hashmap.js
+++ b/tests/lib/hashmap.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import HashMap from '../../src/lib/hashmap.js'

--- a/tests/lib/ponyfills.js
+++ b/tests/lib/ponyfills.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { abortSignalAny } from '../../src/lib/ponyfills.js'

--- a/tests/lib/string.js
+++ b/tests/lib/string.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { isBlank } from '../../src/lib/string.js'

--- a/tests/local-peers.js
+++ b/tests/local-peers.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'brittle'
 import { keyToId, projectKeyToPublicId } from '../src/utils.js'
 import {

--- a/tests/remote-bitfield.js
+++ b/tests/remote-bitfield.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import RemoteBitfield from '../src/core-manager/remote-bitfield.js'

--- a/tests/schema.js
+++ b/tests/schema.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { getTableConfig } from 'drizzle-orm/sqlite-core'

--- a/tests/schema/schema-to-drizzle.js
+++ b/tests/schema/schema-to-drizzle.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { jsonSchemaToDrizzleColumns } from '../../src/schema/schema-to-drizzle.js'

--- a/tests/sync/core-sync-state.js
+++ b/tests/sync/core-sync-state.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import NoiseSecretStream from '@hyperswarm/secret-stream'

--- a/tests/sync/namespace-sync-state.js
+++ b/tests/sync/namespace-sync-state.js
@@ -1,4 +1,3 @@
-//@ts-check
 import test from 'brittle'
 import pDefer from 'p-defer'
 import { KeyManager } from '@mapeo/crypto'

--- a/tests/translation-api.js
+++ b/tests/translation-api.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'brittle'
 import TranslationApi, {
   ktranslatedLanguageCodeToSchemaNames,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,4 +1,3 @@
-// @ts-check
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {


### PR DESCRIPTION
No longer necessary now that we type-check all these files in `tsconfig.json`.