### PR TITLE
chore: allow `null` in several Protomux method options

### DIFF
--- a/types/protomux.d.ts
+++ b/types/protomux.d.ts
@@ -53,16 +53,16 @@ declare module 'protomux' {
     cork(): void
     uncork(): void
     pair(
-      opts: { protocol: string; id?: Buffer },
+      opts: { protocol: string; id?: null | Buffer },
       notify: (id: Buffer) => Promise<void>
     ): void
-    unpair(opts: { protocol: string; id?: Buffer }): void
-    opened(opts: { protocol: string; id?: Buffer }): boolean
+    unpair(opts: { protocol: string; id?: null | Buffer }): void
+    opened(opts: { protocol: string; id?: null | Buffer }): boolean
     createChannel(opts: {
       userData?: any
       protocol: string
       aliases?: string[]
-      id?: Buffer
+      id?: null | Buffer
       unique?: boolean
       handshake?: Encoding
       messages: MessageOptions[]


### PR DESCRIPTION
This is a types-only change.

Several Protomux methods support `null` IDs ([`pair`, for example][0]). This updates our type definitions to reflect that.

I think this is a useful change on its own, but may make upcoming changes easier too.

[0]: https://github.com/holepunchto/protomux/blob/ca7f9aeba40b0e042383728fa063f984028362be/index.js#L315