### PR TITLE
chore: only write auth writer core once in CoreOwnership

### DIFF
--- a/src/core-ownership.js
+++ b/src/core-ownership.js
@@ -49,7 +49,7 @@ export class CoreOwnership {
     if (authWriterCore.opened) {
       writeOwnership()
     } else {
-      authWriterCore.on('ready', writeOwnership)
+      authWriterCore.once('ready', writeOwnership)
     }
   }
 


### PR DESCRIPTION
We want to call a function once the auth writer core emits its `ready` event. Using `once` lets us clean up the listener once it fires, rather than leaving it around.

Extracted from #390.