### PR TITLE
fix: auto-download blob namespace

### DIFF
--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -290,7 +290,7 @@ export class CoreManager extends TypedEmitter {
       keyPair,
       encryptionKey: this.#encryptionKeys[namespace],
     })
-    if (namespace !== 'blob' && this.#autoDownload) {
+    if (this.#autoDownload) {
       core.download({ start: 0, end: -1 })
     }
     // Every peer adds a listener, so could have many peers


### PR DESCRIPTION
Media isn't syncing. This seems to be because we hard-coded the `blob` namespace not to auto-download. This removes that and adds an automated test to check it.

I don't know why we did this, but it seems to have originated in [a 2023 commit][0] (later updated in [another commit][1]).

Should address [comapeo-mobile#514].

[0]: https://github.com/digidem/mapeo-core-next/pull/362/commits/5a47b569b6ad7b417fb866f2c518626fca9b39ad
[1]: https://github.com/digidem/mapeo-core-next/commit/ea442a35ef7113dd98dcb3bd984739f333e314f3
[comapeo-mobile#514]: https://github.com/digidem/comapeo-mobile/issues/514