### PR TITLE
feat!: update `@mapeo/schema` to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fastify/type-provider-typebox": "^4.0.0",
         "@hyperswarm/secret-stream": "^6.1.2",
         "@mapeo/crypto": "1.0.0-alpha.10",
-        "@mapeo/schema": "^3.0.0-next.22",
+        "@mapeo/schema": "^3.0.0-next.23",
         "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
         "@sinclair/typebox": "^0.29.6",
         "b4a": "^1.6.3",
@@ -60,7 +60,7 @@
       "devDependencies": {
         "@bufbuild/buf": "^1.26.1",
         "@mapeo/default-config": "4.0.0-alpha.8",
-        "@mapeo/mock-data": "^1.0.3-alpha.3",
+        "@mapeo/mock-data": "^1.0.3-alpha.4",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/b4a": "^1.6.0",
         "@types/bogon": "^1.0.2",
@@ -786,9 +786,9 @@
       "dev": true
     },
     "node_modules/@mapeo/mock-data": {
-      "version": "1.0.3-alpha.3",
-      "resolved": "https://registry.npmjs.org/@mapeo/mock-data/-/mock-data-1.0.3-alpha.3.tgz",
-      "integrity": "sha512-BgERv0MedwIOEW0jNGAJxDsII2V//7pRULUkGC1ykHpOX76m5qFyB7aKVJJbQI7kdhlgc6K4MhDZ/JzDWdSUcw==",
+      "version": "1.0.3-alpha.4",
+      "resolved": "https://registry.npmjs.org/@mapeo/mock-data/-/mock-data-1.0.3-alpha.4.tgz",
+      "integrity": "sha512-2Pwmjc4UUb7snWCGVgPpLevy5IckPtW/Q1DF3FKU3nd96ksUNt7Guo1ALLXl1m2MMe27eaUg4Y7pteKNLnXImw==",
       "dev": true,
       "dependencies": {
         "@faker-js/faker": "^8.3.1",
@@ -800,17 +800,17 @@
         "list-mapeo-schemas": "bin/list-mapeo-schemas.js"
       },
       "peerDependencies": {
-        "@mapeo/schema": "^3.0.0-next.21"
+        "@mapeo/schema": "^3.0.0-next.23"
       }
     },
     "node_modules/@mapeo/schema": {
-      "version": "3.0.0-next.22",
-      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.22.tgz",
-      "integrity": "sha512-LGgazGZoP8Gq2SaLvWf2rf+njtC2qcpliWl7BctOXTO6pZ9oNX9QSBFOwk/0PjU2fg4iHqKal5UaEIhbIBmWgA==",
+      "version": "3.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.23.tgz",
+      "integrity": "sha512-NtI32BBwVahOC12ETrsBhNOjBtgF/6p/AatouaivBTe3cXudEGXm3lOgExDytHzKGJDKP4ALNOWLUbEKKlsTWQ==",
       "dependencies": {
         "compact-encoding": "^2.12.0",
         "protobufjs": "^7.2.5",
-        "type-fest": "^4.1.0"
+        "type-fest": "^4.26.0"
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
@@ -7587,9 +7587,10 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
-      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.26.1",
     "@mapeo/default-config": "4.0.0-alpha.8",
-    "@mapeo/mock-data": "^1.0.3-alpha.3",
+    "@mapeo/mock-data": "^1.0.3-alpha.4",
     "@sinonjs/fake-timers": "^10.0.2",
     "@types/b4a": "^1.6.0",
     "@types/bogon": "^1.0.2",
@@ -155,7 +155,7 @@
     "@fastify/type-provider-typebox": "^4.0.0",
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "1.0.0-alpha.10",
-    "@mapeo/schema": "^3.0.0-next.22",
+    "@mapeo/schema": "^3.0.0-next.23",
     "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",

--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -251,6 +251,7 @@ export class DataType extends TypedEmitter {
     )
     /** @type {any} */
     const doc = {
+      // @ts-expect-error Can't figure out why TypeScript doesn't think `value` is spreadable.
       ...value,
       docId,
       createdAt,

--- a/test-e2e/project-crud.js
+++ b/test-e2e/project-crud.js
@@ -51,7 +51,6 @@ const fixtures = [
     schemaName: 'track',
     observationRefs: [],
     tags: {},
-    attachments: [],
     locations: Array.from({ length: 10 }, trackPositionFixture),
   },
 ]


### PR DESCRIPTION
This updates `@mapeo/schema`, and related dependencies, to the latest version.

This changed two things:

- `Observation`s now require `lat` and `lon` again
- `Track`s no longer have attachments