### PR TITLE
chore: rename peer namespace state status options

### DIFF
--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -29,7 +29,7 @@ import RemoteBitfield, {
  * @property {number} have blocks the peer has locally
  * @property {number} want blocks this peer wants from us
  * @property {number} wanted blocks we want from this peer
- * @property {'disconnected' | 'connecting' | 'connected'} status
+ * @property {'stopped' | 'starting' | 'started'} status
  */
 /**
  * @typedef {object} DerivedState
@@ -206,13 +206,12 @@ export class CoreSyncState {
   #onPeerAdd = (peer) => {
     const peerId = keyToId(peer.remotePublicKey)
 
-    // Update state to ensure this peer is in the state and set to connected
+    // Update state to ensure this peer is in the state correctly
     const peerState = this.#getPeerState(peerId)
-    peerState.status = 'connecting'
+    peerState.status = 'starting'
 
     this.#core?.update({ wait: true }).then(() => {
-      // A peer should become connected
-      peerState.status = 'connected'
+      peerState.status = 'started'
       this.#update()
     })
 
@@ -237,7 +236,7 @@ export class CoreSyncState {
   }
 
   /**
-   * Handle a peer being removed - keeps it in state, but sets state.connected = false
+   * Handle a peer being removed - keeps it in state, but marks it stopped
    *
    * (defined as class field to bind to `this`)
    * @param {HypercorePeer} peer
@@ -245,7 +244,7 @@ export class CoreSyncState {
   #onPeerRemove = (peer) => {
     const peerId = keyToId(peer.remotePublicKey)
     const peerState = this.#getPeerState(peerId)
-    peerState.status = 'disconnected'
+    peerState.status = 'stopped'
     this.#update()
   }
 }
@@ -267,7 +266,7 @@ export class PeerState {
   /** @type {Bitfield} */
   #wants = new RemoteBitfield()
   /** @type {PeerNamespaceState['status']} */
-  status = 'disconnected'
+  status = 'stopped'
   #wantAll
   constructor({ wantAll = true } = {}) {
     this.#wantAll = wantAll

--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -180,13 +180,13 @@ function mutatingAddPeerState(accumulator, currentValue) {
   accumulator.want += currentValue.want
   accumulator.wanted += currentValue.wanted
   if ('status' in accumulator && accumulator.status !== currentValue.status) {
-    if (currentValue.status === 'disconnected') {
-      accumulator.status === 'disconnected'
+    if (currentValue.status === 'stopped') {
+      accumulator.status === 'stopped'
     } else if (
-      currentValue.status === 'connecting' &&
-      accumulator.status === 'connected'
+      currentValue.status === 'starting' &&
+      accumulator.status === 'starting'
     ) {
-      accumulator.status = 'connecting'
+      accumulator.status = 'starting'
     }
   }
   return accumulator

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -311,7 +311,7 @@ function getSyncStatus(peerId, state) {
     if (!peerState) {
       syncStatus[namespace] = 'unknown'
     } else if (
-      peerState.status === 'connected' &&
+      peerState.status === 'started' &&
       state[namespace].localState.want === 0
     ) {
       syncStatus[namespace] = 'synced'

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -510,7 +510,7 @@ function isSynced(state, type, peerSyncControllers) {
       const { peerId } = psc
       if (psc.syncCapability[ns] === 'blocked') continue
       if (!(peerId in state[ns].remoteStates)) return false
-      if (state[ns].remoteStates[peerId].status === 'connecting') return false
+      if (state[ns].remoteStates[peerId].status === 'starting') return false
     }
   }
   return true
@@ -538,11 +538,11 @@ function getRemoteDevicesSyncState(namespaceSyncState, peerSyncControllers) {
       /** @type {boolean} */
       let isSyncEnabled
       switch (peerNamespaceState.status) {
-        case 'disconnected':
-        case 'connecting':
+        case 'stopped':
+        case 'starting':
           isSyncEnabled = false
           break
-        case 'connected':
+        case 'started':
           isSyncEnabled = true
           break
         default:

--- a/tests/sync/core-sync-state.js
+++ b/tests/sync/core-sync-state.js
@@ -43,19 +43,19 @@ const scenarios = [
           want: 1,
           have: 2,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
         peer1: {
           want: 1,
           have: 2,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
         peer2: {
           want: 2,
           have: 1,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
       },
     },
@@ -75,29 +75,29 @@ const scenarios = [
           want: 0,
           have: 0,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
         peer1: {
           want: 0,
           have: 0,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
       },
     },
   },
   {
-    message: 'connected = true',
+    message: 'started',
     state: {
       length: 3,
       localState: { have: 0b111 },
-      remoteStates: [{ have: 0b001, want: 0b011, status: 'connected' }],
+      remoteStates: [{ have: 0b001, want: 0b011, status: 'started' }],
     },
     expected: {
       coreLength: 3,
       localState: { want: 0, have: 3, wanted: 1 },
       remoteStates: {
-        peer0: { want: 1, have: 1, wanted: 0, status: 'connected' },
+        peer0: { want: 1, have: 1, wanted: 0, status: 'started' },
       },
     },
   },
@@ -116,7 +116,7 @@ const scenarios = [
           want: 1,
           have: 1,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
       },
     },
@@ -136,7 +136,7 @@ const scenarios = [
           want: 1,
           have: 2,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
       },
     },
@@ -156,7 +156,7 @@ const scenarios = [
           want: 0,
           have: 3,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
       },
     },
@@ -180,19 +180,19 @@ const scenarios = [
           want: 10,
           have: 40,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
         peer1: {
           want: 5,
           have: 40,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
         peer2: {
           want: 5,
           have: 40,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
       },
     },
@@ -212,13 +212,13 @@ const scenarios = [
           want: 1,
           have: 0,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
         peer1: {
           want: 2,
           have: 0,
           wanted: 0,
-          status: 'disconnected',
+          status: 'stopped',
         },
       },
     },
@@ -265,7 +265,7 @@ test('deriveState() have at index beyond bitfield page size', () => {
         want: 10,
         have: 1,
         wanted: 1,
-        status: 'disconnected',
+        status: 'stopped',
       },
     },
   }
@@ -290,8 +290,8 @@ test('CoreReplicationState', async () => {
     seed.write('local')
     const kp1 = NoiseSecretStream.keyPair(seed)
     const peerIds = new Map()
-    /** @type {Map<string, 'connected' | 'disconnected'>} */
-    const connectedState = new Map()
+    /** @type {Map<string, 'started' | 'stopped'>} */
+    const statusesByPeer = new Map()
     for (const [
       index,
       { have, want, prehave },
@@ -300,13 +300,13 @@ test('CoreReplicationState', async () => {
       const kp2 = NoiseSecretStream.keyPair(seed)
       const peerId = kp2.publicKey.toString('hex')
       peerIds.set('peer' + index, peerId)
-      connectedState.set(peerId, 'disconnected')
+      statusesByPeer.set(peerId, 'stopped')
 
       // We unit test deriveState with no bitfields, but we need something here
       // for things to work
       crs.insertPreHaves(peerId, 0, createUint32Array(prehave || 0))
       if (typeof have !== 'number' && typeof want !== 'number') continue
-      connectedState.set(peerId, 'connected')
+      statusesByPeer.set(peerId, 'started')
       const core = await createCore(localCore.key)
       setPeerWants(crs, peerId, want)
       replicate(localCore, core, { kp1, kp2 })
@@ -322,7 +322,7 @@ test('CoreReplicationState', async () => {
           peerId,
           {
             ...value,
-            status: connectedState.get(peerId),
+            status: statusesByPeer.get(peerId),
           },
         ]
       })

--- a/tests/sync/namespace-sync-state.js
+++ b/tests/sync/namespace-sync-state.js
@@ -102,7 +102,7 @@ test('sync cores in a namespace', async () => {
         want: 0,
         wanted: 0,
         have: 30,
-        status: 'connected',
+        status: 'started',
       },
     },
     'syncState1 is synced'
@@ -115,7 +115,7 @@ test('sync cores in a namespace', async () => {
         want: 0,
         wanted: 0,
         have: 30,
-        status: 'connected',
+        status: 'started',
       },
     },
     'syncState2 is synced'


### PR DESCRIPTION
This change should have no impact on functionality. This came up while @gmaclennan and I were pairing.

This renames the options for `PeerNamespaceState#status`:

- `disconnected` → `stopped`
- `connecting` → `starting`
- `connected` → `started`