### PR TITLE
test: rename CoreManager test helper function name and args

### DIFF
--- a/tests/helpers/core-manager.js
+++ b/tests/helpers/core-manager.js
@@ -51,15 +51,15 @@ const destroyStream = (stream) =>
   })
 
 /**
- * @param {CoreManager} cmToAdd
+ * @param {CoreManager} cmToTakeFrom
  * @param {CoreManager} cmToReceive
  * @returns {Promise<void>}
  */
-async function addWriterCores(cmToAdd, cmToReceive) {
-  await cmToAdd.ready()
+async function takeWriterCores(cmToTakeFrom, cmToReceive) {
+  await cmToTakeFrom.ready()
   for (const ns of NAMESPACES) {
     if (ns === 'auth') continue
-    const core = cmToAdd.getWriterCore(ns)
+    const core = cmToTakeFrom.getWriterCore(ns)
     cmToReceive.addCore(core.key, ns)
   }
 }
@@ -95,8 +95,8 @@ export function replicate(
   cm1[kCoreManagerReplicate](n1)
   cm2[kCoreManagerReplicate](n2)
 
-  addWriterCores(cm1, cm2)
-  addWriterCores(cm2, cm1)
+  takeWriterCores(cm1, cm2)
+  takeWriterCores(cm2, cm1)
 
   return {
     async destroy() {


### PR DESCRIPTION
_This change is not urgent._

This is just a simple rename for clarity. See [this comment][0].

[0]: https://github.com/digidem/mapeo-core-next/pull/783#pullrequestreview-2266845710