### PR TITLE
chore: remove unused member from `MapeoProject`

### DIFF
--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -78,8 +78,6 @@ export class MapeoProject extends TypedEmitter {
   #blobStore
   #coreOwnership
   #roles
-  /** @ts-ignore */
-  #ownershipWriteDone
   #sqlite
   #memberApi
   #iconApi
@@ -413,9 +411,11 @@ export class MapeoProject extends TypedEmitter {
 
   /**
    * Resolves when hypercores have all loaded
+   *
+   * @returns {Promise<void>}
    */
-  async ready() {
-    await Promise.all([this.#coreManager.ready(), this.#ownershipWriteDone])
+  ready() {
+    return this.#coreManager.ready()
   }
 
   /**


### PR DESCRIPTION
*This change should have no user impact.*

`#ownershipWriteDone` was never used, so we can remove it.

(It's still used in `CoreOwnership` but that's completely separate.)