### PR TITLE
chore: rename `PeerCoreState` to `PeerNamespaceState`

### DIFF
--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -25,7 +25,7 @@ import RemoteBitfield, {
  * @property {number} wanted blocks we want from this peer
  */
 /**
- * @typedef {object} PeerCoreState
+ * @typedef {object} PeerNamespaceState
  * @property {number} have blocks the peer has locally
  * @property {number} want blocks this peer wants from us
  * @property {number} wanted blocks we want from this peer
@@ -35,7 +35,7 @@ import RemoteBitfield, {
  * @typedef {object} DerivedState
  * @property {number} coreLength known (sparse) length of the core
  * @property {LocalCoreState} localState local state
- * @property {{ [peerId in PeerId]: PeerCoreState }} remoteStates map of state of all known peers
+ * @property {{ [peerId in PeerId]: PeerNamespaceState }} remoteStates map of state of all known peers
  */
 
 /**
@@ -266,7 +266,7 @@ export class PeerState {
   #haves
   /** @type {Bitfield} */
   #wants = new RemoteBitfield()
-  /** @type {PeerCoreState['status']} */
+  /** @type {PeerNamespaceState['status']} */
   status = 'disconnected'
   #wantAll
   constructor({ wantAll = true } = {}) {
@@ -359,7 +359,7 @@ export function deriveState(coreState) {
   const length = coreState.length || 0
   /** @type {LocalCoreState} */
   const localState = { have: 0, want: 0, wanted: 0 }
-  /** @type {Record<PeerId, PeerCoreState>} */
+  /** @type {Record<PeerId, PeerNamespaceState>} */
   const remoteStates = {}
 
   /** @type {Map<PeerId, PeerState>} */

--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -68,13 +68,13 @@ export class NamespaceSyncState {
     for (const css of this.#coreStates.values()) {
       const coreState = css.getState()
       mutatingAddPeerState(state.localState, coreState.localState)
-      for (const [peerId, peerCoreState] of Object.entries(
+      for (const [peerId, peerNamespaceState] of Object.entries(
         coreState.remoteStates
       )) {
         if (!(peerId in state.remoteStates)) {
-          state.remoteStates[peerId] = peerCoreState
+          state.remoteStates[peerId] = peerNamespaceState
         } else {
-          mutatingAddPeerState(state.remoteStates[peerId], peerCoreState)
+          mutatingAddPeerState(state.remoteStates[peerId], peerNamespaceState)
         }
       }
     }
@@ -140,12 +140,12 @@ export class NamespaceSyncState {
 
 /**
  * @overload
- * @param {import('./core-sync-state.js').PeerCoreState['status']} status
- * @returns {import('./core-sync-state.js').PeerCoreState}
+ * @param {import('./core-sync-state.js').PeerNamespaceState['status']} status
+ * @returns {import('./core-sync-state.js').PeerNamespaceState}
  */
 
 /**
- * @param {import('./core-sync-state.js').PeerCoreState['status']} [status]
+ * @param {import('./core-sync-state.js').PeerNamespaceState['status']} [status]
  */
 export function createState(status) {
   if (status) {
@@ -164,16 +164,16 @@ export function createState(status) {
 
 /**
  * @overload
- * @param {import('./core-sync-state.js').PeerCoreState} accumulator
- * @param {import('./core-sync-state.js').PeerCoreState} currentValue
- * @returns {import('./core-sync-state.js').PeerCoreState}
+ * @param {import('./core-sync-state.js').PeerNamespaceState} accumulator
+ * @param {import('./core-sync-state.js').PeerNamespaceState} currentValue
+ * @returns {import('./core-sync-state.js').PeerNamespaceState}
  */
 
 /**
  * Adds peer state in `currentValue` to peer state in `accumulator`
  *
- * @param {import('./core-sync-state.js').PeerCoreState} accumulator
- * @param {import('./core-sync-state.js').PeerCoreState} currentValue
+ * @param {import('./core-sync-state.js').PeerNamespaceState} accumulator
+ * @param {import('./core-sync-state.js').PeerNamespaceState} currentValue
  */
 function mutatingAddPeerState(accumulator, currentValue) {
   accumulator.have += currentValue.have

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -293,7 +293,7 @@ export class PeerSyncController {
 }
 
 /**
- * @typedef {{ [namespace in Namespace]?: import("./core-sync-state.js").PeerCoreState }} PeerState
+ * @typedef {{ [namespace in Namespace]?: import("./core-sync-state.js").PeerNamespaceState }} PeerState
  */
 
 /** @typedef {Record<Namespace, 'unknown' | 'syncing' | 'synced'>} SyncStatus */

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -441,12 +441,13 @@ function getRemoteDevicesSyncState(namespaceSyncState, peerSyncControllers) {
       const isBlocked = psc.syncCapability[namespace] === 'blocked'
       if (isBlocked) continue
 
-      const peerCoreState = namespaceSyncState[namespace].remoteStates[peerId]
-      if (!peerCoreState) continue
+      const peerNamespaceState =
+        namespaceSyncState[namespace].remoteStates[peerId]
+      if (!peerNamespaceState) continue
 
       /** @type {boolean} */
       let isSyncEnabled
-      switch (peerCoreState.status) {
+      switch (peerNamespaceState.status) {
         case 'disconnected':
         case 'connecting':
           isSyncEnabled = false
@@ -455,7 +456,7 @@ function getRemoteDevicesSyncState(namespaceSyncState, peerSyncControllers) {
           isSyncEnabled = true
           break
         default:
-          throw new ExhaustivenessError(peerCoreState.status)
+          throw new ExhaustivenessError(peerNamespaceState.status)
       }
 
       if (!Object.hasOwn(result, peerId)) {
@@ -469,8 +470,8 @@ function getRemoteDevicesSyncState(namespaceSyncState, peerSyncControllers) {
         ? 'initial'
         : 'data'
       result[peerId][namespaceGroup].isSyncEnabled = isSyncEnabled
-      result[peerId][namespaceGroup].want += peerCoreState.want
-      result[peerId][namespaceGroup].wanted += peerCoreState.wanted
+      result[peerId][namespaceGroup].want += peerNamespaceState.want
+      result[peerId][namespaceGroup].wanted += peerNamespaceState.wanted
     }
   }
 

--- a/tests/sync/core-sync-state.js
+++ b/tests/sync/core-sync-state.js
@@ -391,7 +391,7 @@ function slowBitCount(n) {
 
 /**
  *
- * @param {{ have?: number | bigint, prehave?: number, want?: number | bigint, status?: import('../../src/sync/core-sync-state.js').PeerCoreState['status'] }} param0
+ * @param {{ have?: number | bigint, prehave?: number, want?: number | bigint, status?: import('../../src/sync/core-sync-state.js').PeerNamespaceState['status'] }} param0
  */
 function createState({ have, prehave, want, status }) {
   const peerState = new PeerState()


### PR DESCRIPTION
This is just a rename, which is a bit more correct.

Because Gregor and I paired on this, I plan to merge it with no review.