### PR TITLE
chore: uninstall unused light-my-request dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,6 @@
         "eslint": "^8.57.0",
         "husky": "^8.0.0",
         "iterpal": "^0.4.0",
-        "light-my-request": "^5.10.0",
         "lint-staged": "^14.0.1",
         "mapeo-offline-map": "^2.0.0",
         "math-random-seed": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "eslint": "^8.57.0",
     "husky": "^8.0.0",
     "iterpal": "^0.4.0",
-    "light-my-request": "^5.10.0",
     "lint-staged": "^14.0.1",
     "mapeo-offline-map": "^2.0.0",
     "math-random-seed": "^2.0.0",


### PR DESCRIPTION
This dependency seems unused, so we can remove it.

It looks like it was added in 8e64abdf736b31d1a13a1d9791fd9f677118d8d2 but never used.