### PR TITLE
feat: add API to change sync auto-stop timeout

### DIFF
--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -244,13 +244,13 @@ export class SyncApi extends TypedEmitter {
    * happens after this duration in milliseconds, sync will be automatically
    * stopped as if {@link stop} was called.
    */
-  start({ autostopDataSyncAfter = null } = {}) {
-    assertAutostopDataSyncAfterIsValid(autostopDataSyncAfter)
+  start({ autostopDataSyncAfter } = {}) {
     this.#wantsToSyncData = true
-    this.#autostopDataSyncAfter = autostopDataSyncAfter
-    // Ensure the timeout is started anew.
-    this.#clearAutostopDataSyncTimeoutIfExists()
-    this.#updateState()
+    if (autostopDataSyncAfter === undefined) {
+      this.#updateState()
+    } else {
+      this.setAutostopDataSyncTimeout(autostopDataSyncAfter)
+    }
   }
 
   /**
@@ -276,6 +276,17 @@ export class SyncApi extends TypedEmitter {
    */
   [kRescindFullStopRequest]() {
     this.#hasRequestedFullStop = false
+    this.#updateState()
+  }
+
+  /**
+   * @param {null | number} autostopDataSyncAfter
+   * @returns {void}
+   */
+  setAutostopDataSyncTimeout(autostopDataSyncAfter) {
+    assertAutostopDataSyncAfterIsValid(autostopDataSyncAfter)
+    this.#clearAutostopDataSyncTimeoutIfExists()
+    this.#autostopDataSyncAfter = autostopDataSyncAfter
     this.#updateState()
   }
 

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -302,7 +302,7 @@ test('auto-stop', async (t) => {
     "invitee hasn't auto-stopped yet because the timer has been restarted"
   )
 
-  const invitorProjectOnSyncDisabled = pEvent(
+  let invitorProjectOnSyncDisabled = pEvent(
     invitorProject.$sync,
     'sync-state',
     ({ data: { isSyncEnabled } }) => !isSyncEnabled
@@ -327,6 +327,65 @@ test('auto-stop', async (t) => {
     !inviteeProject.$sync.getState().data.isSyncEnabled,
     'invitee has auto-stopped'
   )
+
+  invitorProject.$sync.setAutostopDataSyncTimeout(20_000)
+  assert(
+    !invitorProject.$sync.getState().data.isSyncEnabled,
+    'invitor is still stopped'
+  )
+
+  invitorProject.$sync.start()
+
+  const observation3 = await invitorProject.observation.create(
+    valueOf(generatedObservations[0])
+  )
+  await waitForSync(projects, 'full')
+  assert(
+    await inviteeProject.observation.getByDocId(observation3.docId),
+    'invitee receives doc'
+  )
+
+  await clock.tickAsync(19_000)
+
+  assert(
+    invitorProject.$sync.getState().data.isSyncEnabled,
+    "invitor hasn't auto-stopped"
+  )
+
+  invitorProjectOnSyncDisabled = pEvent(
+    invitorProject.$sync,
+    'sync-state',
+    ({ data: { isSyncEnabled } }) => !isSyncEnabled
+  )
+
+  clock.tick(2_000)
+
+  await invitorProjectOnSyncDisabled
+  assert(
+    !invitorProject.$sync.getState().data.isSyncEnabled,
+    'invitor has auto-stopped'
+  )
+
+  invitorProject.$sync.start({ autostopDataSyncAfter: 999_999 })
+  invitorProject.$sync.setAutostopDataSyncTimeout(20_000)
+
+  assert(
+    invitorProject.$sync.getState().data.isSyncEnabled,
+    'invitor has not yet auto-stopped'
+  )
+
+  invitorProjectOnSyncDisabled = pEvent(
+    invitorProject.$sync,
+    'sync-state',
+    ({ data: { isSyncEnabled } }) => !isSyncEnabled
+  )
+  clock.tick(21_000)
+  await invitorProjectOnSyncDisabled
+
+  assert(
+    !invitorProject.$sync.getState().data.isSyncEnabled,
+    'invitor has auto-stopped'
+  )
 })
 
 test('validates auto-stop timeouts', async (t) => {
@@ -338,6 +397,9 @@ test('validates auto-stop timeouts', async (t) => {
   for (const autostopDataSyncAfter of invalid) {
     assert.throws(() => {
       project.$sync.start({ autostopDataSyncAfter })
+    })
+    assert.throws(() => {
+      project.$sync.setAutostopDataSyncTimeout(autostopDataSyncAfter)
     })
   }
 


### PR DESCRIPTION
`project.$sync.setAutostopDataSyncTimeout(1234)` sets the auto-stop timeout to 1234 milliseconds without changing the enabled state of sync.

Closes #746.