### PR TITLE
chore: use standard Namespace type

### DIFF
--- a/src/core-manager/core-index.js
+++ b/src/core-manager/core-index.js
@@ -1,6 +1,5 @@
 import crypto from 'hypercore-crypto'
-
-/** @typedef {import('./index.js').Namespace} Namespace */
+/** @import { Namespace } from '../types.js' */
 /** @typedef {import('./index.js').CoreRecord} CoreRecord */
 
 /**

--- a/src/core-manager/index.js
+++ b/src/core-manager/index.js
@@ -14,14 +14,13 @@ import { coresTable } from '../schema/project.js'
 import * as rle from './bitfield-rle.js'
 import { CoreIndex } from './core-index.js'
 
-/** @typedef {import('../types.js').HypercorePeer} HypercorePeer */
+/** @import { HypercorePeer, Namespace } from '../types.js' */
 
 const WRITER_CORE_PREHAVES_DEBOUNCE_DELAY = 1000
 
 export const kCoreManagerReplicate = Symbol('replicate core manager')
 
 /** @typedef {import('hypercore')<'binary', Buffer>} Core */
-/** @typedef {(typeof NAMESPACES)[number]} Namespace */
 /** @typedef {{ core: Core, key: Buffer, namespace: Namespace }} CoreRecord */
 /** @typedef {import('streamx').Duplex} DuplexStream */
 /**
@@ -498,7 +497,7 @@ export class CoreManager extends TypedEmitter {
   }
 
   /**
-   * @param {Exclude<typeof NAMESPACES[number], 'auth'>} namespace
+   * @param {Exclude<Namespace, 'auth'>} namespace
    * @returns {Promise<void>}
    */
   async deleteOthersData(namespace) {

--- a/src/core-ownership.js
+++ b/src/core-ownership.js
@@ -9,9 +9,13 @@ import mapObject from 'map-obj'
 import { discoveryKey } from 'hypercore-crypto'
 import pDefer from 'p-defer'
 import { NAMESPACES } from './constants.js'
-
 /**
- * @typedef {import('./types.js').CoreOwnershipWithSignatures} CoreOwnershipWithSignatures
+ * @import {
+ *   CoreOwnershipWithSignatures,
+ *   CoreOwnershipWithSignaturesValue,
+ *   KeyPair,
+ *   Namespace
+ * } from './types.js'
  */
 
 export class CoreOwnership {
@@ -27,8 +31,8 @@ export class CoreOwnership {
    *   import('@mapeo/schema').CoreOwnership,
    *   import('@mapeo/schema').CoreOwnershipValue
    * >} opts.dataType
-   * @param {Record<import('./core-manager/index.js').Namespace, import('./types.js').KeyPair>} opts.coreKeypairs
-   * @param {import('./types.js').KeyPair} opts.identityKeypair
+   * @param {Record<Namespace, KeyPair>} opts.coreKeypairs
+   * @param {KeyPair} opts.identityKeypair
    */
   constructor({ dataType, coreKeypairs, identityKeypair }) {
     this.#dataType = dataType
@@ -77,7 +81,7 @@ export class CoreOwnership {
   /**
    *
    * @param {string} deviceId
-   * @param {typeof NAMESPACES[number]} namespace
+   * @param {Namespace} namespace
    * @returns {Promise<string>} coreId of core belonging to `deviceId` for `namespace`
    */
   async getCoreId(deviceId, namespace) {
@@ -88,11 +92,11 @@ export class CoreOwnership {
 
   /**
    *
-   * @param {import('./types.js').KeyPair} identityKeypair
-   * @param {Record<typeof NAMESPACES[number], import('./types.js').KeyPair>} coreKeypairs
+   * @param {KeyPair} identityKeypair
+   * @param {Record<Namespace, KeyPair>} coreKeypairs
    */
   async #writeOwnership(identityKeypair, coreKeypairs) {
-    /** @type {import('./types.js').CoreOwnershipWithSignaturesValue} */
+    /** @type {CoreOwnershipWithSignaturesValue} */
     const docValue = {
       schemaName: 'coreOwnership',
       ...mapObject(coreKeypairs, (key, value) => {

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -49,6 +49,7 @@ import {
   kRescindFullStopRequest,
 } from './sync/sync-api.js'
 
+/** @import { CoreStorage, Namespace } from './types.js' */
 /** @typedef {import("@mapeo/schema").ProjectSettingsValue} ProjectValue */
 /** @typedef {import('type-fest').SetNonNullable<ProjectKeys, 'encryptionKeys'>} ValidatedProjectKeys */
 
@@ -86,7 +87,7 @@ export class MapeoManager extends TypedEmitter {
   // Maps project public id -> project instance
   /** @type {Map<string, MapeoProject>} */
   #activeProjects
-  /** @type {import('./types.js').CoreStorage} */
+  /** @type {CoreStorage} */
   #coreStorage
   #dbFolder
   /** @type {string} */
@@ -106,7 +107,7 @@ export class MapeoManager extends TypedEmitter {
    * @param {string} opts.dbFolder Folder for sqlite Dbs. Folder must exist. Use ':memory:' to store everything in-memory
    * @param {string} opts.projectMigrationsFolder path for drizzle migrations folder for project database
    * @param {string} opts.clientMigrationsFolder path for drizzle migrations folder for client database
-   * @param {string | import('./types.js').CoreStorage} opts.coreStorage Folder for hypercore storage or a function that returns a RandomAccessStorage instance
+   * @param {string | CoreStorage} opts.coreStorage Folder for hypercore storage or a function that returns a RandomAccessStorage instance
    * @param {import('fastify').FastifyInstance} opts.fastify Fastify server instance
    * @param {String} [opts.defaultConfigPath]
    */
@@ -359,7 +360,7 @@ export class MapeoManager extends TypedEmitter {
     const projectKeypair = KeyManager.generateProjectKeypair()
 
     // 2. Create namespace encryption keys
-    /** @type {Record<import('./core-manager/core-index.js').Namespace, Buffer>} */
+    /** @type {Record<Namespace, Buffer>} */
     const encryptionKeys = {
       auth: randomBytes(32),
       blob: randomBytes(32),

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -50,6 +50,8 @@ import { IconApi } from './icon-api.js'
 import { readConfig } from './config-import.js'
 import TranslationApi from './translation-api.js'
 
+/** @import { CoreStorage, KeyPair, Namespace } from './types.js' */
+
 /** @typedef {Omit<import('@mapeo/schema').ProjectSettingsValue, 'schemaName'>} EditableProjectSettings */
 /** @typedef {import('@mapeo/schema').ProjectSettingsValue['configMetadata']} ConfigMetadata */
 
@@ -101,7 +103,7 @@ export class MapeoProject extends TypedEmitter {
    * @param {import('./generated/keys.js').EncryptionKeys} opts.encryptionKeys Encryption keys for each namespace
    * @param {import('drizzle-orm/better-sqlite3').BetterSQLite3Database} opts.sharedDb
    * @param {IndexWriter} opts.sharedIndexWriter
-   * @param {import('./types.js').CoreStorage} opts.coreStorage Folder to store all hypercore data
+   * @param {CoreStorage} opts.coreStorage Folder to store all hypercore data
    * @param {(mediaType: 'blobs' | 'icons') => Promise<string>} opts.getMediaBaseUrl
    * @param {import('./local-peers.js').LocalPeers} opts.localPeers
    * @param {Logger} [opts.logger]
@@ -685,7 +687,7 @@ export class MapeoProject extends TypedEmitter {
     }
 
     const namespacesWithoutAuth =
-      /** @satisfies {Exclude<import('./core-manager/index.js').Namespace, 'auth'>[]} */ ([
+      /** @satisfies {Exclude<Namespace, 'auth'>[]} */ ([
         'config',
         'data',
         'blob',
@@ -908,11 +910,10 @@ async function deleteTranslations(opts) {
  * @param {Buffer} opts.projectKey
  * @param {Buffer} [opts.projectSecretKey]
  * @param {import('@mapeo/crypto').KeyManager} opts.keyManager
- * @returns {Record<import('./core-manager/index.js').Namespace, import('./types.js').KeyPair>}
+ * @returns {Record<Namespace, KeyPair>}
  */
 function getCoreKeypairs({ projectKey, projectSecretKey, keyManager }) {
-  const keypairs =
-    /** @type {Record<import('./core-manager/index.js').Namespace, import('./types.js').KeyPair>} */ ({})
+  const keypairs = /** @type {Record<Namespace, KeyPair>} */ ({})
 
   for (const namespace of NAMESPACES) {
     keypairs[namespace] =

--- a/src/roles.js
+++ b/src/roles.js
@@ -2,6 +2,7 @@ import { currentSchemaVersions } from '@mapeo/schema'
 import mapObject from 'map-obj'
 import { kCreateWithDocId } from './datatype/index.js'
 import { assert, setHas } from './utils.js'
+/** @import { Namespace } from './types.js' */
 
 // Randomly generated 8-byte encoded as hex
 export const CREATOR_ROLE_ID = 'a12a6702b93bd7ff'
@@ -67,7 +68,7 @@ const isRoleIdAssignableToAnyone = setHas(ROLE_IDS_ASSIGNABLE_TO_ANYONE)
  * @property {string} name
  * @property {Record<import('@mapeo/schema').MapeoDoc['schemaName'], DocCapability>} docs
  * @property {RoleIdAssignableToOthers[]} roleAssignment
- * @property {Record<import('./core-manager/core-index.js').Namespace, 'allowed' | 'blocked'>} sync
+ * @property {Record<Namespace, 'allowed' | 'blocked'>} sync
  */
 
 /**

--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -2,8 +2,7 @@ import { keyToId } from '../utils.js'
 import RemoteBitfield, {
   BITS_PER_PAGE,
 } from '../core-manager/remote-bitfield.js'
-/** @typedef {import('../types.js').HypercoreRemoteBitfield} HypercoreRemoteBitfield */
-/** @typedef {import('../types.js').HypercorePeer} HypercorePeer */
+/** @import { HypercorePeer, HypercoreRemoteBitfield, Namespace } from '../types.js' */
 
 /**
  * @typedef {RemoteBitfield} Bitfield
@@ -17,7 +16,7 @@ import RemoteBitfield, {
  * @property {PeerState} localState
  * @property {Map<PeerId, PeerState>} remoteStates
  * @property {Map<string, import('./peer-sync-controller.js').PeerSyncController>} peerSyncControllers
- * @property {import('../core-manager/index.js').Namespace} namespace
+ * @property {Namespace} namespace
  */
 /**
  * @typedef {object} LocalCoreState
@@ -77,7 +76,7 @@ export class CoreSyncState {
    * @param {object} opts
    * @param {() => void} opts.onUpdate Called when a state update is available (via getState())
    * @param {Map<string, import('./peer-sync-controller.js').PeerSyncController>} opts.peerSyncControllers
-   * @param {import('../core-manager/index.js').Namespace} opts.namespace
+   * @param {Namespace} opts.namespace
    */
   constructor({ onUpdate, peerSyncControllers, namespace }) {
     this.#peerSyncControllers = peerSyncControllers

--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -1,12 +1,13 @@
 import { CoreSyncState } from './core-sync-state.js'
 import { discoveryKey } from 'hypercore-crypto'
+/** @import { Namespace } from '../types.js' */
 
 /**
  * @typedef {Omit<import('./core-sync-state.js').DerivedState, 'coreLength'> & { dataToSync: boolean, coreCount: number }} SyncState
  */
 
 /**
- * @template {import('../core-manager/index.js').Namespace} [TNamespace=import('../core-manager/index.js').Namespace]
+ * @template {Namespace} [TNamespace=Namespace]
  */
 export class NamespaceSyncState {
   /** @type {Map<string, CoreSyncState>} */

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -2,10 +2,8 @@ import mapObject from 'map-obj'
 import { NAMESPACES } from '../constants.js'
 import { Logger } from '../logger.js'
 import { ExhaustivenessError, createMap } from '../utils.js'
+/** @import { Namespace } from '../types.js' */
 
-/**
- * @typedef {import('../core-manager/index.js').Namespace} Namespace
- */
 /**
  * @typedef {import('../roles.js').Role['sync'][Namespace] | 'unknown'} SyncCapability
  */

--- a/src/sync/sync-state.js
+++ b/src/sync/sync-state.js
@@ -3,10 +3,11 @@ import { NAMESPACES } from '../constants.js'
 import { NamespaceSyncState } from './namespace-sync-state.js'
 import { throttle } from 'throttle-debounce'
 import mapObject from 'map-obj'
+/** @import { Namespace } from '../types.js' */
 
 /**
  * @typedef {Record<
- *  import('../core-manager/index.js').Namespace,
+ *  Namespace,
  *  import('./namespace-sync-state.js').SyncState
  * >} State
  */
@@ -16,8 +17,7 @@ import mapObject from 'map-obj'
  * @extends {TypedEmitter<{ state: (state: State) => void}>}
  */
 export class SyncState extends TypedEmitter {
-  #syncStates =
-    /** @type {Record<import('../core-manager/index.js').Namespace, NamespaceSyncState> } */ ({})
+  #syncStates = /** @type {Record<Namespace, NamespaceSyncState> } */ ({})
   /**
    *
    * @param {object} opts

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,9 @@ import type NoiseStream from '@hyperswarm/secret-stream'
 import { Duplex } from 'streamx'
 import RandomAccessStorage from 'random-access-storage'
 import { DefaultListener, ListenerSignature } from 'tiny-typed-emitter'
+import type { NAMESPACES } from './constants.js'
+
+export type Namespace = (typeof NAMESPACES)[number]
 
 type SupportedBlobVariants = typeof SUPPORTED_BLOB_VARIANTS
 export type BlobType = keyof SupportedBlobVariants

--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -24,7 +24,7 @@ import { waitForCores } from './helpers/core-manager.js'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { coresTable } from '../src/schema/project.js'
 import { eq } from 'drizzle-orm'
-/** @typedef {import('../src/constants.js').NAMESPACES[number]} Namespace */
+/** @import { Namespace } from '../src/types.js' */
 
 /** @param {any} [key] */
 async function createCore(key) {
@@ -323,7 +323,7 @@ test('sends "haves" bitfields over project creator core replication stream', asy
   const cm2 = createCoreManager({ projectKey })
   /**
    * For each peer, indexed by peerId, a map of hypercore bitfields, indexed by discoveryId
-   * @type {Map<string, Map<import('../src/core-manager/index.js').Namespace, Map<string, RemoteBitfield>>>}
+   * @type {Map<string, Map<Namespace, Map<string, RemoteBitfield>>>}
    */
   const havesByPeer = new Map()
 

--- a/tests/core-ownership.js
+++ b/tests/core-ownership.js
@@ -10,6 +10,8 @@ import { randomBytes } from 'node:crypto'
 import { parseVersionId, getVersionId } from '@mapeo/schema'
 import { discoveryKey } from 'hypercore-crypto'
 
+/** @import { Namespace } from '../src/types.js' */
+
 test('Valid coreOwnership record', () => {
   const validDoc = generateValidDoc()
   const version = parseVersionId(validDoc.versionId)
@@ -74,7 +76,7 @@ test('Invalid coreOwnership docId and coreIds (wrong length)', () => {
   const version = parseVersionId(validDoc.versionId)
 
   for (const key of Object.keys(validDoc.coreSignatures)) {
-    const namespace = /** @type {import('./core-manager.js').Namespace} */ (key)
+    const namespace = /** @type {Namespace} */ (key)
     const invalidDoc = {
       ...validDoc,
       [`${namespace}CoreId`]: validDoc[`${namespace}CoreId`].slice(0, -1),


### PR DESCRIPTION
This is a types-only change.

The `Namespace` type is pretty central, but was stuffed away in `core-manager/index.js`. Its type was also inferred in many cases.

Now it's in a more central spot: `types.ts`.

I think this is useful on its own, but it should make a future change easier.