### PR TITLE
chore: don't error when calling `#sendHaves` without a peer

### DIFF
--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -449,7 +449,7 @@ export class CoreManager extends TypedEmitter {
    */
   async #sendHaves(peer, cores) {
     if (!peer) {
-      console.warn('sendHaves no peer', peer.remotePublicKey)
+      console.error('Called #sendHaves with no peer')
       // TODO: How to handle this and when does it happen?
       return
     }


### PR DESCRIPTION
We were effectively doing something like this:

```javascript
if (!object) {
  console.warn('no object', object.propertyAccessThatWillFail)
}
```

This could throw an error because we can't access properties on `null` or `undefined`.[^0]

This updates the log message to avoid this error.

[^0]: It's possible that the value was another falsy value, such as `false`, where you can technically access properties. I still think this change is an improvement in that situation, because `false.remotePublicKey` is `undefined`, which isn't very useful.
