### PR TITLE
chore: remove unused `hyperswarm` dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 - Familiarity with [GitHub pull requests](https://help.github.com/articles/using-pull-requests) and issues.
 - Knowledge of JavaScript and JSDoc
 - Knowledge of [markdown](https://help.github.com/articles/markdown-basics/) for editing `.md` documents.
-- Understanding of or interest in learning technologies used in this project like [hypercore](https://npmjs.com/hypercore), [hyperswarm](https://npmjs.com/hyperswarm), and other dependencies.
+- Understanding of or interest in learning technologies used in this project like [hypercore](https://npmjs.com/hypercore) and other dependencies.
 
 ## Steps to contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "hypercore": "10.17.0",
         "hypercore-crypto": "3.4.0",
         "hyperdrive": "11.5.3",
-        "hyperswarm": "4.4.1",
         "json-stable-stringify": "^1.1.1",
         "magic-bytes.js": "^1.10.0",
         "map-obj": "^5.0.2",
@@ -3081,13 +3080,6 @@
         }
       }
     },
-    "node_modules/debugging-stream": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.4"
-      }
-    },
     "node_modules/decamelize": {
       "version": "6.0.0",
       "dev": true,
@@ -3208,23 +3200,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dht-rpc": {
-      "version": "6.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.1",
-        "compact-encoding": "^2.11.0",
-        "compact-encoding-net": "^1.2.0",
-        "events": "^3.3.0",
-        "fast-fifo": "^1.1.0",
-        "kademlia-routing-table": "^1.0.1",
-        "nat-sampler": "^1.0.1",
-        "sodium-universal": "^4.0.0",
-        "streamx": "^2.13.2",
-        "time-ordered-set": "^1.0.2",
-        "udx-native": "^1.5.3"
       }
     },
     "node_modules/difflib": {
@@ -4807,30 +4782,6 @@
       "version": "1.0.0",
       "license": "Apache-2.0"
     },
-    "node_modules/hyperdht": {
-      "version": "6.5.3",
-      "license": "MIT",
-      "dependencies": {
-        "@hyperswarm/secret-stream": "^6.0.0",
-        "b4a": "^1.3.1",
-        "bogon": "^1.0.0",
-        "compact-encoding": "^2.4.1",
-        "compact-encoding-net": "^1.0.1",
-        "debugging-stream": "^2.0.0",
-        "dht-rpc": "^6.7.0",
-        "events": "^3.3.0",
-        "hypercore-crypto": "^3.3.0",
-        "noise-curve-ed": "^2.0.0",
-        "noise-handshake": "^3.0.0",
-        "record-cache": "^1.1.1",
-        "safety-catch": "^1.0.1",
-        "sodium-universal": "^4.0.0",
-        "xache": "^1.1.0"
-      },
-      "bin": {
-        "hyperdht": "bin.js"
-      }
-    },
     "node_modules/hyperdrive": {
       "version": "11.5.3",
       "license": "Apache-2.0",
@@ -4845,17 +4796,6 @@
         "streamx": "^2.12.4",
         "sub-encoder": "^2.1.1",
         "unix-path-resolve": "^1.0.2"
-      }
-    },
-    "node_modules/hyperswarm": {
-      "version": "4.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.3.1",
-        "events": "^3.3.0",
-        "hyperdht": "^6.5.2",
-        "safety-catch": "^1.0.2",
-        "shuffled-priority-queue": "^2.1.0"
       }
     },
     "node_modules/ieee754": {
@@ -5488,10 +5428,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/kademlia-routing-table": {
-      "version": "1.0.1",
-      "license": "MIT"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -6225,11 +6161,8 @@
     },
     "node_modules/napi-macros": {
       "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/nat-sampler": {
-      "version": "1.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7549,13 +7482,6 @@
         "node": ">= 12.13.0"
       }
     },
-    "node_modules/record-cache": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.3.1"
-      }
-    },
     "node_modules/redent": {
       "version": "4.0.0",
       "dev": true,
@@ -7945,13 +7871,6 @@
         "jsonc-parser": "^3.2.0",
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^8.0.0"
-      }
-    },
-    "node_modules/shuffled-priority-queue": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "unordered-set": "^2.0.1"
       }
     },
     "node_modules/side-channel": {
@@ -8541,10 +8460,6 @@
         "node": ">=12.22"
       }
     },
-    "node_modules/time-ordered-set": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
     "node_modules/timeout-refresh": {
       "version": "2.0.1",
       "license": "MIT"
@@ -8849,18 +8764,6 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
-    "node_modules/udx-native": {
-      "version": "1.5.5",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.5.0",
-        "events": "^3.3.0",
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.4.0",
-        "streamx": "^2.12.0"
-      }
-    },
     "node_modules/uglify-js": {
       "version": "3.19.2",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
@@ -8924,10 +8827,6 @@
     },
     "node_modules/unix-path-resolve": {
       "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/unordered-set": {
-      "version": "2.0.1",
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "hypercore": "10.17.0",
     "hypercore-crypto": "3.4.0",
     "hyperdrive": "11.5.3",
-    "hyperswarm": "4.4.1",
     "json-stable-stringify": "^1.1.1",
     "magic-bytes.js": "^1.10.0",
     "map-obj": "^5.0.2",


### PR DESCRIPTION
`hyperswarm` is no longer used, so we can remove it.

Note that we still use `@hyperswarm/secret-stream` in this project.