### PR TITLE
fix: stale caches for sync state when peer is added

### DIFF
--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -172,6 +172,7 @@ export class CoreSyncState {
   addPeer(peerId) {
     if (this.#remoteStates.has(peerId)) return
     this.#remoteStates.set(peerId, new PeerState())
+    this.#update()
   }
 
   /**

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -19,7 +19,7 @@ import fsPromises from 'node:fs/promises'
 import { kSyncState } from '../src/sync/sync-api.js'
 import { readConfig } from '../src/config-import.js'
 
-export const FAST_TESTS = !!process.env.FAST_TESTS
+const FAST_TESTS = !!process.env.FAST_TESTS
 const projectMigrationsFolder = new URL('../drizzle/project', import.meta.url)
   .pathname
 const clientMigrationsFolder = new URL('../drizzle/client', import.meta.url)


### PR DESCRIPTION
This fixes the following bug:

1. Device A creates a project.
2. Device A creates an observation.
3. Device A reads the sync state.
4. Device A invites Device B.
5. Device A reads the sync state again. It's wrong! It's the same state as in Step 3.

This happened because of two stale state caches, both of which I fixed.

- `NamespaceSyncState`'s cache needed to be invalidated when a peer gets added. I did this by adding an update in `CoreSyncState#addPeer`, which `NamespaceSyncState` "listens to".

- `SyncState`'s cache also needed to be invalidated. I investigated doing this before realizing that its cache only saves a single method call to `NamespaceSyncState.prototype.getState`, which is itself cached. Rather than properly fix the cache (which would add some additional complexity), I simply removed it.

Fixes #724.