### PR TITLE
test: fix config import assertion message typo

### DIFF
--- a/tests/config-import.js
+++ b/tests/config-import.js
@@ -216,7 +216,7 @@ test('config import - presets', async () => {
   )
   assert(
     /invalid preset noObjectPreset/.test(config.warnings[0].message),
-    'the first error is because the preseassert.equal not an object'
+    'the first error is because the preset is not an object'
   )
   assert(
     /invalid preset nullPreset/.test(config.warnings[1].message),


### PR DESCRIPTION
This happened in dfd7632344c7a66f3427398e36021d271ef7b00e. Presumably, I was trying to find-replace `t.is` with `assert.equal` and the regex was too broad.

I plan to merge this without review if CI passes.