### PR TITLE
feat: create projects as initial project

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -350,13 +350,17 @@ export class MapeoManager extends TypedEmitter {
    * Create a new project.
    * @param {(
    *   import('type-fest').Simplify<(
-   *     Partial<Pick<ProjectValue, 'name'>> &
+   *     Partial<Pick<ProjectValue, 'name' | 'isInitialProject'>> &
    *     { configPath?: string }
    *   )>
    * )} [options]
    * @returns {Promise<string>} Project public id
    */
-  async createProject({ name, configPath = this.#defaultConfigPath } = {}) {
+  async createProject({
+    name,
+    configPath = this.#defaultConfigPath,
+    isInitialProject = false,
+  } = {}) {
     // 1. Create project keypair
     const projectKeypair = KeyManager.generateProjectKeypair()
 
@@ -401,7 +405,7 @@ export class MapeoManager extends TypedEmitter {
     })
 
     // 5. Write project settings to project instance
-    await project.$setProjectSettings({ name })
+    await project.$setProjectSettings({ name, isInitialProject })
 
     // 6. Write device info into project
     const deviceInfo = this.getDeviceInfo()

--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -28,6 +28,7 @@ test('Managing created projects', async (t) => {
   const project1Id = await manager.createProject()
   const project2Id = await manager.createProject({
     name: 'project 2',
+    isInitialProject: true,
   })
 
   await t.test('initial information from listed projects', async () => {
@@ -79,7 +80,7 @@ test('Managing created projects', async (t) => {
         name: 'project 2',
         defaultPresets: undefined,
         configMetadata: undefined,
-        isInitialProject: false,
+        isInitialProject: true,
       },
       'matched name for project2 with undefined default presets'
     )


### PR DESCRIPTION
You can now create a project and set its "is initial project?" value, like so:

```js
const projectId = manager.createProject({ isInitialProject: true })
```