### PR TITLE
test: speed up "create and sync data" test

### DIFF
--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -91,7 +91,7 @@ test('Create and sync data', { timeout: 60_000 }, async (t) => {
       Promise.all(
         map(projects, async (project) => {
           const deviceId = project.deviceId.slice(0, 7)
-          // @ts-ignore - to complex to narrow `schemaName` to valid values
+          // @ts-ignore - too complex to narrow `schemaName` to valid values
           const docs = await project[schemaName].getMany()
           const expected = generatedDocs.filter(
             (v) => v.schemaName === schemaName

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -26,11 +26,11 @@ import { kSyncState } from '../src/sync/sync-api.js'
 
 const SCHEMAS_INITIAL_SYNC = ['preset', 'field']
 
-test('Create and sync data', { timeout: 60_000 }, async (t) => {
+test('Create and sync data', { timeout: 100_000 }, async (t) => {
   // NOTE: Unlike other tests in this file, this test uses `node:assert` instead
   // of `t` to ease our transition away from Brittle. We can remove this comment
   // when Brittle is removed.
-  const COUNT = 5
+  const COUNT = 10
   const managers = await createManagers(COUNT, t)
   const [invitor, ...invitees] = managers
   const disconnect = connectPeers(managers, { discovery: false })


### PR DESCRIPTION
*I recommend [reviewing this with whitespace changes disabled](https://github.com/digidem/mapeo-core-next/pull/689/files?w=1).*

This speeds up our "create and sync data" test. On my machine, it went from ~73 seconds to ~12.

I did this by making a few changes:

- Decrease the number of managers from 10 to 5, dramatically reducing the amount of connections required. I don't think 10 really offers much here, other than perhaps a stress test, and lowering it offers a huge speedup.

- Run assertions concurrently.

- When comparing sets, use `Set` instead of sorted arrays. This speeds things up a bit.

- Use `node:assert` instead of Brittle for a slight performance boost.  We also plan to drop Brittle in the future and this will ease the transition.

Each of these could theoretically be done separately.

I've been running this test a lot which is why I'm fixing this now.