### PR TITLE
chore: require curly brackets for multiline blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
       "sourceType": "module"
     },
     "rules": {
+      "curly": [
+        "error",
+        "multi-line"
+      ],
       "eqeqeq": "error",
       "default-case": "error",
       "default-case-last": "error",

--- a/src/blob-store/index.js
+++ b/src/blob-store/index.js
@@ -151,10 +151,11 @@ export class BlobStore {
     const drive = this.#getDrive(driveId)
     const blobs = await drive.getBlobs()
 
-    if (!blobs)
+    if (!blobs) {
       throw new Error(
         'Hyperblobs instance not found for drive ' + driveId.slice(0, 7)
       )
+    }
 
     return blobs.createReadStream(entry.value.blob, options)
   }
@@ -171,10 +172,11 @@ export class BlobStore {
     const drive = this.#getDrive(driveId)
     const blobs = await drive.getBlobs()
 
-    if (!blobs)
+    if (!blobs) {
       throw new Error(
         'Hyperblobs instance not found for drive ' + driveId.slice(0, 7)
       )
+    }
 
     return blobs.get(entry.value.blob, { wait: false, start: 0, length })
   }

--- a/src/blob-store/live-download.js
+++ b/src/blob-store/live-download.js
@@ -126,7 +126,7 @@ export class DriveLiveDownload extends TypedEmitter {
    * @returns {BlobDownloadState | BlobDownloadStateError}
    */
   get state() {
-    if (this.#error)
+    if (this.#error) {
       return {
         haveCount: this.#haveCount,
         haveBytes: this.#haveBytes,
@@ -135,6 +135,7 @@ export class DriveLiveDownload extends TypedEmitter {
         error: this.#error,
         status: 'error',
       }
+    }
     return {
       haveCount: this.#haveCount,
       haveBytes: this.#haveBytes,

--- a/src/config-import.js
+++ b/src/config-import.js
@@ -209,8 +209,9 @@ export async function readConfig(configPath) {
       for (const [lang, languageTranslations] of Object.entries(
         translationsFile
       )) {
-        if (!isRecord(languageTranslations))
+        if (!isRecord(languageTranslations)) {
           throw new Error('invalid language translations object')
+        }
         for (const { name, value } of translationsForLanguage(warnings)(
           lang,
           languageTranslations

--- a/src/core-manager/core-index.js
+++ b/src/core-manager/core-index.js
@@ -59,8 +59,9 @@ export class CoreIndex {
   getWriter(namespace) {
     const writerRecord = this.#writersByNamespace.get(namespace)
     // Shouldn't happen, since we add all the writers in the contructor
-    if (!writerRecord)
+    if (!writerRecord) {
       throw new Error(`Writer for namespace '${namespace}' is not defined`)
+    }
     return writerRecord
   }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -29,9 +29,10 @@ createDebug.formatters.X = function (v) {
       k,
       // @ts-ignore - type checks here don't get us anything
       mapObject(v, (k, v) => {
-        if (k === 'remoteStates')
+        if (k === 'remoteStates') {
           // @ts-ignore - type checks here don't get us anything
           return [k, mapObject(v, (k, v) => [k.slice(0, 7), v])]
+        }
         return [k, v]
       }),
     ])

--- a/test-e2e/translation-api.js
+++ b/test-e2e/translation-api.js
@@ -23,8 +23,9 @@ test('translation api - put() and get() presets', async (t) => {
       const matchingTranslation = presetTranslations.find((translation) => {
         return translation.message === presetsTranslationMap[preset.name]
       })
-      if (matchingTranslation)
+      if (matchingTranslation) {
         return { docIdRef: preset.docId, ...matchingTranslation }
+      }
     })
     .filter(isDefined)
 
@@ -95,8 +96,9 @@ test('translation api - put() and get() fields', async (t) => {
       const matchingTranslation = fieldTranslations.find((translation) => {
         return translation.message === fieldsTranslationMap[field.label]
       })
-      if (matchingTranslation)
+      if (matchingTranslation) {
         return { docIdRef: field.docId, ...matchingTranslation }
+      }
     })
     .filter(isDefined)
 
@@ -158,8 +160,9 @@ test('translation api - passing `lang` to dataType', async (t) => {
       const matchingTranslation = fieldTranslations.find((translation) => {
         return translation.message === fieldsTranslationMap[field.label]
       })
-      if (matchingTranslation)
+      if (matchingTranslation) {
         return { docIdRef: field.docId, ...matchingTranslation }
+      }
     })
     .filter(isDefined)
   for (const translationDoc of fieldTranslationsDoc) {
@@ -204,8 +207,9 @@ test('translation api - passing `lang` to dataType', async (t) => {
       const matchingTranslation = presetTranslations.find((translation) => {
         return translation.message === presetsTranslationMap[preset.name]
       })
-      if (matchingTranslation)
+      if (matchingTranslation) {
         return { docIdRef: preset.docId, ...matchingTranslation }
+      }
     })
     .filter(isDefined)
   for (const translationDoc of presetTranslationsDoc) {
@@ -291,8 +295,9 @@ test('translation api - re-loading from disk', async (t) => {
                 )
               }
             )
-            if (matchingTranslation)
+            if (matchingTranslation) {
               return { docIdRef: preset.docId, ...matchingTranslation }
+            }
           })
           .filter(isDefined)
         for (const translationDoc of presetTranslationsDoc) {
@@ -308,8 +313,9 @@ test('translation api - re-loading from disk', async (t) => {
                 return translation.message === fieldsTranslationMap[field.label]
               }
             )
-            if (matchingTranslation)
+            if (matchingTranslation) {
               return { docIdRef: field.docId, ...matchingTranslation }
+            }
           })
           .filter(isDefined)
         for (const translationDoc of fieldTranslationsDoc) {

--- a/tests/fastify-plugins/blobs.js
+++ b/tests/fastify-plugins/blobs.js
@@ -308,10 +308,11 @@ function createServer(opts) {
   return fastify().register(BlobServerPlugin, {
     prefix: opts.prefix,
     getBlobStore: async (projectPublicId) => {
-      if (projectPublicId !== projectKeyToPublicId(opts.projectKey))
+      if (projectPublicId !== projectKeyToPublicId(opts.projectKey)) {
         throw new Error(
           `Could not get blobStore for project id ${projectPublicId}`
         )
+      }
       return opts.blobStore
     },
   })

--- a/tests/fastify-plugins/static-maps.js
+++ b/tests/fastify-plugins/static-maps.js
@@ -247,8 +247,9 @@ function setup(t) {
 function getContentLength(headers) {
   const contentLength = headers['content-length']
 
-  if (Array.isArray(contentLength))
+  if (Array.isArray(contentLength)) {
     throw new Error('Cannot parse content-length header')
+  }
   if (typeof contentLength === 'number') return contentLength
   if (typeof contentLength === 'string') return parseInt(contentLength, 10)
   return contentLength

--- a/tests/sync/core-sync-state.js
+++ b/tests/sync/core-sync-state.js
@@ -577,7 +577,8 @@ export function replicate(
  * @param {number} n
  */
 function createUint32Array(n) {
-  if (n > 2 ** 32 - 1)
+  if (n > 2 ** 32 - 1) {
     throw new Error('Currently can only make array from 32-bit number')
+  }
   return new Uint32Array([n])
 }


### PR DESCRIPTION
This enables the [ESLint `curly` rule][0] to enforce the use of curly brackets when the block contains multiple lines.

After reading a bunch of our code, this intends to make explicit an implicit part of our code style.

[0]: https://eslint.org/docs/latest/rules/curly
