### PR TITLE
feat: expose creator, coordinator, and member role IDs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,16 @@
+import {
+  CREATOR_ROLE_ID,
+  COORDINATOR_ROLE_ID,
+  MEMBER_ROLE_ID,
+} from './roles.js'
 export { plugin as MapeoStaticMapsFastifyPlugin } from './fastify-plugins/maps/static-maps.js'
 export { plugin as MapeoOfflineFallbackMapFastifyPlugin } from './fastify-plugins/maps/offline-fallback-map.js'
 export { plugin as MapeoMapsFastifyPlugin } from './fastify-plugins/maps/index.js'
 export { FastifyController } from './fastify-controller.js'
 export { MapeoManager } from './mapeo-manager.js'
+
+export const roles = /** @type {const} */ ({
+  CREATOR_ROLE_ID,
+  COORDINATOR_ROLE_ID,
+  MEMBER_ROLE_ID,
+})

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict'
 import { InviteResponse_Decision } from '../src/generated/rpc.js'
 import { once } from 'node:events'
 import { connectPeers, createManagers, waitForPeers } from './utils.js'
-import { COORDINATOR_ROLE_ID, MEMBER_ROLE_ID } from '../src/roles.js'
+import { roles } from '../src/index.js'
+
+const { COORDINATOR_ROLE_ID, MEMBER_ROLE_ID } = roles
 
 /** @typedef {import('../src/generated/rpc.js').Invite} Invite */
 

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -8,7 +8,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import * as v8 from 'node:v8'
 
-import { MapeoManager } from '../src/index.js'
+import { MapeoManager, roles } from '../src/index.js'
 import { kManagerReplicate, kRPC } from '../src/mapeo-manager.js'
 import { once } from 'node:events'
 import { generate } from '@mapeo/mock-data'
@@ -16,7 +16,6 @@ import { valueOf } from '../src/utils.js'
 import { randomInt } from 'node:crypto'
 import { temporaryFile, temporaryDirectory } from 'tempy'
 import fsPromises from 'node:fs/promises'
-import { MEMBER_ROLE_ID } from '../src/roles.js'
 import { kSyncState } from '../src/sync/sync-api.js'
 import { readConfig } from '../src/config-import.js'
 
@@ -91,7 +90,7 @@ export async function invite({
   invitor,
   projectId,
   invitees,
-  roleId = MEMBER_ROLE_ID,
+  roleId = roles.MEMBER_ROLE_ID,
   roleName,
   reject = false,
 }) {


### PR DESCRIPTION
You can now import `CREATOR_ROLE_ID`, `COORDINATOR_ROLE_ID`, and `MEMBER_ROLE_ID`.

```javascript
import { roles } from '@mapeo/core'

myProject.$member.invite(deviceId, { roleId: roles.MEMBER_ROLE_ID })
```

CoMapeo Mobile [currently hard-codes these values][0].

Note that "weirder" IDs, like `LEFT_ROLE_ID`, are deliberately *not exported right now* because they're easy to add later if needed.

Closes #532.

[0]: https://github.com/digidem/comapeo-mobile/blob/2cfa789360a2faa066a85fde8aad73d5e80a5dfd/src/frontend/sharedTypes/index.ts#L31-L37
