### PR TITLE
feat!: expose device-specific sync state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,6 @@
         "cpy-cli": "^5.0.0",
         "drizzle-kit": "^0.20.14",
         "eslint": "^8.57.0",
-        "filter-obj": "^6.0.0",
         "husky": "^8.0.0",
         "iterpal": "^0.4.0",
         "light-my-request": "^5.10.0",
@@ -4127,18 +4126,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-6.0.0.tgz",
-      "integrity": "sha512-lscJ1kdwOyW2Nb3wcoU/LnNLoHg+Weoe7r8NT8xjNAdIZPm/JQuKoMcu3FnWrlKOjtAcf98pewuUyjeD6GoKig==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-my-way": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "cpy-cli": "^5.0.0",
     "drizzle-kit": "^0.20.14",
     "eslint": "^8.57.0",
-    "filter-obj": "^6.0.0",
     "husky": "^8.0.0",
     "iterpal": "^0.4.0",
     "light-my-request": "^5.10.0",

--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -148,9 +148,9 @@ export class NamespaceSyncState {
  */
 export function createState(status) {
   if (status) {
-    return { want: 0, have: 0, wanted: 0, missing: 0, status }
+    return { want: 0, have: 0, wanted: 0, status }
   } else {
-    return { want: 0, have: 0, wanted: 0, missing: 0 }
+    return { want: 0, have: 0, wanted: 0 }
   }
 }
 
@@ -178,7 +178,6 @@ function mutatingAddPeerState(accumulator, currentValue) {
   accumulator.have += currentValue.have
   accumulator.want += currentValue.want
   accumulator.wanted += currentValue.wanted
-  accumulator.missing += currentValue.missing
   if ('status' in accumulator && accumulator.status !== currentValue.status) {
     if (currentValue.status === 'disconnected') {
       accumulator.status === 'disconnected'

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -12,9 +12,6 @@ import { ExhaustivenessError, createMap } from '../utils.js'
 
 /** @type {Namespace[]} */
 export const PRESYNC_NAMESPACES = ['auth', 'config', 'blobIndex']
-export const DATA_NAMESPACES = NAMESPACES.filter(
-  (ns) => !PRESYNC_NAMESPACES.includes(ns)
-)
 
 /**
  * @internal
@@ -32,7 +29,7 @@ export class PeerSyncController {
   #syncCapability = createNamespaceMap('unknown')
   /** @type {SyncEnabledState} */
   #syncEnabledState = 'none'
-  /** @type {Record<Namespace, import('./core-sync-state.js').CoreState | null>} */
+  /** @type {Record<Namespace, import('./core-sync-state.js').LocalCoreState | null>} */
   #prevLocalState = createNamespaceMap(null)
   /** @type {SyncStatus} */
   #syncStatus = createNamespaceMap('unknown')

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -3,7 +3,6 @@ import { SyncState } from './sync-state.js'
 import {
   PeerSyncController,
   PRESYNC_NAMESPACES,
-  DATA_NAMESPACES,
 } from './peer-sync-controller.js'
 import { Logger } from '../logger.js'
 import { NAMESPACES } from '../constants.js'
@@ -23,20 +22,25 @@ export const kRescindFullStopRequest = Symbol('foreground')
  */
 
 /**
- * @typedef {object} SyncTypeState
- * @property {number} have Number of blocks we have locally
- * @property {number} want Number of blocks we want from connected peers
- * @property {number} wanted Number of blocks that connected peers want from us
- * @property {number} missing Number of blocks missing (we don't have them, but connected peers don't have them either)
- * @property {boolean} dataToSync Is there data available to sync? (want > 0 || wanted > 0)
- * @property {boolean} isSyncEnabled Do we want to sync this type of data?
+ * @internal
+ * @typedef {object} RemoteDeviceNamespaceGroupSyncState
+ * @property {boolean} isSyncEnabled do we want to sync this namespace group?
+ * @property {number} want number of blocks this device wants from us
+ * @property {number} wanted number of blocks we want from this device
+ */
+
+/**
+ * @internal
+ * @typedef {object} RemoteDeviceSyncState state of sync for a remote peer
+ * @property {RemoteDeviceNamespaceGroupSyncState} initial state of initial namespaces (auth, config, and blob index)
+ * @property {RemoteDeviceNamespaceGroupSyncState} data state of data namespaces (data and blob)
  */
 
 /**
  * @typedef {object} State
- * @property {SyncTypeState} initial State of initial sync (sync of auth, metadata and project config)
- * @property {SyncTypeState} data State of data sync (observations, map data, photos, audio, video etc.)
- * @property {number} connectedPeers Number of connected peers
+ * @property {{ isSyncEnabled: boolean }} initial state of initial namespace syncing (auth, config, and blob index) for local device
+ * @property {{ isSyncEnabled: boolean }} data state of data namespace syncing (data and blob) for local device
+ * @property {Record<string, RemoteDeviceSyncState>} remoteDeviceSyncState sync states for remote peers
  */
 
 /**
@@ -138,24 +142,33 @@ export class SyncApi extends TypedEmitter {
    * @returns {State}
    */
   #getState(namespaceSyncState) {
-    const state = reduceSyncState(namespaceSyncState)
+    const remoteDeviceSyncState = getRemoteDevicesSyncState(
+      namespaceSyncState,
+      this.#peerSyncControllers.values()
+    )
 
     switch (this.#previousSyncEnabledState) {
       case 'none':
-        state.initial.isSyncEnabled = state.data.isSyncEnabled = false
-        break
+        return {
+          initial: { isSyncEnabled: false },
+          data: { isSyncEnabled: false },
+          remoteDeviceSyncState,
+        }
       case 'presync':
-        state.initial.isSyncEnabled = true
-        state.data.isSyncEnabled = false
-        break
+        return {
+          initial: { isSyncEnabled: true },
+          data: { isSyncEnabled: false },
+          remoteDeviceSyncState,
+        }
       case 'all':
-        state.initial.isSyncEnabled = state.data.isSyncEnabled = true
-        break
+        return {
+          initial: { isSyncEnabled: true },
+          data: { isSyncEnabled: true },
+          remoteDeviceSyncState,
+        }
       default:
         throw new ExhaustivenessError(this.#previousSyncEnabledState)
     }
-
-    return state
   }
 
   /**
@@ -417,53 +430,52 @@ function isSynced(state, type, peerSyncControllers) {
 }
 
 /**
- * Reduce the more detailed sync state we use internally to the public sync
- * state that sums namespaces into an 'initial' and 'full' sync state
  * @param {import('./sync-state.js').State} namespaceSyncState
- * @returns {State}
+ * @param {Iterable<PeerSyncController>} peerSyncControllers
+ * @returns {State['remoteDeviceSyncState']}
  */
-function reduceSyncState(namespaceSyncState) {
-  const connectedPeers = Object.values(
-    namespaceSyncState.auth.remoteStates
-  ).filter((remoteState) => remoteState.status === 'connected').length
-  const state = {
-    initial: createInitialSyncTypeState(),
-    data: createInitialSyncTypeState(),
-    connectedPeers,
-  }
-  for (const ns of PRESYNC_NAMESPACES) {
-    const nsState = namespaceSyncState[ns]
-    mutatingAddNamespaceState(state.initial, nsState)
-  }
-  for (const ns of DATA_NAMESPACES) {
-    const nsState = namespaceSyncState[ns]
-    mutatingAddNamespaceState(state.data, nsState)
-  }
-  return state
-}
+function getRemoteDevicesSyncState(namespaceSyncState, peerSyncControllers) {
+  /** @type {State['remoteDeviceSyncState']} */ const result = {}
 
-/**
- * @param {SyncTypeState} accumulator
- * @param {import('./namespace-sync-state.js').SyncState} currentValue
- */
-function mutatingAddNamespaceState(accumulator, currentValue) {
-  accumulator.have += currentValue.localState.have
-  accumulator.want += currentValue.localState.want
-  accumulator.wanted += currentValue.localState.wanted
-  accumulator.missing += currentValue.localState.missing
-  accumulator.dataToSync ||= currentValue.dataToSync
-}
+  for (const psc of peerSyncControllers) {
+    const { peerId } = psc
 
-/**
- * @returns {SyncTypeState}
- */
-function createInitialSyncTypeState() {
-  return {
-    have: 0,
-    want: 0,
-    wanted: 0,
-    missing: 0,
-    dataToSync: false,
-    isSyncEnabled: true,
+    for (const namespace of NAMESPACES) {
+      const isBlocked = psc.syncCapability[namespace] === 'blocked'
+      if (isBlocked) continue
+
+      const peerCoreState = namespaceSyncState[namespace].remoteStates[peerId]
+      if (!peerCoreState) continue
+
+      /** @type {boolean} */
+      let isSyncEnabled
+      switch (peerCoreState.status) {
+        case 'disconnected':
+        case 'connecting':
+          isSyncEnabled = false
+          break
+        case 'connected':
+          isSyncEnabled = true
+          break
+        default:
+          throw new ExhaustivenessError(peerCoreState.status)
+      }
+
+      if (!Object.hasOwn(result, peerId)) {
+        result[peerId] = {
+          initial: { isSyncEnabled: false, want: 0, wanted: 0 },
+          data: { isSyncEnabled: false, want: 0, wanted: 0 },
+        }
+      }
+
+      const namespaceGroup = PRESYNC_NAMESPACES.includes(namespace)
+        ? 'initial'
+        : 'data'
+      result[peerId][namespaceGroup].isSyncEnabled = isSyncEnabled
+      result[peerId][namespaceGroup].want += peerCoreState.want
+      result[peerId][namespaceGroup].wanted += peerCoreState.wanted
+    }
   }
+
+  return result
 }

--- a/tests/sync/core-sync-state.js
+++ b/tests/sync/core-sync-state.js
@@ -29,7 +29,7 @@ import { EventEmitter } from 'node:events'
  */
 const scenarios = [
   {
-    message: '3 peers, start with haves, test want, have, wanted and missing',
+    message: '3 peers, start with haves, test want, have, and wanted',
     state: {
       length: 4,
       localState: { have: 0b0111 },
@@ -37,27 +37,24 @@ const scenarios = [
     },
     expected: {
       coreLength: 4,
-      localState: { want: 0, have: 3, wanted: 2, missing: 1 },
+      localState: { want: 0, have: 3, wanted: 2 },
       remoteStates: {
         peer0: {
           want: 1,
           have: 2,
-          wanted: 1,
-          missing: 1,
+          wanted: 0,
           status: 'disconnected',
         },
         peer1: {
           want: 1,
           have: 2,
-          wanted: 1,
-          missing: 1,
+          wanted: 0,
           status: 'disconnected',
         },
         peer2: {
           want: 2,
           have: 1,
           wanted: 0,
-          missing: 1,
           status: 'disconnected',
         },
       },
@@ -72,20 +69,18 @@ const scenarios = [
     },
     expected: {
       coreLength: 4,
-      localState: { want: 0, have: 0, wanted: 0, missing: 4 },
+      localState: { want: 0, have: 0, wanted: 0 },
       remoteStates: {
         peer0: {
           want: 0,
           have: 0,
           wanted: 0,
-          missing: 4,
           status: 'disconnected',
         },
         peer1: {
           want: 0,
           have: 0,
           wanted: 0,
-          missing: 4,
           status: 'disconnected',
         },
       },
@@ -100,9 +95,9 @@ const scenarios = [
     },
     expected: {
       coreLength: 3,
-      localState: { want: 0, have: 3, wanted: 1, missing: 0 },
+      localState: { want: 0, have: 3, wanted: 1 },
       remoteStates: {
-        peer0: { want: 1, have: 1, wanted: 0, missing: 0, status: 'connected' },
+        peer0: { want: 1, have: 1, wanted: 0, status: 'connected' },
       },
     },
   },
@@ -115,13 +110,12 @@ const scenarios = [
     },
     expected: {
       coreLength: 3,
-      localState: { want: 0, have: 3, wanted: 1, missing: 0 },
+      localState: { want: 0, have: 3, wanted: 1 },
       remoteStates: {
         peer0: {
           want: 1,
           have: 1,
           wanted: 0,
-          missing: 0,
           status: 'disconnected',
         },
       },
@@ -136,13 +130,12 @@ const scenarios = [
     },
     expected: {
       coreLength: 3,
-      localState: { want: 0, have: 3, wanted: 1, missing: 0 },
+      localState: { want: 0, have: 3, wanted: 1 },
       remoteStates: {
         peer0: {
           want: 1,
           have: 2,
           wanted: 0,
-          missing: 0,
           status: 'disconnected',
         },
       },
@@ -157,13 +150,12 @@ const scenarios = [
     },
     expected: {
       coreLength: 3,
-      localState: { want: 0, have: 3, wanted: 0, missing: 0 },
+      localState: { want: 0, have: 3, wanted: 0 },
       remoteStates: {
         peer0: {
           want: 0,
           have: 3,
           wanted: 0,
-          missing: 0,
           status: 'disconnected',
         },
       },
@@ -182,27 +174,24 @@ const scenarios = [
     },
     expected: {
       coreLength: 72,
-      localState: { want: 0, have: 50, wanted: 15, missing: 22 },
+      localState: { want: 0, have: 50, wanted: 15 },
       remoteStates: {
         peer0: {
           want: 10,
           have: 40,
-          wanted: 5,
-          missing: 22,
+          wanted: 0,
           status: 'disconnected',
         },
         peer1: {
           want: 5,
           have: 40,
-          wanted: 10,
-          missing: 0,
+          wanted: 0,
           status: 'disconnected',
         },
         peer2: {
           want: 5,
           have: 40,
-          wanted: 10,
-          missing: 0,
+          wanted: 0,
           status: 'disconnected',
         },
       },
@@ -217,20 +206,18 @@ const scenarios = [
     },
     expected: {
       coreLength: 2,
-      localState: { want: 0, have: 2, wanted: 2, missing: 0 },
+      localState: { want: 0, have: 2, wanted: 2 },
       remoteStates: {
         peer0: {
           want: 1,
           have: 0,
           wanted: 0,
-          missing: 0,
           status: 'disconnected',
         },
         peer1: {
           want: 2,
           have: 0,
           wanted: 0,
-          missing: 0,
           status: 'disconnected',
         },
       },
@@ -272,14 +259,12 @@ test('deriveState() have at index beyond bitfield page size', () => {
       want: 1,
       have: 10,
       wanted: 10,
-      missing: BITS_PER_PAGE - 1,
     },
     remoteStates: {
       peer0: {
         want: 10,
         have: 1,
         wanted: 1,
-        missing: BITS_PER_PAGE - 1,
         status: 'disconnected',
       },
     },

--- a/tests/sync/namespace-sync-state.js
+++ b/tests/sync/namespace-sync-state.js
@@ -49,8 +49,7 @@ test('sync cores in a namespace', async () => {
       if (
         state.localState.want === 0 &&
         state.localState.wanted === 0 &&
-        state.localState.have === 30 &&
-        state.localState.missing === 10
+        state.localState.have === 30
       ) {
         syncState1Sync.resolve(state.remoteStates)
       }
@@ -66,8 +65,7 @@ test('sync cores in a namespace', async () => {
       if (
         state.localState.want === 0 &&
         state.localState.wanted === 0 &&
-        state.localState.have === 30 &&
-        state.localState.missing === 10
+        state.localState.have === 30
       ) {
         syncState2Sync.resolve(state.remoteStates)
       }
@@ -104,7 +102,6 @@ test('sync cores in a namespace', async () => {
         want: 0,
         wanted: 0,
         have: 30,
-        missing: 10,
         status: 'connected',
       },
     },
@@ -118,7 +115,6 @@ test('sync cores in a namespace', async () => {
         want: 0,
         wanted: 0,
         have: 30,
-        missing: 10,
         status: 'connected',
       },
     },


### PR DESCRIPTION
`myProject.$sync.getState()` and the `sync-state` event now return objects like this:

```javascript
{
  initial: { isSyncEnabled: true },
  data: { isSyncEnabled: true },
  remoteDeviceSyncState: {
    abc123: {
      initial: { isSyncEnabled: true, want: 0, wanted: 0 },
      data: { isSyncEnabled: true, want: 2, wanted: 0 },
    },
    def456: {
      initial: { isSyncEnabled: true, want: 0, wanted: 0 },
      data: { isSyncEnabled: true, want: 0, wanted: 1 },
    },
  },
}
```

In English, this means:

- We now have sync information for individual peers, instead of aggregated info.

- `want` and `wanted` have slightly different meaning than before. `want` is the number of blocks a peer wants from us, and `wanted` is the number of blocks we want from a specific peer.

  For example, imagine peers A, B, and C are connected and syncing. Peer A has observation 1, B has observation 2 and 3, and C has nothing. Each of these peers has a relationship:

  - From A's perspective...
    - B wants 1 observation from us and has 2 observations it knows we want.
    - C wants 1 observation from us.
  - From B's perspective... - A wants 2 observations from us and has 1 observation is knows we want. - C wants 2 observations from us.
  - From C's perspective...
    - A has 1 observation is knows we want, and wants nothing from us.
    - A has 2 observations is knows we want, and wants nothing from us.

- Some data should now be inferred. For example, the number of peers is now the number of keys in `remoteDeviceSyncState`, not a calculated value.

- `have` and `missing` were removed from remote states, because they are unused.

Closes #743.