### PR TITLE
test: use mock data in more places

### DIFF
--- a/test-e2e/core-ownership.js
+++ b/test-e2e/core-ownership.js
@@ -1,7 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { KeyManager } from '@mapeo/crypto'
-import { parseVersionId } from '@mapeo/schema'
+import { generate } from '@mapeo/mock-data'
+import { parseVersionId, valueOf } from '@mapeo/schema'
 import RAM from 'random-access-memory'
 import { discoveryKey } from 'hypercore-crypto'
 import Fastify from 'fastify'
@@ -33,28 +34,15 @@ test('CoreOwnership', async () => {
   const authCoreId = await coreOwnership.getCoreId(deviceId, 'auth')
   assert.equal(await coreOwnership.getOwner(authCoreId), deviceId)
 
-  const preset = await project.preset.create({
-    schemaName: 'preset',
-    name: 'test preset',
-    geometry: ['point'],
-    tags: {},
-    addTags: {},
-    removeTags: {},
-    terms: [],
-    fieldRefs: [],
-    color: '#ff00ff',
-  })
+  const preset = await project.preset.create(valueOf(generate('preset')[0]))
   assert.equal(
     discoveryId(await coreOwnership.getCoreId(deviceId, 'config')),
     parseVersionId(preset.versionId).coreDiscoveryKey.toString('hex')
   )
 
-  const observation = await project.observation.create({
-    schemaName: 'observation',
-    attachments: [],
-    tags: {},
-    metadata: {},
-  })
+  const observation = await project.observation.create(
+    valueOf(generate('observation')[0])
+  )
   assert.equal(
     discoveryId(await coreOwnership.getCoreId(deviceId, 'data')),
     parseVersionId(observation.versionId).coreDiscoveryKey.toString('hex')

--- a/test-e2e/created_by_to_device_id.js
+++ b/test-e2e/created_by_to_device_id.js
@@ -1,3 +1,5 @@
+import { generate } from '@mapeo/mock-data'
+import { valueOf } from '@mapeo/schema'
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
@@ -32,12 +34,9 @@ test('$createdByToDeviceId', async (t) => {
   creatorProject.$sync.start()
   memberProject.$sync.start()
 
-  const observation = await creatorProject.observation.create({
-    schemaName: 'observation',
-    attachments: [],
-    tags: {},
-    metadata: {},
-  })
+  const observation = await creatorProject.observation.create(
+    valueOf(generate('observation')[0])
+  )
 
   await waitForSync(projects, 'full')
 


### PR DESCRIPTION
Our tests have several spots where we create mock data, such as observations or presets. We typically rely on `@mapeo/mock-data` for this, but could use it in a few more places. That's what this commit does!

I think this is useful for three reasons:

1. It's less code.
2. It doesn't need to be manually updated when we make schema updates.
3. It will make [an upcoming change][0] smaller.

[0]: https://github.com/digidem/mapeo-core-next/pull/715