### PR TITLE
docs: remove useless `@returns` from several functions

### DIFF
--- a/src/blob-store/live-download.js
+++ b/src/blob-store/live-download.js
@@ -291,7 +291,7 @@ export class DriveLiveDownload extends TypedEmitter {
  *
  * @param {Iterable<{ state: BlobDownloadState | BlobDownloadStateError }>} liveDownloads
  * @param {{ signal?: AbortSignal }} options
- * @returns
+ * @returns {BlobDownloadState | BlobDownloadStateError}
  */
 export function combineStates(liveDownloads, { signal } = {}) {
   /** @type {BlobDownloadState | BlobDownloadStateError} */

--- a/src/core-manager/bitfield-rle.js
+++ b/src/core-manager/bitfield-rle.js
@@ -198,7 +198,7 @@ function encodeFinal(state) {
  * @param {number} i
  * @param {number} len
  * @param {number} bit
- * @returns
+ * @returns {void}
  */
 function encodeUpdate(state, i, len, bit) {
   const headLength = i - len - state.inputOffset

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -479,7 +479,6 @@ export class CoreManager extends TypedEmitter {
    * Replicate all cores in core manager
    *
    * @param {Parameters<Corestore['replicate']>[0]} stream
-   * @returns
    */
   [kCoreManagerReplicate](stream) {
     const protocolStream = Hypercore.createProtocolStream(stream, {

--- a/src/core-manager/remote-bitfield.js
+++ b/src/core-manager/remote-bitfield.js
@@ -39,7 +39,7 @@ class RemoteBitfieldPage {
   /**
    *
    * @param {number} index
-   * @returns
+   * @returns {boolean}
    */
   get(index) {
     return quickbit.get(this.bitfield, index)
@@ -373,7 +373,7 @@ export default class RemoteBitfield {
   /**
    * @param {number} start
    * @param {Uint32Array} bitfield
-   * @returns
+   * @returns {boolean}
    */
   insert(start, bitfield) {
     if (start % 32 !== 0) return false

--- a/src/discovery/local-discovery.js
+++ b/src/discovery/local-discovery.js
@@ -184,7 +184,7 @@ export class LocalDiscovery extends TypedEmitter {
   /**
    *
    * @param {OpenedNoiseStream} conn
-   * @returns
+   * @returns {void}
    */
   #handleNoiseStreamConnection(conn) {
     const { remotePublicKey, isInitiator } = conn

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -579,7 +579,6 @@ export class MapeoProject extends TypedEmitter {
    * need to replicate the manager instance via manager[kManagerReplicate])
    *
    * @param {Parameters<import('hypercore')['replicate']>[0]} stream A duplex stream, a @hyperswarm/secret-stream, or a Protomux instance
-   * @returns
    */
   [kProjectReplicate](stream) {
     // @ts-expect-error - hypercore types need updating

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -438,7 +438,7 @@ async function waitForProjectSync(project, peerIds, type = 'initial') {
 /**
  * @param {Record<string, unknown>} remoteStates
  * @param {string[]} peerIds
- * @returns
+ * @returns {boolean}
  */
 function hasPeerIds(remoteStates, peerIds) {
   for (const peerId of peerIds) {

--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -679,7 +679,6 @@ async function countOpenFileDescriptors(dir) {
  * @param {Hypercore} a
  * @param {Hypercore} b
  * @param {Parameters<typeof Hypercore.prototype.replicate>[1] & { delay?: number }} [opts]
- * @returns
  */
 function replicateCores(a, b, { delay = 0, ...opts } = {}) {
   const s1 = a.replicate(true, { keepAlive: false, ...opts })
@@ -691,7 +690,6 @@ function replicateCores(a, b, { delay = 0, ...opts } = {}) {
 /**
  * Randomly delay stream chunks by up to `delay` milliseconds
  * @param {number} delay
- * @returns
  */
 function latencyStream(delay = 0) {
   return new Transform({

--- a/tests/helpers/core-manager.js
+++ b/tests/helpers/core-manager.js
@@ -14,7 +14,7 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 /**
  *
  * @param {Partial<ConstructorParameters<typeof CoreManager>[0]> & { rootKey?: Buffer }} param0
- * @returns
+ * @returns {CoreManager}
  */
 export function createCoreManager({
   rootKey = randomBytes(16),


### PR DESCRIPTION
*This is a minor, JSDoc-only change.*

`@returns` by itself doesn't do much in JSDoc. This either removes those directives or adds their return type.