### PR TITLE
chore: use upstream types for `compact-encoding`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/b4a": "^1.6.0",
         "@types/bogon": "^1.0.2",
+        "@types/compact-encoding": "^2.15.0",
         "@types/debug": "^4.1.8",
         "@types/json-schema": "^7.0.11",
         "@types/json-stable-stringify": "^1.0.36",
@@ -1216,6 +1217,13 @@
       "resolved": "https://registry.npmjs.org/@types/bogon/-/bogon-1.0.2.tgz",
       "integrity": "sha512-R7YtCuBSS16AfLJttU/WxFzEC/rlPxUrdfyHkE/VcIybpC1nXftIg1eaFWx0PpV1ZBF/COjTgwRXprUsNew0ng==",
       "dev": true
+    },
+    "node_modules/@types/compact-encoding": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/compact-encoding/-/compact-encoding-2.15.0.tgz",
+      "integrity": "sha512-NmvvYrQC9QqbbEfm6ISHfCvvfQIwq53B4hZ7aAP6mEXsPc2F15Lkxj+jGzqVeKTT+Ir0HXAj4O9YUDsIpJbOuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@sinonjs/fake-timers": "^10.0.2",
     "@types/b4a": "^1.6.0",
     "@types/bogon": "^1.0.2",
+    "@types/compact-encoding": "^2.15.0",
     "@types/debug": "^4.1.8",
     "@types/json-schema": "^7.0.11",
     "@types/json-stable-stringify": "^1.0.36",

--- a/types/compact-encoding.d.ts
+++ b/types/compact-encoding.d.ts
@@ -1,1 +1,0 @@
-declare module 'compact-encoding'

--- a/types/protomux.d.ts
+++ b/types/protomux.d.ts
@@ -1,30 +1,13 @@
 declare module 'protomux' {
   import { Duplex } from 'streamx'
   import { Duplex as NodeDuplex } from 'stream'
-
-  interface PreEncodingState {
-    buffer: null
-    start: number
-    end: number
-  }
-
-  interface EncodingState {
-    buffer: null | Buffer
-    start: number
-    end: number
-  }
-
-  interface Encoding {
-    preencode(state: PreEncodingState, value: any): void
-    encode(state: EncodingState, value: any): void
-    decode(state: EncodingState): any
-  }
+  import type cenc from 'compact-encoding'
 
   interface Message {
     type: number
     send(msg: any): void
     onmessage: (message: any) => void
-    encoding: Encoding
+    encoding: cenc.Encoder
   }
 
   type MessageOptions = Partial<Pick<Message, 'onmessage' | 'encoding'>>
@@ -65,7 +48,7 @@ declare module 'protomux' {
       aliases?: string[]
       id?: null | Buffer
       unique?: boolean
-      handshake?: Encoding
+      handshake?: cenc.Encoder
       messages: MessageOptions[]
       onopen?(handshake?: any): Promise<void> | void
       onclose?(): Promise<void> | void


### PR DESCRIPTION
This is a types-only change.

[`@types/compact-encoding`][0] was recently published. Let's use that instead of our "empty" type.

[0]: https://www.npmjs.com/package/@types/compact-encoding