### PR TITLE
chore: fix type error in sync test

### DIFF
--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -27,6 +27,7 @@ import { valueOf } from '../src/utils.js'
 import pTimeout from 'p-timeout'
 import { BLOCKED_ROLE_ID, COORDINATOR_ROLE_ID } from '../src/roles.js'
 import { kSyncState } from '../src/sync/sync-api.js'
+import { blobMetadata } from '../tests/helpers/blob-store.js'
 /** @typedef {import('../src/mapeo-project.js').MapeoProject} MapeoProject */
 /** @typedef {import('../src/sync/sync-api.js').SyncTypeState} SyncState */
 /** @typedef {import('../src/sync/sync-api.js').State} State */
@@ -146,7 +147,7 @@ test('syncing blobs', async (t) => {
 
   const blob = await invitorProject.$blobs.create(
     { original: fixturePath },
-    { mimeType: 'image/jpeg' }
+    blobMetadata({ mimeType: 'image/jpeg' })
   )
 
   disconnectPeers = connectPeers(managers, { discovery: false })


### PR DESCRIPTION
*This is a test-only change.*

I should have rebased/merged `main` before merging e16bee96e99a1bdb2333a35e10b3028c76c36dfc.

e16bee96e99a1bdb2333a35e10b3028c76c36dfc updated the types for `project.$blobs.create()`. That commit was written before f5591d5cbc36cf64452aef0612666748e7248634 was merged, which called that function. Merging e16bee96e99a1bdb2333a35e10b3028c76c36dfc caused a type error.

This fixes all of that.