### PR TITLE
chore: remove unused cache from `CoreSyncState`

### DIFF
--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -58,8 +58,6 @@ export class CoreSyncState {
   #remoteStates = new Map()
   /** @type {InternalState['localState']} */
   #localState = new PeerState()
-  /** @type {DerivedState | null} */
-  #cachedState = null
   #preHavesLength = 0
   #update
   #peerSyncControllers
@@ -77,14 +75,12 @@ export class CoreSyncState {
     // Called whenever the state changes, so we clear the cache because next
     // call to getState() will need to re-derive the state
     this.#update = () => {
-      this.#cachedState = null
       process.nextTick(onUpdate)
     }
   }
 
   /** @type {() => DerivedState} */
   getState() {
-    if (this.#cachedState) return this.#cachedState
     const localCoreLength = this.#core?.length || 0
     return deriveState({
       length: Math.max(localCoreLength, this.#preHavesLength),


### PR DESCRIPTION
*This change should have no impact and is not urgent.*

I noticed this unused cache while working on [#724]. It's safe to remove because it's never used.

If we find performance issues in this class, we can always come back and re-add a (working) cache.

[#724]: https://github.com/digidem/mapeo-core-next/issues/724