### PR TITLE
test: disconnect managers in teardown, not inline

### DIFF
--- a/test-e2e/local-peers.js
+++ b/test-e2e/local-peers.js
@@ -1,18 +1,13 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import {
-  connectPeers,
-  createManagers,
-  disconnectPeers,
-  waitForPeers,
-} from './utils.js'
+import { connectPeers, createManagers, waitForPeers } from './utils.js'
 
 test('Local peers discovery each other and share device info', async (t) => {
   const mobileManagers = await createManagers(5, t, 'mobile')
   const desktopManagers = await createManagers(5, t, 'desktop')
   const managers = [...mobileManagers, ...desktopManagers]
-  connectPeers(managers, { discovery: true })
-  t.after(() => disconnectPeers(managers))
+  const disconnectPeers = connectPeers(managers, { discovery: true })
+  t.after(disconnectPeers)
   await waitForPeers(managers, { waitForDeviceInfo: true })
   const deviceInfos = [...mobileManagers, ...desktopManagers].map((m) =>
     m.getDeviceInfo()

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -2,19 +2,15 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { InviteResponse_Decision } from '../src/generated/rpc.js'
 import { once } from 'node:events'
-import {
-  connectPeers,
-  createManagers,
-  disconnectPeers,
-  waitForPeers,
-} from './utils.js'
+import { connectPeers, createManagers, waitForPeers } from './utils.js'
 import { COORDINATOR_ROLE_ID, MEMBER_ROLE_ID } from '../src/roles.js'
 
 /** @typedef {import('../src/generated/rpc.js').Invite} Invite */
 
 test('member invite accepted', async (t) => {
   const [creator, joiner] = await createManagers(2, t)
-  connectPeers([creator, joiner])
+  const disconnectPeers = connectPeers([creator, joiner])
+  t.after(disconnectPeers)
   await waitForPeers([creator, joiner])
 
   const createdProjectId = await creator.createProject({ name: 'Mapeo' })
@@ -66,14 +62,13 @@ test('member invite accepted', async (t) => {
     await joinerProject.$member.getMany(),
     'Project members match'
   )
-
-  await disconnectPeers([creator, joiner])
 })
 
 test('chain of invites', async (t) => {
   const managers = await createManagers(4, t)
   const [creator, ...joiners] = managers
-  connectPeers(managers)
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
   await waitForPeers(managers)
 
   const createdProjectId = await creator.createProject({ name: 'Mapeo' })
@@ -116,16 +111,14 @@ test('chain of invites', async (t) => {
       'Project members match'
     )
   }
-
-  await disconnectPeers(managers)
 })
 
 test('generates new invite IDs for each invite', async (t) => {
   const inviteCount = 10
 
   const [creator, joiner] = await createManagers(2, t)
-  connectPeers([creator, joiner])
-  t.after(() => disconnectPeers([creator, joiner]))
+  const disconnectPeers = connectPeers([creator, joiner])
+  t.after(disconnectPeers)
   await waitForPeers([creator, joiner])
 
   const createdProjectId = await creator.createProject({ name: 'Mapeo' })
@@ -156,7 +149,8 @@ test('generates new invite IDs for each invite', async (t) => {
 test("member can't invite", { skip: true }, async (t) => {
   const managers = await createManagers(3, t)
   const [creator, member, joiner] = managers
-  connectPeers(managers)
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
   await waitForPeers(managers)
 
   const createdProjectId = await creator.createProject({ name: 'Mapeo' })
@@ -188,13 +182,12 @@ test("member can't invite", { skip: true }, async (t) => {
     assert.fail('should not send invite')
   )
   await exceptionPromise
-
-  await disconnectPeers(managers)
 })
 
 test('member invite rejected', async (t) => {
   const [creator, joiner] = await createManagers(2, t)
-  connectPeers([creator, joiner])
+  const disconnectPeers = connectPeers([creator, joiner])
+  t.after(disconnectPeers)
   await waitForPeers([creator, joiner])
 
   const createdProjectId = await creator.createProject({ name: 'Mapeo' })
@@ -234,14 +227,12 @@ test('member invite rejected', async (t) => {
     1,
     'Only 1 member in project still'
   )
-
-  await disconnectPeers([creator, joiner])
 })
 
 test('cancelation', async (t) => {
   const [creator, joiner] = await createManagers(2, t)
-  connectPeers([creator, joiner])
-  t.after(() => disconnectPeers([creator, joiner]))
+  const disconnectPeers = connectPeers([creator, joiner])
+  t.after(disconnectPeers)
   await waitForPeers([creator, joiner])
 
   const createdProjectId = await creator.createProject({ name: 'Mapeo' })
@@ -278,8 +269,8 @@ test('cancelation', async (t) => {
 
 test('canceling nothing', async (t) => {
   const [creator, joiner] = await createManagers(2, t)
-  connectPeers([creator, joiner])
-  t.after(() => disconnectPeers([creator, joiner]))
+  const disconnectPeers = connectPeers([creator, joiner])
+  t.after(disconnectPeers)
 
   const createdProjectId = await creator.createProject({ name: 'Mapeo' })
   const creatorProject = await creator.getProject(createdProjectId)

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -16,7 +16,6 @@ import {
   connectPeers,
   createManager,
   createManagers,
-  disconnectPeers,
   getDiskUsage,
   invite,
   waitForPeers,
@@ -36,7 +35,8 @@ test('Creator cannot leave project if they are the only member', async (t) => {
 test('Creator cannot leave project if no other coordinators exist', async (t) => {
   const managers = await createManagers(2, t)
 
-  connectPeers(managers)
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
   await waitForPeers(managers)
 
   const [creator, member] = managers
@@ -68,14 +68,13 @@ test('Creator cannot leave project if no other coordinators exist', async (t) =>
   await assert.rejects(async () => {
     await creator.leaveProject(projectId)
   }, 'creator attempting to leave project with no other coordinators fails')
-
-  await disconnectPeers(managers)
 })
 
 test('Blocked member cannot leave project', async (t) => {
   const managers = await createManagers(2, t)
 
-  connectPeers(managers)
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
   await waitForPeers(managers)
 
   const [creator, member] = managers
@@ -113,14 +112,13 @@ test('Blocked member cannot leave project', async (t) => {
   await assert.rejects(async () => {
     await member.leaveProject(projectId)
   }, 'Member attempting to leave project fails')
-
-  await disconnectPeers(managers)
 })
 
 test('Creator can leave project if another coordinator exists', async (t) => {
   const managers = await createManagers(2, t)
 
-  connectPeers(managers)
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
   await waitForPeers(managers)
 
   const [creator, coordinator] = managers
@@ -166,14 +164,13 @@ test('Creator can leave project if another coordinator exists', async (t) => {
     ROLES[LEFT_ROLE_ID],
     'coordinator can still retrieve info about creator who left'
   )
-
-  await disconnectPeers(managers)
 })
 
 test('Member can leave project if creator exists', async (t) => {
   const managers = await createManagers(2, t)
 
-  connectPeers(managers)
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
   await waitForPeers(managers)
 
   const [creator, member] = managers
@@ -219,14 +216,13 @@ test('Member can leave project if creator exists', async (t) => {
     ROLES[LEFT_ROLE_ID],
     'creator can still retrieve info about member who left'
   )
-
-  await disconnectPeers(managers)
 })
 
 test('Data access after leaving project', async (t) => {
   const managers = await createManagers(3, t)
 
-  connectPeers(managers)
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
   await waitForPeers(managers)
 
   const [creator, coordinator, member] = managers
@@ -303,8 +299,6 @@ test('Data access after leaving project', async (t) => {
   await assert.rejects(async () => {
     await coordinatorProject.$setProjectSettings({ name: 'foo' })
   }, 'coordinator cannot update project settings after leaving')
-
-  await disconnectPeers(managers)
 })
 
 test('leaving a project deletes data from disk', async (t) => {

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -47,7 +47,8 @@ test('Create and sync data', { timeout: 100_000 }, async (t) => {
     return acc
   }, new Set())
 
-  connectPeers(managers, { discovery: false })
+  const disconnectPeers = connectPeers(managers, { discovery: false })
+  t.after(disconnectPeers)
   await waitForSync(projects, 'initial')
 
   await Promise.all(
@@ -376,7 +377,8 @@ test('shares cores', async function (t) {
   const COUNT = 5
   const managers = await createManagers(COUNT, t)
   const [invitor, ...invitees] = managers
-  connectPeers(managers, { discovery: false })
+  const disconnectPeers = connectPeers(managers, { discovery: false })
+  t.after(disconnectPeers)
   const projectId = await invitor.createProject({ name: 'Mapeo' })
   await invite({ invitor, invitees, projectId })
 

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -28,17 +28,7 @@ const clientMigrationsFolder = new URL('../drizzle/client', import.meta.url)
 
 /**
  * @param {readonly MapeoManager[]} managers
- */
-export async function disconnectPeers(managers) {
-  await Promise.all(
-    managers.map(async (manager) => {
-      return manager.stopLocalPeerDiscoveryServer({ force: true })
-    })
-  )
-}
-
-/**
- * @param {readonly MapeoManager[]} managers
+ * @returns {() => void}
  */
 export function connectPeers(managers, { discovery = true } = {}) {
   if (discovery) {
@@ -50,9 +40,12 @@ export function connectPeers(managers, { discovery = true } = {}) {
         }
       })
     }
-    return function destroy() {
-      return disconnectPeers(managers)
-    }
+    return () =>
+      Promise.all(
+        managers.map((manager) =>
+          manager.stopLocalPeerDiscoveryServer({ force: true })
+        )
+      )
   } else {
     /** @type {import('../src/types.js').ReplicationStream[]} */
     const replicationStreams = []


### PR DESCRIPTION
We want to disconnect managers at the end of tests. This moves that to a `t.after()` call so that it will run whether the test passes or fails.