### PR TITLE
docs: disable doc build when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,14 @@ jobs:
         run: |
           npm ci
           npm run doc
-      - name: Push updated markdown docs
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: 'docs: update API docs'
-          file_pattern: 'docs/api/md/*'
+      # TODO: Re-enable this.
+      # See <https://github.com/digidem/mapeo-core-next/issues/707>.
+      #
+      # - name: Push updated markdown docs
+      #   uses: stefanzweifel/git-auto-commit-action@v5
+      #   with:
+      #     commit_message: 'docs: update API docs'
+      #     file_pattern: 'docs/api/md/*'
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
           commit-message: 'Release {version}'


### PR DESCRIPTION
This is currently broken but we want to do a release.

In the long term, we'll fix this (see #707). In the short term, we disable this.
