### PR TITLE
fix: remove `selfHostedServer` from `deviceInfo.deviceType` rpc

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -38,7 +38,6 @@ message DeviceInfo {
     mobile = 1;
     tablet = 2;
     desktop = 3;
-    selfHostedServer = 4;
   }
   string name = 1;
   optional DeviceType deviceType = 2;

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -39,7 +39,6 @@ export declare const DeviceInfo_DeviceType: {
     readonly mobile: "mobile";
     readonly tablet: "tablet";
     readonly desktop: "desktop";
-    readonly selfHostedServer: "selfHostedServer";
     readonly UNRECOGNIZED: "UNRECOGNIZED";
 };
 export type DeviceInfo_DeviceType = typeof DeviceInfo_DeviceType[keyof typeof DeviceInfo_DeviceType];

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -48,7 +48,6 @@ export var DeviceInfo_DeviceType = {
     mobile: "mobile",
     tablet: "tablet",
     desktop: "desktop",
-    selfHostedServer: "selfHostedServer",
     UNRECOGNIZED: "UNRECOGNIZED",
 };
 export function deviceInfo_DeviceTypeFromJSON(object) {
@@ -65,9 +64,6 @@ export function deviceInfo_DeviceTypeFromJSON(object) {
         case 3:
         case "desktop":
             return DeviceInfo_DeviceType.desktop;
-        case 4:
-        case "selfHostedServer":
-            return DeviceInfo_DeviceType.selfHostedServer;
         case -1:
         case "UNRECOGNIZED":
         default:
@@ -84,8 +80,6 @@ export function deviceInfo_DeviceTypeToNumber(object) {
             return 2;
         case DeviceInfo_DeviceType.desktop:
             return 3;
-        case DeviceInfo_DeviceType.selfHostedServer:
-            return 4;
         case DeviceInfo_DeviceType.UNRECOGNIZED:
         default:
             return -1;

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -83,7 +83,6 @@ export const DeviceInfo_DeviceType = {
   mobile: "mobile",
   tablet: "tablet",
   desktop: "desktop",
-  selfHostedServer: "selfHostedServer",
   UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
@@ -103,9 +102,6 @@ export function deviceInfo_DeviceTypeFromJSON(object: any): DeviceInfo_DeviceTyp
     case 3:
     case "desktop":
       return DeviceInfo_DeviceType.desktop;
-    case 4:
-    case "selfHostedServer":
-      return DeviceInfo_DeviceType.selfHostedServer;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -123,8 +119,6 @@ export function deviceInfo_DeviceTypeToNumber(object: DeviceInfo_DeviceType): nu
       return 2;
     case DeviceInfo_DeviceType.desktop:
       return 3;
-    case DeviceInfo_DeviceType.selfHostedServer:
-      return 4;
     case DeviceInfo_DeviceType.UNRECOGNIZED:
     default:
       return -1;

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -699,7 +699,14 @@ export class MapeoManager extends TypedEmitter {
   }
 
   /**
-   * @template {import('type-fest').Exact<import('./schema/client.js').DeviceInfoParam, T>} T
+   * @typedef {Exclude<
+   * import('./schema/client.js').DeviceInfoParam['deviceType'],
+   * 'selfHostedServer'>} RPCDeviceType
+   */
+
+  /**
+   * @template {import('type-fest').Exact<
+   * import('./schema/client.js').DeviceInfoParam & {deviceType?: RPCDeviceType}, T>} T
    * @param {T} deviceInfo
    */
   async setDeviceInfo(deviceInfo) {


### PR DESCRIPTION
this is a regression from previous release of core. 
We originally added `selfHostedServer` to `DeviceInfo.deviceType` to match schema definition. But we don't want to be able to open rpc connections to a remote server; so instead we just mangle the types to omit that enum member were appropiate