### PR TITLE
chore: ignore test fixture ZIPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ proto/build
 !/drizzle/**/*.sql
 .eslintcache
 docs/api/html/*
-test/fixtures/config/*.zip
+tests/fixtures/config/*.zip


### PR DESCRIPTION
This fixes a minor issue from 1c097ee1a3f5d3425824a4b8d846c59350aeb567: ZIP fixtures weren't properly ignored.