### PR TITLE
chore: use `Object.hasOwn()`

### DIFF
--- a/src/blob-store/index.js
+++ b/src/blob-store/index.js
@@ -252,8 +252,7 @@ function proxyProps(target, props) {
   // @ts-ignore - too much time to learn how to teach this to Typescript
   return new Proxy(target, {
     get(target, prop, receiver) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (props.hasOwnProperty(prop)) {
+      if (Object.hasOwn(props, prop)) {
         return Reflect.get(props, prop, receiver)
       } else {
         return Reflect.get(target, prop, receiver)

--- a/src/config-import.js
+++ b/src/config-import.js
@@ -140,7 +140,7 @@ export async function readConfig(configPath) {
           schemaName: 'field',
         }
         for (const key of Object.keys(valueSchemas.field.properties)) {
-          if (hasOwn(field, key)) {
+          if (Object.hasOwn(field, key)) {
             fieldValue[key] = field[key]
           }
         }
@@ -188,7 +188,7 @@ export async function readConfig(configPath) {
           terms: [],
         }
         for (const key of Object.keys(valueSchemas.preset.properties)) {
-          if (hasOwn(preset, key)) {
+          if (Object.hasOwn(preset, key)) {
             presetValue[key] = preset[key]
           }
         }
@@ -551,14 +551,6 @@ function isFieldOptions(message) {
  */
 function isRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
-}
-
-/**
- * @param {Record<string | symbol, unknown>} obj
- * @param {string | symbol} prop
- */
-function hasOwn(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop)
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2019",
-    "lib": ["es2020"],
+    "lib": ["es2022"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
This change should have no user impact.

`Object.hasOwn()` replaces `Object.prototype.hasOwnProperty()` in modern JavaScript. Its advantages can be seen in the following code snippet:

```javascript
// Still works even if you overwrite `hasOwnProperty`:
const overwritten = { hasOwnProperty: () => true }
Object.hasOwn(overwritten, "foo")
// => false
overwritten.hasOwnProperty("foo")
// => true (incorrect)

// Still works even if the object has a null prototype:
const nullPrototype = Object.create(null)
nullPrototype.foo = "bar"
Object.hasOwn(nullPrototype, "foo")
// => true
nullPrototype.hasOwnProperty("foo")
// TypeError: nullPrototype.hasOwnProperty is not a function
```

This replaces all uses of `Object.prototype.hasOwnProperty()` with `Object.hasOwn()`.

I think this is a useful change on its own, but will also help in a future change.