### PR TITLE
feat: add auto-stop option to `$sync.start()`

### DIFF
--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -62,7 +62,8 @@ export class SyncApi extends TypedEmitter {
   #previousSyncEnabledState = 'none'
   /** @type {null | number} */
   #previousDataHave = null
-  #autostopDataSyncAfter = Infinity
+  /** @type {null | number} */
+  #autostopDataSyncAfter = null
   /** @type {null | ReturnType<typeof setTimeout>} */
   #autostopDataSyncTimeout = null
   /** @type {Map<import('protomux'), Set<Buffer>>} */
@@ -207,7 +208,7 @@ export class SyncApi extends TypedEmitter {
           this.#peerSyncControllers
         )
       ) {
-        if (Number.isFinite(this.#autostopDataSyncAfter)) {
+        if (typeof this.#autostopDataSyncAfter === 'number') {
           this.#autostopDataSyncTimeout ??= setTimeout(() => {
             this.#wantsToSyncData = false
             this.#updateState()
@@ -239,11 +240,11 @@ export class SyncApi extends TypedEmitter {
    * nothing until the app is foregrounded.
    *
    * @param {object} [options]
-   * @param {number} [options.autostopDataSyncAfter=Infinity] If no data sync
+   * @param {null | number} [options.autostopDataSyncAfter] If no data sync
    * happens after this duration in milliseconds, sync will be automatically
    * stopped as if {@link stop} was called.
    */
-  start({ autostopDataSyncAfter = Infinity } = {}) {
+  start({ autostopDataSyncAfter = null } = {}) {
     assertAutostopDataSyncAfterIsValid(autostopDataSyncAfter)
     this.#wantsToSyncData = true
     this.#autostopDataSyncAfter = autostopDataSyncAfter
@@ -372,11 +373,11 @@ export class SyncApi extends TypedEmitter {
 }
 
 /**
- * @param {number} ms
+ * @param {null | number} ms
  * @returns {void}
  */
 function assertAutostopDataSyncAfterIsValid(ms) {
-  if (ms === Infinity) return
+  if (ms === null) return
   assert(
     ms > 0 && ms <= 2 ** 31 - 1 && Number.isSafeInteger(ms),
     'auto-stop timeout must be Infinity or a positive integer between 0 and the largest 32-bit signed integer'

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -7,7 +7,7 @@ import {
 } from './peer-sync-controller.js'
 import { Logger } from '../logger.js'
 import { NAMESPACES } from '../constants.js'
-import { ExhaustivenessError, keyToId } from '../utils.js'
+import { ExhaustivenessError, assert, keyToId } from '../utils.js'
 
 export const kHandleDiscoveryKey = Symbol('handle discovery key')
 export const kSyncState = Symbol('sync state')
@@ -60,6 +60,11 @@ export class SyncApi extends TypedEmitter {
   #hasRequestedFullStop = false
   /** @type {SyncEnabledState} */
   #previousSyncEnabledState = 'none'
+  /** @type {null | number} */
+  #previousDataHave = null
+  #autostopDataSyncAfter = Infinity
+  /** @type {null | ReturnType<typeof setTimeout>} */
+  #autostopDataSyncTimeout = null
   /** @type {Map<import('protomux'), Set<Buffer>>} */
   #pendingDiscoveryKeys = new Map()
   #l
@@ -152,9 +157,33 @@ export class SyncApi extends TypedEmitter {
     return state
   }
 
+  /**
+   * Update which namespaces are synced and the autostop timeout.
+   *
+   * The following table describes the expected behavior based on inputs.
+   *
+   * | Want to sync data? | Full stop requested? | Synced? | Enabled | Timeout |
+   * |--------------------|----------------------|---------|---------|---------|
+   * | no                 | no                   | no      | presync | off     |
+   * | no                 | no                   | yes     | presync | off     |
+   * | no                 | yes                  | no      | presync | off     |
+   * | no                 | yes                  | yes     | none    | off     |
+   * | yes                | no                   | no      | all     | off     |
+   * | yes                | no                   | yes     | all     | on      |
+   * | yes                | yes                  | no      | all     | off     |
+   * | yes                | yes                  | yes     | none    | off     |
+   */
   #updateState(namespaceSyncState = this[kSyncState].getState()) {
+    const dataHave = namespaceSyncState.data.localState.have
+    const hasReceivedNewData = dataHave !== this.#previousDataHave
+    if (hasReceivedNewData) {
+      this.#clearAutostopDataSyncTimeoutIfExists()
+    }
+    this.#previousDataHave = dataHave
+
     /** @type {SyncEnabledState} */ let syncEnabledState
     if (this.#hasRequestedFullStop) {
+      this.#clearAutostopDataSyncTimeoutIfExists()
       if (this.#previousSyncEnabledState === 'none') {
         syncEnabledState = 'none'
       } else if (
@@ -170,8 +199,27 @@ export class SyncApi extends TypedEmitter {
       } else {
         syncEnabledState = 'presync'
       }
+    } else if (this.#wantsToSyncData) {
+      if (
+        isSynced(
+          namespaceSyncState,
+          this.#wantsToSyncData ? 'full' : 'initial',
+          this.#peerSyncControllers
+        )
+      ) {
+        if (Number.isFinite(this.#autostopDataSyncAfter)) {
+          this.#autostopDataSyncTimeout ??= setTimeout(() => {
+            this.#wantsToSyncData = false
+            this.#updateState()
+          }, this.#autostopDataSyncAfter)
+        }
+      } else {
+        this.#clearAutostopDataSyncTimeoutIfExists()
+      }
+      syncEnabledState = 'all'
     } else {
-      syncEnabledState = this.#wantsToSyncData ? 'all' : 'presync'
+      this.#clearAutostopDataSyncTimeoutIfExists()
+      syncEnabledState = 'presync'
     }
 
     this.#l.log(`Setting sync enabled state to "${syncEnabledState}"`)
@@ -189,9 +237,18 @@ export class SyncApi extends TypedEmitter {
    *
    * If the app is backgrounded and sync has already completed, this will do
    * nothing until the app is foregrounded.
+   *
+   * @param {object} [options]
+   * @param {number} [options.autostopDataSyncAfter=Infinity] If no data sync
+   * happens after this duration in milliseconds, sync will be automatically
+   * stopped as if {@link stop} was called.
    */
-  start() {
+  start({ autostopDataSyncAfter = Infinity } = {}) {
+    assertAutostopDataSyncAfterIsValid(autostopDataSyncAfter)
     this.#wantsToSyncData = true
+    this.#autostopDataSyncAfter = autostopDataSyncAfter
+    // Ensure the timeout is started anew.
+    this.#clearAutostopDataSyncTimeoutIfExists()
     this.#updateState()
   }
 
@@ -236,6 +293,13 @@ export class SyncApi extends TypedEmitter {
         res()
       })
     })
+  }
+
+  #clearAutostopDataSyncTimeoutIfExists() {
+    if (this.#autostopDataSyncTimeout) {
+      clearTimeout(this.#autostopDataSyncTimeout)
+      this.#autostopDataSyncTimeout = null
+    }
   }
 
   /**
@@ -305,6 +369,18 @@ export class SyncApi extends TypedEmitter {
     this.#peerIds.delete(peerId)
     this.#pendingDiscoveryKeys.delete(protomux)
   }
+}
+
+/**
+ * @param {number} ms
+ * @returns {void}
+ */
+function assertAutostopDataSyncAfterIsValid(ms) {
+  if (ms === Infinity) return
+  assert(
+    ms > 0 && ms <= 2 ** 31 - 1 && Number.isSafeInteger(ms),
+    'auto-stop timeout must be Infinity or a positive integer between 0 and the largest 32-bit signed integer'
+  )
 }
 
 /**

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -275,7 +275,7 @@ test('validates auto-stop timeouts', async (t) => {
   const projectId = await manager.createProject({ name: 'foo' })
   const project = await manager.getProject(projectId)
 
-  const invalid = [-Infinity, 0, 1.23, 2 ** 31]
+  const invalid = [-Infinity, 0, 1.23, 2 ** 31, Infinity]
   for (const autostopDataSyncAfter of invalid) {
     assert.throws(() => {
       project.$sync.start({ autostopDataSyncAfter })

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict'
 import { pEvent } from 'p-event'
 import { setTimeout as delay } from 'timers/promises'
 import { excludeKeys } from 'filter-obj'
+import FakeTimers from '@sinonjs/fake-timers'
 import {
   connectPeers,
+  createManager,
   createManagers,
   invite,
   seedDatabases,
@@ -158,6 +160,99 @@ test('start and stop sync', async function (t) {
   t.alike(obs2Synced, obs2, 'observation is synced')
 
   await disconnect()
+})
+
+test('auto-stop', async (t) => {
+  // NOTE: Unlike other tests in this file, this test uses `node:assert` instead
+  // of `t` to ease our transition away from Brittle. We can remove this comment
+  // when Brittle is removed.
+  const clock = FakeTimers.install({ shouldAdvanceTime: true })
+  t.teardown(() => clock.uninstall())
+
+  const managers = await createManagers(2, t)
+  const [invitor, ...invitees] = managers
+
+  const disconnect = connectPeers(managers, { discovery: false })
+  t.teardown(disconnect)
+
+  const projectId = await invitor.createProject({ name: 'mapeo' })
+  await invite({ invitor, invitees, projectId })
+
+  const projects = await Promise.all(
+    managers.map((m) => m.getProject(projectId))
+  )
+  const [invitorProject, inviteeProject] = projects
+
+  const generatedObservations = generate('observation', { count: 2 })
+
+  invitorProject.$sync.start({ autostopDataSyncAfter: 10_000 })
+  inviteeProject.$sync.start({ autostopDataSyncAfter: 10_000 })
+
+  assert(
+    invitorProject.$sync.getState().data.isSyncEnabled,
+    "invitor hasn't auto-stopped yet"
+  )
+  assert(
+    inviteeProject.$sync.getState().data.isSyncEnabled,
+    "invitee hasn't auto-stopped yet"
+  )
+
+  const observation1 = await invitorProject.observation.create(
+    valueOf(generatedObservations[0])
+  )
+  await waitForSync(projects, 'full')
+  assert(
+    await inviteeProject.observation.getByDocId(observation1.docId),
+    'invitee receives doc'
+  )
+
+  await clock.tickAsync(9000)
+
+  const observation2 = await invitorProject.observation.create(
+    valueOf(generatedObservations[1])
+  )
+  await waitForSync(projects, 'full')
+  assert(
+    await inviteeProject.observation.getByDocId(observation2.docId),
+    'invitee receives doc'
+  )
+
+  await clock.tickAsync(9000)
+
+  assert(
+    invitorProject.$sync.getState().data.isSyncEnabled,
+    "invitor hasn't auto-stopped yet because the timer has been restarted"
+  )
+  assert(
+    inviteeProject.$sync.getState().data.isSyncEnabled,
+    "invitee hasn't auto-stopped yet because the timer has been restarted"
+  )
+
+  await clock.tickAsync(2000)
+
+  assert(
+    !invitorProject.$sync.getState().data.isSyncEnabled,
+    'invitor has auto-stopped'
+  )
+  assert(
+    !inviteeProject.$sync.getState().data.isSyncEnabled,
+    'invitee has auto-stopped'
+  )
+})
+
+test('validates auto-stop timeouts', async (t) => {
+  const manager = await createManager('test', t)
+  const projectId = await manager.createProject({ name: 'foo' })
+  const project = await manager.getProject(projectId)
+
+  const invalid = [-Infinity, 0, 1.23, 2 ** 31]
+  for (const autostopDataSyncAfter of invalid) {
+    assert.throws(() => {
+      project.$sync.start({ autostopDataSyncAfter })
+    })
+  }
+
+  assert(!project.$sync.getState().data.isSyncEnabled, 'sync is not enabled')
 })
 
 test('gracefully shutting down sync for all projects when backgrounded', async function (t) {

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -243,8 +243,23 @@ test('auto-stop', async (t) => {
     "invitee hasn't auto-stopped yet because the timer has been restarted"
   )
 
-  await clock.tickAsync(2000)
+  const invitorProjectOnSyncDisabled = pEvent(
+    invitorProject.$sync,
+    'sync-state',
+    ({ data: { isSyncEnabled } }) => !isSyncEnabled
+  )
+  const inviteeProjectOnSyncDisabled = pEvent(
+    inviteeProject.$sync,
+    'sync-state',
+    ({ data: { isSyncEnabled } }) => !isSyncEnabled
+  )
 
+  clock.tick(2000)
+
+  await Promise.all([
+    invitorProjectOnSyncDisabled,
+    inviteeProjectOnSyncDisabled,
+  ])
   assert(
     !invitorProject.$sync.getState().data.isSyncEnabled,
     'invitor has auto-stopped'


### PR DESCRIPTION
`myProject.$sync.start({ autostopDataSyncAfter: 3000 })` will auto-stop data sync after it's inactive for 3 seconds.

Addresses #627.