### PR TITLE
test: speed up sync test in FAST_TESTS mode

### DIFF
--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -9,6 +9,7 @@ import FakeTimers from '@sinonjs/fake-timers'
 import Fastify from 'fastify'
 import { map } from 'iterpal'
 import {
+  FAST_TESTS,
   connectPeers,
   createManager,
   createManagers,
@@ -34,7 +35,7 @@ import { kSyncState } from '../src/sync/sync-api.js'
 const SCHEMAS_INITIAL_SYNC = ['preset', 'field']
 
 test('Create and sync data', { timeout: 100_000 }, async (t) => {
-  const COUNT = 10
+  const COUNT = FAST_TESTS ? 5 : 10
   const managers = await createManagers(COUNT, t)
   const [invitor, ...invitees] = managers
   const disconnect = connectPeers(managers, { discovery: false })

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -19,7 +19,7 @@ import fsPromises from 'node:fs/promises'
 import { kSyncState } from '../src/sync/sync-api.js'
 import { readConfig } from '../src/config-import.js'
 
-const FAST_TESTS = !!process.env.FAST_TESTS
+export const FAST_TESTS = !!process.env.FAST_TESTS
 const projectMigrationsFolder = new URL('../drizzle/project', import.meta.url)
   .pathname
 const clientMigrationsFolder = new URL('../drizzle/client', import.meta.url)


### PR DESCRIPTION
*This is a test-only change.*

I've been working on sync lately, and this test takes a long time. This change speeds it up if the `FAST_TESTS` environment variable is set.

Stole this [idea from @achou11][0].

[0]: https://github.com/digidem/mapeo-core-next/pull/689#discussion_r1619110581