### PR TITLE
chore: use `npm ci` for deployment, not `npm install`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,4 @@ jobs:
           # optional: set this secret in your repo config for publishing to NPM
           npm-token: ${{ secrets.NPM_TOKEN }}
           build-command: |
-            npm install
+            npm ci


### PR DESCRIPTION
[`npm ci`][0] is slightly better for deployments than `npm install`.

- It ensures all installed packages match `package-lock.json`.
- It automatically removes `node_modules/` if it exists, ensuring a clean slate.
- It won't update `package.json` or `package-lock.json`.

Not a huge difference, but recommended for deployments.

[0]: https://docs.npmjs.com/cli/v10/commands/npm-ci