### PR TITLE
feat: support additional metadata for blobs

### DIFF
--- a/src/blob-api.js
+++ b/src/blob-api.js
@@ -6,6 +6,37 @@ import { createHash, randomBytes } from 'node:crypto'
 /** @typedef {import('./types.js').BlobId} BlobId */
 /** @typedef {import('./types.js').BlobType} BlobType  */
 
+/**
+ * Location coordinate data. Based on [Expo's `LocationObjectCoords`][0].
+ * [0]: https://docs.expo.dev/versions/latest/sdk/location/#locationobjectcoords
+ *
+ * @typedef {object} LocationObjectCoords
+ * @prop {number | null} accuracy
+ * @prop {number | null} altitude
+ * @prop {number | null} altitudeAccuracy
+ * @prop {number | null} heading
+ * @prop {number} latitude
+ * @prop {number} longitude
+ * @prop {number | null} speed
+ */
+
+/**
+ * Location metadata for a blob. Based on [Expo's `LocationObject`][0].
+ * [0]: https://docs.expo.dev/versions/latest/sdk/location/#locationobject
+ *
+ * @typedef {object} LocationObject
+ * @prop {LocationObjectCoords} coords
+ * @prop {boolean} [mocked]
+ * @prop {number} timestamp
+ */
+
+/**
+ * @typedef {object} Metadata
+ * @prop {string} mimeType
+ * @prop {number} timestamp
+ * @prop {LocationObject} [location]
+ */
+
 export class BlobApi {
   #blobStore
   #getMediaBaseUrl
@@ -40,7 +71,7 @@ export class BlobApi {
   /**
    * Write blobs for provided variants of a file
    * @param {{ original: string, preview?: string, thumbnail?: string }} filepaths
-   * @param {{ mimeType: string }} metadata
+   * @param {Metadata} metadata
    * @returns {Promise<{ driveId: string, name: string, type: 'photo' | 'video' | 'audio', hash: string }>}
    */
   async create(filepaths, metadata) {

--- a/test-e2e/manager-fastify-server.js
+++ b/test-e2e/manager-fastify-server.js
@@ -15,6 +15,7 @@ import { FastifyController } from '../src/fastify-controller.js'
 import { plugin as StaticMapsPlugin } from '../src/fastify-plugins/maps/static-maps.js'
 import { plugin as MapServerPlugin } from '../src/fastify-plugins/maps/index.js'
 import { plugin as OfflineFallbackMapPlugin } from '../src/fastify-plugins/maps/offline-fallback-map.js'
+import { blobMetadata } from '../tests/helpers/blob-store.js'
 
 const BLOB_FIXTURES_DIR = fileURLToPath(
   new URL('../tests/fixtures/blob-api/', import.meta.url)
@@ -150,7 +151,7 @@ test('retrieving blobs using url', async (t) => {
   await t.test('blob exists', async () => {
     const blobId = await project.$blobs.create(
       { original: join(BLOB_FIXTURES_DIR, 'original.png') },
-      { mimeType: 'image/png' }
+      blobMetadata({ mimeType: 'image/png' })
     )
 
     const blobUrl = await project.$blobs.getUrl({
@@ -314,7 +315,7 @@ test('retrieving audio file', async (t) => {
   await t.test('creating audio', async () => {
     const blobId = await project.$blobs.create(
       { original: join(BLOB_FIXTURES_DIR, 'audio.mp3') },
-      { mimeType: 'audio/mp3' }
+      blobMetadata({ mimeType: 'audio/mp3' })
     )
     const blobUrl = await project.$blobs.getUrl({
       ...blobId,

--- a/tests/blob-api.js
+++ b/tests/blob-api.js
@@ -6,7 +6,7 @@ import { createHash } from 'node:crypto'
 import { fileURLToPath } from 'url'
 import { BlobApi } from '../src/blob-api.js'
 
-import { createBlobStore } from './helpers/blob-store.js'
+import { createBlobStore, blobMetadata } from './helpers/blob-store.js'
 
 test('create blobs', async () => {
   const { blobStore } = createBlobStore()
@@ -31,7 +31,7 @@ test('create blobs', async () => {
       preview: join(directory, 'preview.png'),
       thumbnail: join(directory, 'thumbnail.png'),
     },
-    { mimeType: 'image/png' }
+    blobMetadata({ mimeType: 'image/png' })
   )
 
   assert.equal(attachment.driveId, blobStore.writerDriveId)

--- a/tests/helpers/blob-store.js
+++ b/tests/helpers/blob-store.js
@@ -3,6 +3,7 @@ import { pipelinePromise as pipeline, Writable } from 'streamx'
 
 import { BlobStore } from '../../src/blob-store/index.js'
 import { createCoreManager } from './core-manager.js'
+/** @typedef {import('../../src/blob-api.js').Metadata} Metadata */
 
 /**
  * @param {Object} [opts]
@@ -32,3 +33,25 @@ export async function concat(rs) {
   )
   return buf
 }
+
+/**
+ * @param {Partial<Metadata>} overrides
+ * @returns {Metadata}
+ */
+export const blobMetadata = (overrides) => ({
+  mimeType: 'image/png',
+  timestamp: Date.now(),
+  location: {
+    coords: {
+      accuracy: 3,
+      altitude: 8848,
+      altitudeAccuracy: 3,
+      heading: 180,
+      latitude: 27.988333,
+      longitude: 86.925278,
+      speed: 0,
+    },
+    timestamp: Date.now(),
+  },
+  ...overrides,
+})


### PR DESCRIPTION
This adds support for two additional blob metadata fields: location and timestamp.

This works when tested against [this CoMapeo PR][0], which sets those fields but has to ignore type errors.

Closes #719.

[0]: https://github.com/digidem/comapeo-mobile/pull/532