### PR TITLE
fix: properly emit sync state right after starting/stopping

### DIFF
--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -228,9 +228,9 @@ export class SyncApi extends TypedEmitter {
       peerSyncController.setSyncEnabledState(syncEnabledState)
     }
 
-    this.emit('sync-state', this.#getState(namespaceSyncState))
-
     this.#previousSyncEnabledState = syncEnabledState
+
+    this.emit('sync-state', this.#getState(namespaceSyncState))
   }
 
   /**


### PR DESCRIPTION
We didn't correctly emit `state.data.isSyncEnabled` right after starting or stopping; you needed to call the function twice to make it emit the correct state.

This fixes that by emitting the event at a more correct time.