### PR TITLE
chore: update hypercore-crypto to 3.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "fastify-plugin": "^4.5.1",
         "hyperblobs": "2.3.0",
         "hypercore": "10.17.0",
-        "hypercore-crypto": "3.4.0",
+        "hypercore-crypto": "3.4.2",
         "hyperdrive": "11.5.3",
         "hyperswarm": "4.4.1",
         "json-stable-stringify": "^1.1.1",
@@ -2369,8 +2369,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.4",
-      "license": "ISC"
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2474,6 +2475,8 @@
     "node_modules/blake2b": {
       "version": "2.1.4",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "blake2b-wasm": "^2.4.0",
         "nanoassert": "^2.0.0"
@@ -2482,6 +2485,8 @@
     "node_modules/blake2b-wasm": {
       "version": "2.4.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
@@ -2647,6 +2652,8 @@
     "node_modules/chacha20-universal": {
       "version": "1.0.4",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "nanoassert": "^2.0.0"
       }
@@ -2840,8 +2847,9 @@
       }
     },
     "node_modules/compact-encoding": {
-      "version": "2.12.0",
-      "license": "Apache-2.0",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.15.0.tgz",
+      "integrity": "sha512-af/NomxL9Mo0lqCk++rxLLDZI+lJqeBrPt4dK6FbjxTCEhfC9yQAIoO6yq9ixyCirce0luQwErkwJrhem6clxA==",
       "dependencies": {
         "b4a": "^1.3.0"
       }
@@ -4795,12 +4803,13 @@
       }
     },
     "node_modules/hypercore-crypto": {
-      "version": "3.4.0",
-      "license": "MIT",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.4.2.tgz",
+      "integrity": "sha512-16ii4M6T1dFfRa41Szv3IR0wXfImJMYJ8ysZEGwHEDH7sMeWVEBck6tg1GCNutYl39E+H7wMY2p3ndCRfj+XdQ==",
       "dependencies": {
-        "b4a": "^1.1.0",
-        "compact-encoding": "^2.5.1",
-        "sodium-universal": "^4.0.0"
+        "b4a": "^1.6.6",
+        "compact-encoding": "^2.15.0",
+        "sodium-universal": "^4.0.1"
       }
     },
     "node_modules/hypercore-errors": {
@@ -7882,6 +7891,8 @@
     "node_modules/sha256-universal": {
       "version": "1.2.1",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "b4a": "^1.0.1",
         "sha256-wasm": "^2.2.1"
@@ -7890,6 +7901,8 @@
     "node_modules/sha256-wasm": {
       "version": "2.2.2",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
@@ -7898,6 +7911,8 @@
     "node_modules/sha512-universal": {
       "version": "1.2.1",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "b4a": "^1.0.1",
         "sha512-wasm": "^2.3.1"
@@ -7906,6 +7921,8 @@
     "node_modules/sha512-wasm": {
       "version": "2.3.4",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
@@ -8057,6 +8074,8 @@
     "node_modules/siphash24": {
       "version": "1.3.1",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "nanoassert": "^2.0.0"
       }
@@ -8120,6 +8139,8 @@
     "node_modules/sodium-javascript": {
       "version": "0.8.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "blake2b": "^2.1.1",
         "chacha20-universal": "^1.0.4",
@@ -8148,19 +8169,19 @@
       }
     },
     "node_modules/sodium-universal": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
-      "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.1.tgz",
+      "integrity": "sha512-sNp13PrxYLaUFHTGoDKkSDFvoEu51bfzE12RwGlqU1fcrkpAOK0NvizaJzOWV0Omtk9me2+Pnbjcf/l0efxuGQ==",
       "dependencies": {
-        "blake2b": "^2.1.1",
-        "chacha20-universal": "^1.0.4",
-        "nanoassert": "^2.0.0",
-        "sha256-universal": "^1.1.0",
-        "sha512-universal": "^1.1.0",
-        "siphash24": "^1.0.1",
-        "sodium-javascript": "~0.8.0",
-        "sodium-native": "^4.0.0",
-        "xsalsa20": "^1.0.0"
+        "sodium-native": "^4.0.0"
+      },
+      "peerDependencies": {
+        "sodium-javascript": "~0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "sodium-javascript": {
+          "optional": true
+        }
       }
     },
     "node_modules/sonic-boom": {
@@ -9060,7 +9081,9 @@
     },
     "node_modules/xsalsa20": {
       "version": "1.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "fastify-plugin": "^4.5.1",
     "hyperblobs": "2.3.0",
     "hypercore": "10.17.0",
-    "hypercore-crypto": "3.4.0",
+    "hypercore-crypto": "3.4.2",
     "hyperdrive": "11.5.3",
     "hyperswarm": "4.4.1",
     "json-stable-stringify": "^1.1.1",


### PR DESCRIPTION
This updates hypercore-crypto to its latest version.

This project has no changelog but [perusing the commits][0] shows:

- Sub-dependency upgrades
- Minor security and performance improvements

[0]: https://github.com/holepunchto/hypercore-crypto/commits/main